### PR TITLE
feat(silentMessageToggle): improve the persistence switch, an option …

### DIFF
--- a/src/plugins/silentMessageToggle/index.tsx
+++ b/src/plugins/silentMessageToggle/index.tsx
@@ -19,7 +19,7 @@
 import { ChatBarButton, ChatBarButtonFactory } from "@api/ChatButtons";
 import { addMessagePreSendListener, MessageSendListener, removeMessagePreSendListener } from "@api/MessageEvents";
 import { definePluginSettings } from "@api/Settings";
-import { Devs } from "@utils/constants";
+import { Devs, EquicordDevs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { React, useEffect, useState } from "@webpack/common";
 
@@ -27,11 +27,15 @@ let lastState = false;
 
 const settings = definePluginSettings({
     persistState: {
-        type: OptionType.BOOLEAN,
-        description: "Whether to persist the state of the silent message toggle when changing channels",
-        default: false,
-        onChange(newValue: boolean) {
-            if (newValue === false) lastState = false;
+        type: OptionType.SELECT,
+        description: "How to persist the silent message toggle state",
+        options: [
+            { label: "Don't persist (reset on channel change)", value: "none", default: true },
+            { label: "Persist between channels", value: "channels" },
+            { label: "Persist between channels and restarts", value: "restarts" }
+        ],
+        onChange(newValue: string) {
+            lastState = newValue !== "none" && lastState;
         }
     },
     autoDisable: {
@@ -42,10 +46,10 @@ const settings = definePluginSettings({
 });
 
 const SilentMessageToggle: ChatBarButtonFactory = ({ isMainChat }) => {
-    const [enabled, setEnabled] = useState(lastState);
+    const [enabled, setEnabled] = useState(settings.store.persistState === "restarts" || lastState);
 
     function setEnabledValue(value: boolean) {
-        if (settings.store.persistState) lastState = value;
+        if (settings.store.persistState !== "none") lastState = value;
         setEnabled(value);
     }
 
@@ -89,7 +93,7 @@ const SilentMessageToggle: ChatBarButtonFactory = ({ isMainChat }) => {
 
 export default definePlugin({
     name: "SilentMessageToggle",
-    authors: [Devs.Nuckyz, Devs.CatNoir],
+    authors: [Devs.Nuckyz, Devs.CatNoir, EquicordDevs.Z1xus],
     description: "Adds a button to the chat bar to toggle sending a silent message.",
     settings,
 


### PR DESCRIPTION
this PR makes silentMessageToggle have a proper switch instead of the booleans as well as adds a new option to persist the state between restarts

![image](https://github.com/user-attachments/assets/2d7d7335-2e94-4574-ac9d-86c8af5d68ec)
