### PR TITLE
[feat] Add an option to disable the glide plugin theme system

### DIFF
--- a/src/equicordplugins/glide/index.tsx
+++ b/src/equicordplugins/glide/index.tsx
@@ -142,6 +142,15 @@ const settings = definePluginSettings({
         default: "0.2",
         onChange: injectCSS
     },
+    colorsEnabled: {
+        type: OptionType.BOOLEAN,
+        description: "Whether or not to enable theming",
+        onChange: () => {
+            if (Settings.plugins.Glide.enabled) {
+                injectCSS();
+            }
+        }
+    },
     ColorPreset: {
         type: OptionType.SELECT,
         description: "Some pre-made color presets (more soon hopefully)",
@@ -318,13 +327,15 @@ function getCSS(fontName) {
         {
             --animspeed: ${Settings.plugins.Glide.animationSpeed + "s"};
             --font-primary: ${(fontName.length > 0 ? fontName : "Nunito")};
-            --accent: #${Settings.plugins.Glide.Accent};
-            --bgcol: #${Settings.plugins.Glide.Primary};
-            --text: #${Settings.plugins.Glide.Text};
-            --brand: #${Settings.plugins.Glide.Brand};
-            --mutedtext: ${mute(Settings.plugins.Glide.Text, 20)};
-            --mutedbrand: ${mute(Settings.plugins.Glide.Brand, 10)};
-            --mutedaccent: ${mute(Settings.plugins.Glide.Accent, 10)};
+            ${Settings.plugins.Glide.colorsEnabled ? `
+                --accent: #${Settings.plugins.Glide.Accent};
+                --bgcol: #${Settings.plugins.Glide.Primary};
+                --text: #${Settings.plugins.Glide.Text};
+                --brand: #${Settings.plugins.Glide.Brand};
+                --mutedtext: ${mute(Settings.plugins.Glide.Text, 20)};
+                --mutedbrand: ${mute(Settings.plugins.Glide.Brand, 10)};
+                --mutedaccent: ${mute(Settings.plugins.Glide.Accent, 10)};
+            ` : ""}
         }
 :root
 {
@@ -341,7 +352,7 @@ function getCSS(fontName) {
 
 
     /*COLOR ASSIGNING  (most of these probably effect more than whats commented)*/
-
+    ${Settings.plugins.Glide.colorsEnabled ? `
         /*accent based*/
 
             /*buttons*/
@@ -546,7 +557,7 @@ function getCSS(fontName) {
                 .unread_d8bfb3
                 {
                     background-color: var(--text) !important;
-                }
+                }` : ""}
 
         /*ROUNDING (rounding)*/
 

--- a/src/equicordplugins/glide/index.tsx
+++ b/src/equicordplugins/glide/index.tsx
@@ -145,11 +145,7 @@ const settings = definePluginSettings({
     colorsEnabled: {
         type: OptionType.BOOLEAN,
         description: "Whether or not to enable theming",
-        onChange: () => {
-            if (Settings.plugins.Glide.enabled) {
-                injectCSS();
-            }
-        }
+        onChange: () => injectCSS()
     },
     ColorPreset: {
         type: OptionType.SELECT,
@@ -653,7 +649,7 @@ function getCSS(fontName) {
                 }
 
                 /*Hide icon on file uploading status*/
-                .icon_b52bef
+                .icon_f46c86
                 {
                     display: none;
                 }


### PR DESCRIPTION
This pr aims to make it possible to disable the theme system inside of glide.

My motivation to do this came from that theme system missing alot of styling in many parts of the app rendering the native solution (online links or builtin themes) superior.
This option should then provide a clean way to avoid conflicts when using themes and glide in conjunction.

I've also added an extra reformat commit with the intention of standardizing the indents across the file (and partially fixing eslint styling errors)