### PR TITLE
fix(MessageBurst): cleanup and add new option

### DIFF
--- a/src/equicordplugins/messageBurst/index.ts
+++ b/src/equicordplugins/messageBurst/index.ts
@@ -23,6 +23,10 @@ function shouldEdit(channel: Channel, message: Message, timePeriod: number) {
         should = false;
     }
 
+    if (document.querySelector('[class^="replyBar__"]')) {
+        should = false;
+    }
+
     // @ts-ignore
     const timestamp = new Date(message.timestamp);
     const now = new Date();

--- a/src/equicordplugins/messageBurst/index.ts
+++ b/src/equicordplugins/messageBurst/index.ts
@@ -62,8 +62,6 @@ export default definePlugin({
 
         const { should, content } = shouldEdit(channel, lastMessage as Message, this.settings.store.timePeriod);
 
-        console.log(should, content, this.settings.store.timePeriod);
-
         if (should) {
             MessageActions.editMessage(channelId, lastMessageId, {
                 content: `${content}\n${message.content}`


### PR DESCRIPTION
- Removes debug logging
- Don't edit the last message if you're attempting to reply to someone
- Add an option to disable merging messages when the last message contains an attachment

(p.s. I completely forgot to do this sorry!)