### PR TITLE
Fix Linux installer script URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ MacOS
 Linux
 - [CLI](https://github.com/Equicord/Equilotl/releases/latest/download/EquilotlCli-Linux)
 ```shell
-sh -c "$(curl -sS https://raw.githubusercontent.com/Equicord/Equicord/refs/heads/main/misc/installer.sh)"
+sh -c "$(curl -sS https://raw.githubusercontent.com/Equicord/Equicord/refs/heads/main/misc/install.sh)"
 ```
 ## Installing Equicord Devbuild
 


### PR DESCRIPTION
The Linux installer script is actually named install.sh and not installer.sh. Thats why I got a 404 Error. Exchanging the URL will fix it. I successfully tested it on my CachyOS (Arch Linux) install.