### PR TITLE
fix(demonstration): modify the toolbox for checkbox

### DIFF
--- a/src/equicordplugins/demonstration/index.tsx
+++ b/src/equicordplugins/demonstration/index.tsx
@@ -71,11 +71,6 @@ function ToggleModal() {
     );
 }
 
-function isToggled() {
-    const style = document.getElementById("DemonstrationStyle");
-    if (style != null) { return true; } else { return false; }
-}
-
 function handleToggle() {
     const style = document.getElementById("DemonstrationStyle");
     if (style != null) {
@@ -138,7 +133,7 @@ export default definePlugin({
     authors: [Devs.Samwich, EquicordDevs.Panniku],
     settings,
     toolboxActions: {
-        "Toggle Demonstration": (() => { handleToggle(); })
+        "Toggle Demonstration": (() => handleToggle())
     },
     settingsAboutComponent: () => {
         return (

--- a/src/equicordplugins/demonstration/index.tsx
+++ b/src/equicordplugins/demonstration/index.tsx
@@ -71,6 +71,11 @@ function ToggleModal() {
     );
 }
 
+function isToggled() {
+    const style = document.getElementById("DemonstrationStyle");
+    if (style != null) { return true; } else { return false; }
+}
+
 function handleToggle() {
     const style = document.getElementById("DemonstrationStyle");
     if (style != null) {
@@ -133,7 +138,7 @@ export default definePlugin({
     authors: [Devs.Samwich, EquicordDevs.Panniku],
     settings,
     toolboxActions: {
-        "Toggle Demonstration": (() => handleToggle())
+        "Toggle Demonstration": (() => { handleToggle(); })
     },
     settingsAboutComponent: () => {
         return (
@@ -147,6 +152,5 @@ export default definePlugin({
     },
     stop() {
         document.removeEventListener("keydown", handleKeydown);
-    },
-
+    }
 });

--- a/src/equicordplugins/equicordToolbox/index.tsx
+++ b/src/equicordplugins/equicordToolbox/index.tsx
@@ -25,13 +25,12 @@ import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { findComponentByCodeLazy } from "@webpack";
 import { Menu, Popout, useState } from "@webpack/common";
-import { type ReactNode } from "react";
+import type { ReactNode } from "react";
 
 const HeaderBarIcon = findComponentByCodeLazy(".HEADER_BAR_BADGE_TOP:", '.iconBadge,"top"');
 
 function VencordPopout(onClose: () => void) {
     const { useQuickCss } = useSettings(["useQuickCss"]);
-    const [demonstrationToggled, setToggled] = useState(false);
 
     const pluginEntries = [] as ReactNode[];
 
@@ -44,16 +43,22 @@ function VencordPopout(onClose: () => void) {
                 >
                     {Object.entries(plugin.toolboxActions).map(([text, action]) => {
                         const key = `vc-toolbox-${plugin.name}-${text}`;
-
-                        // For certain plugins :trolleyzoom:
+                    
                         if (plugin.name === "Demonstration") {
+                            const [demonstrationToggled, setToggled] = useState(false);
+
                             return (
                                 <Menu.MenuCheckboxItem
                                     id="vc-toolbox-demonstration-toggle"
                                     key={key}
                                     checked={!!demonstrationToggled}
                                     label={text}
-                                    action={() => { action(); setToggled(!demonstrationToggled); }}
+                                    action={
+                                        () => { 
+                                            action(); 
+                                            setToggled(!demonstrationToggled); 
+                                        }
+                                    }
                                 />
                             );
                         }

--- a/src/equicordplugins/equicordToolbox/index.tsx
+++ b/src/equicordplugins/equicordToolbox/index.tsx
@@ -25,12 +25,13 @@ import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { findComponentByCodeLazy } from "@webpack";
 import { Menu, Popout, useState } from "@webpack/common";
-import type { ReactNode } from "react";
+import { type ReactNode } from "react";
 
 const HeaderBarIcon = findComponentByCodeLazy(".HEADER_BAR_BADGE_TOP:", '.iconBadge,"top"');
 
 function VencordPopout(onClose: () => void) {
     const { useQuickCss } = useSettings(["useQuickCss"]);
+    const [demonstrationToggled, setToggled] = useState(false);
 
     const pluginEntries = [] as ReactNode[];
 
@@ -43,6 +44,19 @@ function VencordPopout(onClose: () => void) {
                 >
                     {Object.entries(plugin.toolboxActions).map(([text, action]) => {
                         const key = `vc-toolbox-${plugin.name}-${text}`;
+
+                        // For certain plugins :trolleyzoom:
+                        if (plugin.name === "Demonstration") {
+                            return (
+                                <Menu.MenuCheckboxItem
+                                    id="vc-toolbox-demonstration-toggle"
+                                    key={key}
+                                    checked={!!demonstrationToggled}
+                                    label={text}
+                                    action={() => { action(); setToggled(!demonstrationToggled); }}
+                                />
+                            );
+                        }
 
                         return (
                             <Menu.MenuItem

--- a/src/plugins/whoReacted/index.tsx
+++ b/src/plugins/whoReacted/index.tsx
@@ -19,6 +19,7 @@
 import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
+import { Logger } from "@utils/Logger";
 import { sleep } from "@utils/misc";
 import { Queue } from "@utils/Queue";
 import { useForceUpdater } from "@utils/react";
@@ -170,6 +171,8 @@ export default definePlugin({
 
         const reactions = getReactionsWithQueue(message, emoji, type);
         const users = Object.values(reactions).filter(Boolean) as User[];
+
+        new Logger("WhoReacted").log(settings.store.avatarClick);
 
         return (
             <div

--- a/src/plugins/whoReacted/index.tsx
+++ b/src/plugins/whoReacted/index.tsx
@@ -19,7 +19,6 @@
 import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs } from "@utils/constants";
-import { Logger } from "@utils/Logger";
 import { sleep } from "@utils/misc";
 import { Queue } from "@utils/Queue";
 import { useForceUpdater } from "@utils/react";
@@ -171,8 +170,6 @@ export default definePlugin({
 
         const reactions = getReactionsWithQueue(message, emoji, type);
         const users = Object.values(reactions).filter(Boolean) as User[];
-
-        new Logger("WhoReacted").log(settings.store.avatarClick);
 
         return (
             <div


### PR DESCRIPTION
This modifies the EquicordToolbox plugin to allow a single entry for "Demonstration" to use a checkbox menu item.

please i need an efficient way of doing this without modifying the plugin item itself :pleading_face: 