### PR TITLE
Fix downloading installer on Linux

### DIFF
--- a/scripts/runInstaller.mjs
+++ b/scripts/runInstaller.mjs
@@ -39,7 +39,7 @@ function getFilename() {
         case "darwin":
             return "EquicordInstaller.MacOS.zip";
         case "linux":
-            return "EquicordInstaller-linux";
+            return "EquicordInstallerCli-linux";
         default:
             throw new Error("Unsupported platform: " + process.platform);
     }


### PR DESCRIPTION
So I wanted to inject a dev build of Equicord onto my Discord but it failed to download the installer on linux with the error 404.

Looking into it, I found the function `getFilename` which has the names of the executables for each platform. Comparing that to the names found on the [releases page](https://github.com/Equicord/Installer/releases/tag/v2.0.1), they did not line up for linux.

So I changed it from `EquicordInstaller-linux` to `EquicordInstallerCli-linux` and my issue was fixed.