### PR TITLE
Client submodules updating + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "04:00"
+    target-branch: "sub" # change this to your branch
+    reviewers:
+      - "thororen1234"
+    commit-message:
+      prefix: "dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    target-branch: "sub" # change this to your branch
+    target-branch: "main" # dependabot only works with the default branch :(
     reviewers:
       - "thororen1234"
     commit-message:

--- a/src/main/updater/git.ts
+++ b/src/main/updater/git.ts
@@ -68,7 +68,14 @@ async function calculateGitChanges() {
 
 async function pull() {
     const res = await git("pull");
-    return res.stdout.includes("Fast-forward");
+
+    if (res.stdout.includes("Fast-forward")) {
+        await git("submodule", "update", "--init", "--recursive");
+
+        return true;
+    }
+
+    return false;
 }
 
 async function build() {


### PR DESCRIPTION
This is what I learned from Mooncord.

When the client updates it pulls the latest repo but if you are using submodules, it wont get any new modules you added in the newer commits. So I modified the git.ts file so when a pull happens it updates the modules to the pinned commit on this repo.

Also you would want to use dependabot to automatically create pull requests for updating the modules, sadly dependabot only works on the default branch and not any other branches, so maybe a custom action could be better? (this pr adds a config for dependabot too)

Yep thats all, so I just leave this with you now :)