### PR TITLE
fix: notifications background

### DIFF
--- a/src/api/Notifications/styles.css
+++ b/src/api/Notifications/styles.css
@@ -11,10 +11,6 @@
     width: 100%;
 }
 
-.visual-refresh .vc-notification-root {
-    background-color: var(--bg-overlay-floating, var(--background-base-low));
-}
-
 .vc-notification-root:not(.vc-notification-log-wrapper > .vc-notification-root) {
     position: absolute;
     z-index: 2147483647;


### PR DESCRIPTION
This PR reverts the "fix" introduced in [Vencord#3344](https://github.com/Vendicated/Vencord/pull/3344), which broke the notification background (it makes the background transparent when using a Nitro theme).

![Capture d'écran 2025-05-20 190027](https://github.com/user-attachments/assets/d10bed10-4bd9-4dbd-b0e1-4e05421619ba)

No change was needed in the first place, so this simply removes it.