### PR TITLE
Add removeAgeCheck

### DIFF
--- a/src/equicordplugins/removeAgeCheck/index.tsx
+++ b/src/equicordplugins/removeAgeCheck/index.tsx
@@ -1,0 +1,41 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import definePlugin from "@utils/types";
+import { Devs } from "@utils/constants";
+import { findByProps } from "@webpack";
+
+export default definePlugin({
+    name: "RemoveAgeCheck",
+    description: "Bypasses age verification by setting ageVerificationStatus to 3.",
+    authors: [Devs.HPsaucii],
+    start() {
+        // Find the UserStore with getCurrentUser
+        const UserStore = findByProps("getCurrentUser");
+        if (!UserStore) return;
+
+        // Patch getCurrentUser to always set ageVerificationStatus = 3
+        this.unpatch = UserStore.getCurrentUser
+            ? UserStore.getCurrentUser = new Proxy(UserStore.getCurrentUser, {
+                apply(target, thisArg, args) {
+                    const user = Reflect.apply(target, thisArg, args);
+                    if (user) user.ageVerificationStatus = 3;
+                    return user;
+                }
+            })
+            : null;
+
+        // Set it immediately for the current user
+        const user = UserStore.getCurrentUser?.();
+        if (user) user.ageVerificationStatus = 3;
+    },
+    stop() {
+        // Restore original getCurrentUser if patched
+        if (this.unpatch && findByProps("getCurrentUser")) {
+            findByProps("getCurrentUser").getCurrentUser = this.unpatch;
+        }
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -617,6 +617,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Cootshk",
         id: 921605971577548820n
     },
+    HPsaucii: {
+        name: "HPsaucii",
+        id: 578110568209055756n
+    },
 } satisfies Record<string, Dev>);
 
 export const EquicordDevs = Object.freeze({


### PR DESCRIPTION
This pull request adds an Equicord plugin that removes the recent age verification gate implemented by discord, that would otherwise require privacy-invasive photo-identification.

We do this by hardcoding the `getCurrentUser().ageVerificationStatus` to be `3`.

No, I don't know why discord chose this trivial implementation, as it's ridiculously easy to bypass.

Credit to Amia on twitter (a.k.a X) for the console Javascript this is inspired by. https://fixvx.com/amia_dev/status/1948926327895020026 