### PR TITLE
feat(ImagePreview): fixes & add zoom 

### DIFF
--- a/src/equicordplugins/imagePreview/styles.css
+++ b/src/equicordplugins/imagePreview/styles.css
@@ -23,18 +23,13 @@
     max-width: 180px;
 }
 
-.preview-div img {
+.preview-div img,
+video {
     max-width: 100%;
     max-height: 100%;
     display: block;
     margin: 0 auto;
-}
-
-.preview-div video {
-    max-width: 100%;
-    max-height: 100%;
-    display: block;
-    margin: 0 auto;
+    object-fit: contain;
 }
 
 .preview-header {


### PR DESCRIPTION
Fixed the issue where the preview would stay stuck on the screen if the element disappeared or was hidden. Removed mouse influence on the preview; now, it appears at either one of the four corners or centered. Updated some elements from a hover outline to a border since the outline was barely visible. fixed where some images wouldn't load before it would show.