### PR TITLE
DisableAnimations: Plugin to disable most of Discord's animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can join our [discord server](https://discord.gg/5Xh2W87egW) for commits, ch
 - GodMode by Tolgchu
 - GoodPerson by nin0dev & mantikafasi
 - GoogleThat by Samwich
-- GrammarFix by unstream
+- GrammarFix by S€th
 - HideChatButtons by iamme
 - HideMessage by Hanzy
 - HideServers by bepvte

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You can join our [discord server](https://discord.gg/5Xh2W87egW) for commits, ch
 - DecodeBase64 by ThePirateStoner
 - DeadMembers by Kyuuhachi
 - Demonstration by Samwich
+- DisableAnimations by S€th
 - DisableCameras by Joona
 - DoNotLeak by Perny
 - DontFilterMe by Samwich

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can join our [discord server](https://discord.gg/5Xh2W87egW) for commits, ch
 
 ### Extra included plugins
 <details>
-<summary>150 additional plugins</summary>
+<summary>151 additional plugins</summary>
 
 ### All Platforms
 - AllCallTimers by MaxHerbold & D3SOX

--- a/src/equicordplugins/disableAnimations/index.ts
+++ b/src/equicordplugins/disableAnimations/index.ts
@@ -21,7 +21,6 @@ import definePlugin from "@utils/types";
 import { findAll } from "@webpack";
 
 export default definePlugin({
-
     name: "DisableAnimations",
     description: "Disables most of Discord's animations.",
     authors: [EquicordDevs.seth],

--- a/src/equicordplugins/disableAnimations/index.ts
+++ b/src/equicordplugins/disableAnimations/index.ts
@@ -1,0 +1,54 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { findAll } from "@webpack";
+
+export default definePlugin({
+
+    name: "DisableAnimations",
+    description: "Disables most of Discord's animations.",
+    authors: [EquicordDevs.seth],
+    start() {
+        this.springs = findAll((mod) => {
+            if (!mod.Globals) return false;
+            return true;
+        });
+
+        for (const spring of this.springs) {
+            spring.Globals.assign({
+                skipAnimation: true,
+            });
+        }
+
+        this.css = document.createElement("style");
+        this.css.innerText = "* { transition: none !important; animation: none !important; }";
+
+        document.head.appendChild(this.css);
+    },
+    stop() {
+        for (const spring of this.springs) {
+            spring.Globals.assign({
+                skipAnimation: false,
+            });
+        }
+
+        if (this.css) this.css.remove();
+    }
+});

--- a/src/plugins/typingTweaks/index.tsx
+++ b/src/plugins/typingTweaks/index.tsx
@@ -125,7 +125,7 @@ export default definePlugin({
 
     buildSeveralUsers,
 
-    mutateChildren(props: any, users: User[], children: any) {
+    mutateChildren(guildId: any, users: User[], children: any) {
         try {
             if (!Array.isArray(children)) {
                 return children;
@@ -135,7 +135,7 @@ export default definePlugin({
 
             return children.map(c =>
                 c.type === "strong" || (typeof c !== "string" && !React.isValidElement(c))
-                    ? <TypingUser {...props} user={users[element++]} />
+                    ? <TypingUser guildId={guildId} user={users[element++]} />
                     : c
             );
         } catch (e) {


### PR DESCRIPTION
Applies the property `skipAnimation` to all react-sprint instances Discord has. 

Also adds basic CSS `* { transition: none !important; animation: none !important; }`

[Rejected](https://github.com/Vendicated/Vencord/pull/3069) from the official Vencord repository by [Vendicated](https://github.com/Vendicated) saying "just enable Reduced Animations in Accessibility settings"

I'd argue this would be a half decent plugin making discord feel more snappier and a better experience overall.

Some might say it makes discord that much more accessible, but what do I know? I can just turn on Reduced ***Motion*** in Accessibility settings.