### PR TITLE
Fix baseDecoder button

### DIFF
--- a/src/equicordplugins/baseDecoder/index.tsx
+++ b/src/equicordplugins/baseDecoder/index.tsx
@@ -29,7 +29,7 @@ import { Button, ChannelStore, Forms, Text } from "@webpack/common";
 
 const DecodeIcon = () => {
     return (
-        <svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <svg width="24px" height="24px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
             <path d="M6.5 9.50026H14.0385C15.4063 9.50026 16.0902 9.50026 16.5859 9.82073C16.8235 9.97438 17.0259 10.1767 17.1795 10.4144C17.5 10.91 17.5 11.5939 17.5 12.9618C17.5 14.3297 17.5 15.0136 17.1795 15.5092C17.0259 15.7469 16.8235 15.9492 16.5859 16.1029C16.0902 16.4233 15.4063 16.4233 14.0385 16.4233H9.5M6.5 9.50026L8.75 7.42334M6.5 9.50026L8.75 11.5772" stroke="#1C274C" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
             <path d="M22 12C22 16.714 22 19.0711 20.5355 20.5355C19.0711 22 16.714 22 12 22C7.28595 22 4.92893 22 3.46447 20.5355C2 19.0711 2 16.714 2 12C2 7.28595 2 4.92893 3.46447 3.46447C4.92893 2 7.28595 2 12 2C16.714 2 19.0711 2 20.5355 3.46447C21.5093 4.43821 21.8356 5.80655 21.9449 8" stroke="#1C274C" stroke-width="1.5" stroke-linecap="round" />
         </svg>


### PR DESCRIPTION
So I was trying out the `baseDecoder` plugin and I noticed a problem, the button allows you to click it even when your not supposed to.

As you can see in this image my cursor can click the button even while not touching it.
![before](https://api.serversmp.xyz/upload/669991827036ecb33d717eaa.webp)

The fix for this one is to change the width and height of the svg icon from `800px` to `24px`.
![after](https://api.serversmp.xyz/upload/669991fb7036ecb33d717eb4.webp)