### PR TITLE
plugin: SplitLargeMessages

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ You can join our [discord server](https://discord.gg/5Xh2W87egW) for commits, ch
 - WriteUpperCase by Samwich & KrystalSkull
 - YoutubeDescription by arHSM
 - LastActive by Crxa
+- SplitLargeMessages by Reycko
 
 ### Web Only
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can join our [discord server](https://discord.gg/5Xh2W87egW) for commits, ch
 ### Extra included plugins
 
 <details>
-<summary>169 additional plugins</summary>
+<summary>170 additional plugins</summary>
 
 ### All Platforms
 
@@ -96,6 +96,7 @@ You can join our [discord server](https://discord.gg/5Xh2W87egW) for commits, ch
 - JumpToStart by Samwich
 - KeyboardSounds by HypedDomi
 - KeywordNotify by camila314 & x3rt
+- - LastActive by Crxa
 - LimitMiddleClickPaste by no dev listed
 - LoginWithQR by nexpid
 - MediaPlaybackSpeed by D3SOX
@@ -142,6 +143,7 @@ You can join our [discord server](https://discord.gg/5Xh2W87egW) for commits, ch
 - Signature by Ven, Rini, ImBanana, KrystalSkull
 - Slap by Korbo
 - SoundBoardLogger by Moxxie, fres, echo, maintained by thororen
+- - SplitLargeMessages by Reycko
 - SpotifyLyrics by Joona
 - StatsfmPresence by Crxa
 - StatusPresets by iamme
@@ -177,8 +179,6 @@ You can join our [discord server](https://discord.gg/5Xh2W87egW) for commits, ch
 - Woof by Samwich
 - WriteUpperCase by Samwich & KrystalSkull
 - YoutubeDescription by arHSM
-- LastActive by Crxa
-- SplitLargeMessages by Reycko
 
 ### Web Only
 

--- a/src/equicordplugins/splitLargeMessages/index.ts
+++ b/src/equicordplugins/splitLargeMessages/index.ts
@@ -1,0 +1,151 @@
+import { addMessagePreSendListener, MessageSendListener, removeMessagePreSendListener } from "@api/MessageEvents";
+import { definePluginSettings } from "@api/Settings";
+import { EquicordDevs } from "@utils/constants";
+import { getCurrentChannel, sendMessage } from "@utils/discord";
+import definePlugin, { OptionType } from "@utils/types";
+import { ComponentDispatch } from "@webpack/common";
+import { ChannelStore, PermissionsBits, UserStore } from "@webpack/common";
+import { Settings } from "Vencord";
+
+let maxLength: number = 0;
+
+const canSplit: () => boolean = () => {
+    const slowmode = getCurrentChannel()?.rateLimitPerUser ?? 0;
+    const settings = Settings.plugins.SplitLargeMessages;
+    return (settings.splitInSlowmode ? slowmode < settings.slowmodeMax : slowmode <= 0) && settings.disableFileConversion;
+};
+
+const autoMaxLength = () => {
+    const hasNitro = UserStore.getCurrentUser().premiumType === 2;
+    return hasNitro ? 4000 : 2000;
+};
+
+const split = async (channelId: string, chunks: string[], delayInMs: number) => {
+    const sendChunk = async (chunk: string) => {
+        await sendMessage(channelId, { content: chunk }, true);
+    };
+
+    // Send the chunks
+    for (let i = 0; i < chunks.length; i++) {
+        await sendChunk(chunks[i]);
+        if (i < chunks.length - 1) // Not the last chunk
+            await new Promise(resolve => setTimeout(resolve, delayInMs)); // Wait for `delayInMs`
+    }
+};
+
+const listener: MessageSendListener = async (channelId, msg) => {
+    if (msg.content.trim().length < maxLength || !canSplit()) return; // Nothing to split
+
+    const channel = ChannelStore.getChannel(channelId);
+
+    // Check for slowmode
+    let isSlowmode = channel.rateLimitPerUser > 0;
+    if ((channel.accessPermissions & PermissionsBits.MANAGE_MESSAGES) == PermissionsBits.MANAGE_MESSAGES
+        || (channel.accessPermissions & PermissionsBits.MANAGE_CHANNELS) == PermissionsBits.MANAGE_CHANNELS)
+        isSlowmode = false;
+
+    // Not slowmode or splitInSlowmode is on and less than slowmodeMax
+    if (!isSlowmode || (Settings.plugins.SplitLargeMessages.splitInSlowmode && channel.rateLimitPerUser < Settings.plugins.SplitLargeMessages.slowmodeMax)) {
+        const chunks: string[] = [];
+        const hardSplit: boolean = Settings.plugins.SplitLargeMessages.hardSplit;
+        while (msg.content.length > maxLength) {
+            msg.content = msg.content.trim();
+
+            // Get last space or newline
+            const splitIndex = Math.max(msg.content.lastIndexOf(' ', maxLength), msg.content.lastIndexOf('\n', maxLength));
+
+            // If hard split is on or neither newline or space found, split at maxLength
+            if (hardSplit || splitIndex === -1) {
+                chunks.push(msg.content.slice(0, maxLength));
+                msg.content = msg.content.slice(maxLength);
+            }
+            else {
+                chunks.push(msg.content.slice(0, splitIndex));
+                msg.content = msg.content.slice(splitIndex);
+            }
+        }
+
+        ComponentDispatch.dispatchToLastSubscribed('CLEAR_TEXT');
+        await split(channelId, [...chunks, msg.content], Settings.plugins.SplitLargeMessages.sendDelay * 1000);
+    }
+    return { cancel: true };
+};
+
+export default definePlugin({
+    name: 'SplitLargeMessages',
+    description: 'Splits large messages into multiple to fit Discord\'s message limit.',
+    authors: [EquicordDevs.Reycko],
+    dependencies: ['MessageEventsAPI'],
+    settings: definePluginSettings({
+        maxLength: {
+            type: OptionType.NUMBER,
+            description: 'Maximum length of a message before it is split. Set to 0 to automatically detect.',
+            default: 0,
+            max: 4000,
+            onChange(newValue) {
+                if (newValue === 0)
+                    maxLength = autoMaxLength();
+            },
+        },
+
+        disableFileConversion: {
+            type: OptionType.BOOLEAN,
+            description: 'If true, disables file conversion for large messages.',
+            default: true,
+        },
+
+        sendDelay: {
+            type: OptionType.SLIDER,
+            description: 'Delay between each chunk in seconds.',
+            default: 1,
+            markers: [1, 2, 3, 5, 10],
+        },
+
+        hardSplit: {
+            type: OptionType.BOOLEAN,
+            description: 'If true, splits on the last character instead of the last space/newline.',
+            default: false,
+        },
+
+        splitInSlowmode: {
+            type: OptionType.BOOLEAN,
+            description: 'Should messages be split if the channel has slowmode enabled?',
+        },
+
+        slowmodeMax: {
+            type: OptionType.NUMBER,
+            description: 'Maximum slowmode time if splitting in slowmode.',
+            default: 5,
+            min: 1,
+            max: 30,
+        }
+    }),
+
+    start() {
+        if (Settings.plugins.SplitLargeMessages.maxLength === 0)
+            maxLength = autoMaxLength();
+        addMessagePreSendListener(listener);
+    },
+
+    stop() {
+        removeMessagePreSendListener(listener);
+    },
+
+    patches: [
+        {
+            find: 'type:"MESSAGE_LENGTH_UPSELL"', // bypass message length check
+            replacement: {
+                match: /if\(\i.length>\i/,
+                replace: 'if(false',
+            }
+        },
+
+        {
+            find: '(this,"hideAutocomplete"', // disable file conversion
+            replacement: {
+                match: /if\(\i.length>\i\)/,
+                replace: 'if(false)',
+            },
+        }
+    ]
+});

--- a/src/equicordplugins/splitLargeMessages/index.ts
+++ b/src/equicordplugins/splitLargeMessages/index.ts
@@ -1,18 +1,21 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { addMessagePreSendListener, MessageSendListener, removeMessagePreSendListener } from "@api/MessageEvents";
 import { definePluginSettings } from "@api/Settings";
 import { EquicordDevs } from "@utils/constants";
 import { getCurrentChannel, sendMessage } from "@utils/discord";
 import definePlugin, { OptionType } from "@utils/types";
-import { ComponentDispatch } from "@webpack/common";
-import { ChannelStore, PermissionsBits, UserStore } from "@webpack/common";
-import { Settings } from "Vencord";
+import { ChannelStore, ComponentDispatch, PermissionsBits, UserStore } from "@webpack/common";
 
 let maxLength: number = 0;
 
 const canSplit: () => boolean = () => {
     const slowmode = getCurrentChannel()?.rateLimitPerUser ?? 0;
-    const settings = Settings.plugins.SplitLargeMessages;
-    return (settings.splitInSlowmode ? slowmode < settings.slowmodeMax : slowmode <= 0) && settings.disableFileConversion;
+    return (settings.store.splitInSlowmode ? slowmode < settings.store.slowmodeMax : slowmode <= 0) && settings.store.disableFileConversion;
 };
 
 const autoMaxLength = () => {
@@ -40,19 +43,19 @@ const listener: MessageSendListener = async (channelId, msg) => {
 
     // Check for slowmode
     let isSlowmode = channel.rateLimitPerUser > 0;
-    if ((channel.accessPermissions & PermissionsBits.MANAGE_MESSAGES) == PermissionsBits.MANAGE_MESSAGES
-        || (channel.accessPermissions & PermissionsBits.MANAGE_CHANNELS) == PermissionsBits.MANAGE_CHANNELS)
+    if ((channel.accessPermissions & PermissionsBits.MANAGE_MESSAGES) === PermissionsBits.MANAGE_MESSAGES
+        || (channel.accessPermissions & PermissionsBits.MANAGE_CHANNELS) === PermissionsBits.MANAGE_CHANNELS)
         isSlowmode = false;
 
     // Not slowmode or splitInSlowmode is on and less than slowmodeMax
-    if (!isSlowmode || (Settings.plugins.SplitLargeMessages.splitInSlowmode && channel.rateLimitPerUser < Settings.plugins.SplitLargeMessages.slowmodeMax)) {
+    if (!isSlowmode || (settings.store.splitInSlowmode && channel.rateLimitPerUser < settings.store.slowmodeMax)) {
         const chunks: string[] = [];
-        const hardSplit: boolean = Settings.plugins.SplitLargeMessages.hardSplit;
+        const { hardSplit } = settings.store;
         while (msg.content.length > maxLength) {
             msg.content = msg.content.trim();
 
             // Get last space or newline
-            const splitIndex = Math.max(msg.content.lastIndexOf(' ', maxLength), msg.content.lastIndexOf('\n', maxLength));
+            const splitIndex = Math.max(msg.content.lastIndexOf(" ", maxLength), msg.content.lastIndexOf("\n", maxLength));
 
             // If hard split is on or neither newline or space found, split at maxLength
             if (hardSplit || splitIndex === -1) {
@@ -65,64 +68,66 @@ const listener: MessageSendListener = async (channelId, msg) => {
             }
         }
 
-        ComponentDispatch.dispatchToLastSubscribed('CLEAR_TEXT');
-        await split(channelId, [...chunks, msg.content], Settings.plugins.SplitLargeMessages.sendDelay * 1000);
+        ComponentDispatch.dispatchToLastSubscribed("CLEAR_TEXT");
+        await split(channelId, [...chunks, msg.content], settings.store.sendDelay * 1000);
     }
     return { cancel: true };
 };
 
+const settings = definePluginSettings({
+    maxLength: {
+        type: OptionType.NUMBER,
+        description: "Maximum length of a message before it is split. Set to 0 to automatically detect.",
+        default: 0,
+        max: 4000,
+        onChange(newValue) {
+            if (newValue === 0)
+                maxLength = autoMaxLength();
+        },
+    },
+
+    disableFileConversion: {
+        type: OptionType.BOOLEAN,
+        description: "If true, disables file conversion for large messages.",
+        default: true,
+    },
+
+    sendDelay: {
+        type: OptionType.SLIDER,
+        description: "Delay between each chunk in seconds.",
+        default: 1,
+        markers: [1, 2, 3, 5, 10],
+    },
+
+    hardSplit: {
+        type: OptionType.BOOLEAN,
+        description: "If true, splits on the last character instead of the last space/newline.",
+        default: false,
+    },
+
+    splitInSlowmode: {
+        type: OptionType.BOOLEAN,
+        description: "Should messages be split if the channel has slowmode enabled?",
+    },
+
+    slowmodeMax: {
+        type: OptionType.NUMBER,
+        description: "Maximum slowmode time if splitting in slowmode.",
+        default: 5,
+        min: 1,
+        max: 30,
+    }
+});
+
 export default definePlugin({
-    name: 'SplitLargeMessages',
-    description: 'Splits large messages into multiple to fit Discord\'s message limit.',
+    name: "SplitLargeMessages",
+    description: "Splits large messages into multiple to fit Discord's message limit.",
     authors: [EquicordDevs.Reycko],
-    dependencies: ['MessageEventsAPI'],
-    settings: definePluginSettings({
-        maxLength: {
-            type: OptionType.NUMBER,
-            description: 'Maximum length of a message before it is split. Set to 0 to automatically detect.',
-            default: 0,
-            max: 4000,
-            onChange(newValue) {
-                if (newValue === 0)
-                    maxLength = autoMaxLength();
-            },
-        },
-
-        disableFileConversion: {
-            type: OptionType.BOOLEAN,
-            description: 'If true, disables file conversion for large messages.',
-            default: true,
-        },
-
-        sendDelay: {
-            type: OptionType.SLIDER,
-            description: 'Delay between each chunk in seconds.',
-            default: 1,
-            markers: [1, 2, 3, 5, 10],
-        },
-
-        hardSplit: {
-            type: OptionType.BOOLEAN,
-            description: 'If true, splits on the last character instead of the last space/newline.',
-            default: false,
-        },
-
-        splitInSlowmode: {
-            type: OptionType.BOOLEAN,
-            description: 'Should messages be split if the channel has slowmode enabled?',
-        },
-
-        slowmodeMax: {
-            type: OptionType.NUMBER,
-            description: 'Maximum slowmode time if splitting in slowmode.',
-            default: 5,
-            min: 1,
-            max: 30,
-        }
-    }),
+    dependencies: ["MessageEventsAPI"],
+    settings,
 
     start() {
-        if (Settings.plugins.SplitLargeMessages.maxLength === 0)
+        if (settings.store.maxLength === 0)
             maxLength = autoMaxLength();
         addMessagePreSendListener(listener);
     },
@@ -136,7 +141,7 @@ export default definePlugin({
             find: 'type:"MESSAGE_LENGTH_UPSELL"', // bypass message length check
             replacement: {
                 match: /if\(\i.length>\i/,
-                replace: 'if(false',
+                replace: "if(false",
             }
         },
 
@@ -144,7 +149,7 @@ export default definePlugin({
             find: '(this,"hideAutocomplete"', // disable file conversion
             replacement: {
                 match: /if\(\i.length>\i\)/,
-                replace: 'if(false)',
+                replace: "if(false)",
             },
         }
     ]

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1058,6 +1058,10 @@ export const EquicordDevs = Object.freeze({
         name: "Buzzy",
         id: 1273353654644117585n
     },
+    Reycko: {
+        name: "Reycko",
+        id: 1123725368004726794n,
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This PR adds a plugin that splits messages into multiple chunks for both non-Nitro and Nitro users to be able to send messages longer than 2000/4000 characters.

![image](https://github.com/user-attachments/assets/fa3cb09e-4da4-4391-8892-926862c9246f)
https://github.com/user-attachments/assets/86d3e82e-d5ef-4c52-a467-b9ccd560796f

This is inspired by the BetterDiscord plugin of the same name by DevilBro