### PR TITLE
Update Signature, Css fix

### DIFF
--- a/src/components/PluginSettings/styles.css
+++ b/src/components/PluginSettings/styles.css
@@ -252,6 +252,24 @@
 }
 
 .visual-refresh .button-danger-background:hover {
-  background-color:  var(--status-danger-background) !important;
-  color: var(--status-danger-text) !important;
+    background-color:  var(--status-danger-background) !important;
+    color: var(--status-danger-text) !important;
+}
+
+.visual-refresh .vc-plugins-info-card {
+    background-color: var(--card-primary-bg) !important;
+    border: 1px solid var(--border-subtle) !important;
+
+    &:hover {
+    background-color: var(--card-primary-bg) !important;
+    }
+  }
+
+.visual-refresh .vc-plugin-stats {
+    background-color: var(--card-primary-bg) !important;
+    border: 1px solid var(--border-subtle) !important;
+
+    &:hover {
+    background-color: var(--card-primary-bg) !important;
+    }
 }

--- a/src/equicordplugins/signature/index.tsx
+++ b/src/equicordplugins/signature/index.tsx
@@ -22,6 +22,14 @@ const settings = definePluginSettings(
             description: "The signature that will be added to the end of your messages",
             default: "a chronic discord user"
         },
+        textHeader: {
+            description: "What header to preface text with",
+            type: OptionType.SELECT,
+            options: [
+                { label: ">", value: ">", default: true },
+                { label: "-#", value: "-#" }
+            ]
+        },
         showIcon: {
             type: OptionType.BOOLEAN,
             default: true,
@@ -141,7 +149,7 @@ export default definePlugin({
 
 // text processing injection processor
 function textProcessing(input: string) {
-    return `${input}\n> ${settings.store.name}`;
+    return `${input}\n${settings.store.textHeader} ${settings.store.name}`;
 }
 
 


### PR DESCRIPTION
Updated Signature so it allow someone too choose what header to preface their signature with _(Default is the old header `>`)_
![](https://cdn.nest.rip/uploads/589a00df-2d74-4091-9cdb-d844194e5b69.png)

I also finally updated the CSS for the plugin stats cards too match the other cards 
![Before](https://cdn.nest.rip/uploads/33de54df-8748-49d7-96f8-4e11153b6473.png)
![After](https://cdn.nest.rip/uploads/7fd1b73c-8fa6-4505-89ec-bd1e5e1efa00.png)