### PR TITLE
timezone plugin color update

### DIFF
--- a/src/equicordplugins/timezones/styles.css
+++ b/src/equicordplugins/timezones/styles.css
@@ -3,7 +3,7 @@
     right: 0;
     bottom: 0;
     margin: 28px 16px 4px;
-    background: var(--profile-body-background-color, var(--background-primary));
+    background-color: rgba(0 0 0 / 50%);
     border-radius: 4px;
     padding: 0.25rem 0.5rem;
     font-size: 0.75rem;


### PR DESCRIPTION
updates the timezones plugin to change the profile theme color from transparent (background-primary is null) to 50% of black making it more readable


[![Old](https://cdn.nest.rip/uploads/551913e8-fde0-4ffe-849a-d6ea49b2ab6c.png)](https://cdn.nest.rip/uploads/551913e8-fde0-4ffe-849a-d6ea49b2ab6c.png)


[![New](https://cdn.nest.rip/uploads/d2e855a3-a0fd-43b6-bedc-20e02b1e1c6d.png)](https://cdn.nest.rip/uploads/d2e855a3-a0fd-43b6-bedc-20e02b1e1c6d.png)
