### PR TITLE
Questify: Prevent extended delay before fetching Quests on startup.

### DIFF
--- a/src/equicordplugins/questify/index.tsx
+++ b/src/equicordplugins/questify/index.tsx
@@ -11,6 +11,7 @@ import { ErrorBoundary, openPluginModal } from "@components/index";
 import { EquicordDevs } from "@utils/constants";
 import { getIntlMessage } from "@utils/index";
 import definePlugin, { StartAt } from "@utils/types";
+import { onceReady } from "@webpack";
 import { ContextMenuApi, Menu, NavigationRouter } from "@webpack/common";
 import { JSX } from "react";
 
@@ -1122,6 +1123,17 @@ export default definePlugin({
                 rerenderQuests();
             }
         },
+
+        LOGOUT(data) {
+            settings.store.unclaimedUnignoredQuests = 0;
+            settings.store.onQuestsPage = false;
+        },
+
+        LOGIN_SUCCESS(data) {
+            onceReady.then(() => {
+                fetchAndDispatchQuests("Questify", QuestifyLogger);
+            });
+        }
     },
 
     renderQuestifyButton: ErrorBoundary.wrap(QuestButton, { noop: true }),

--- a/src/equicordplugins/questify/settings.tsx
+++ b/src/equicordplugins/questify/settings.tsx
@@ -149,7 +149,7 @@ export function questIsIgnored(questID: string): boolean {
 export function validateIgnoredQuests(ignoredQuests?: string[], questsData?: Quest[]): [string[], number] {
     const quests = questsData ?? Array.from(QuestsStore.quests.values()) as Quest[];
     const excludedQuests = Array.from(QuestsStore.excludedQuests.values()) as ExcludedQuest[];
-    const currentlyIgnored = ignoredQuests ? new Set(ignoredQuests) : new Set(getIgnoredQuestIDs());
+    const currentlyIgnored = ignoredQuests ? new Set(ignoredQuests) : new Set(getIgnoredQuestIDs(questsData?.[0]?.userStatus?.userId));
     const validIgnored = new Set<string>();
     let numUnclaimedUnignoredQuests = 0;
 
@@ -175,7 +175,7 @@ export function validateIgnoredQuests(ignoredQuests?: string[], questsData?: Que
 export function validateAndOverwriteIgnoredQuests(ignoredQuests?: string[], questsData?: Quest[]): string[] {
     const [validIgnored, numUnclaimedUnignoredQuests] = validateIgnoredQuests(ignoredQuests, questsData);
     settings.store.unclaimedUnignoredQuests = numUnclaimedUnignoredQuests;
-    setIgnoredQuestIDs(validIgnored);
+    setIgnoredQuestIDs(validIgnored, questsData?.[0]?.userStatus?.userId);
     return validIgnored;
 }
 

--- a/src/equicordplugins/questify/utils/components.tsx
+++ b/src/equicordplugins/questify/utils/components.tsx
@@ -106,6 +106,7 @@ export interface Quest {
         };
     },
     userStatus: null | {
+        userId: string;
         claimedAt: string | null;
         completedAt: string | null;
         enrolledAt: string | null;

--- a/src/equicordplugins/questify/utils/misc.tsx
+++ b/src/equicordplugins/questify/utils/misc.tsx
@@ -25,15 +25,17 @@ export const leftClick = 0;
 export const middleClick = 1;
 export const rightClick = 2;
 
-export function setIgnoredQuestIDs(questIDs: string[]): void {
-    const currentUserID = UserStore.getCurrentUser().id;
+export function setIgnoredQuestIDs(questIDs: string[], userId?: string): void {
+    const currentUserID = userId ?? UserStore.getCurrentUser()?.id;
+    if (!currentUserID) return;
     const { ignoredQuestProfile } = settings.store;
     const key = ignoredQuestProfile === "shared" ? "shared" : currentUserID;
     settings.store.ignoredQuestIDs[key] = questIDs;
 }
 
-export function getIgnoredQuestIDs(): string[] {
-    const currentUserID = UserStore.getCurrentUser().id;
+export function getIgnoredQuestIDs(userId?: string): string[] {
+    const currentUserID = userId ?? UserStore.getCurrentUser()?.id;
+    if (!currentUserID) return [];
     const { ignoredQuestIDs, ignoredQuestProfile } = settings.store;
     const key = ignoredQuestProfile === "shared" ? "shared" : currentUserID;
     ignoredQuestIDs[key] ??= [];


### PR DESCRIPTION
Title. Pretty much just fetches Quests even earlier than they already are. Prevents a 5-10s delay on startup where the unread indicator is potentially incorrect. Also prevents temporarily mismatched data when using the account switcher.