### PR TITLE
feat(onePingPerDM): never throttle pings from chosen users

### DIFF
--- a/src/plugins/onePingPerDM/index.ts
+++ b/src/plugins/onePingPerDM/index.ts
@@ -1,3 +1,9 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2023 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
@@ -9,9 +15,6 @@ const enum ChannelType {
     GROUP_DM = 3
 }
 
-// ------------------------------------------------------------------
-// 1.  Add the new setting
-// ------------------------------------------------------------------
 const settings = definePluginSettings({
     channelToAffect: {
         type: OptionType.SELECT,

--- a/src/plugins/onePingPerDM/index.ts
+++ b/src/plugins/onePingPerDM/index.ts
@@ -43,15 +43,6 @@ const settings = definePluginSettings({
     }
 });
 
-
-let _ignoreList: string[] | null = null;
-function getIgnoreList(): string[] {
-    if (_ignoreList) return _ignoreList;
-    _ignoreList = settings.store.ignoreUsers.split(", ").filter(Boolean);
-    return _ignoreList;
-}
-
-
 export default definePlugin({
     name: "OnePingPerDM",
     description: "If unread messages are sent by a user in DMs multiple times, you'll only receive one audio ping. Read the messages to reset the limit",
@@ -69,7 +60,8 @@ export default definePlugin({
         }]
     }],
     isPrivateChannelRead(message: MessageJSON) {
-        if (getIgnoreList().includes(message.author.id)) return true;
+        const ignoreList = settings.store.ignoreUsers.split(", ").filter(Boolean)
+        if (ignoreList.includes(message.author.id)) return true;
         const channelType = ChannelStore.getChannel(message.channel_id)?.type;
         if (
             (channelType !== ChannelType.DM && channelType !== ChannelType.GROUP_DM) ||


### PR DESCRIPTION
Adds a comma-separated list of user IDs whose messages will always trigger an audio ping, even when OnePingPerDM would normally suppress subsequent pings.