### PR TITLE
Refac: Clarified Transparency warning message

### DIFF
--- a/src/components/VencordSettings/VencordTab.tsx
+++ b/src/components/VencordSettings/VencordTab.tsx
@@ -109,8 +109,8 @@ function EquicordSettings() {
       title: "Enable window transparency.",
       note: "You need a theme that supports transparency or this will do nothing. Requires a full restart!",
       warning: {
-        enabled: true,
-        message: "This will stop the window from being resizable.",
+        enabled: isWindows,
+        message: "Enabling this will prevent you from snapping this window.",
       },
     },
     !IS_WEB &&


### PR DESCRIPTION
This PR aims to clarify the warning message about the interaction between window snapping and application transparency.
It also hides this message on platforms where this warning may be ignored.