### PR TITLE
feat(MessageLogger): add diffs to messagelogger

### DIFF
--- a/src/plugins/messageLogger/HistoryModal.tsx
+++ b/src/plugins/messageLogger/HistoryModal.tsx
@@ -84,7 +84,7 @@ export function HistoryModal({ modalProps, message }: { modalProps: ModalProps; 
                 </TabBar>
 
                 <div className={classes(CodeContainerClasses.markup, MiscClasses.messageContent, Margins.top20)}>
-                    {parseEditContent(contents[currentTab], message)}
+                    {parseEditContent(contents[currentTab], message, currentTab === contents.length - 1 ? undefined : contents[contents.length - 1])}
                 </div>
             </ModalContent>
         </ModalRoot>

--- a/src/plugins/messageLogger/deleteStyleOverlay.css
+++ b/src/plugins/messageLogger/deleteStyleOverlay.css
@@ -1,3 +1,3 @@
 .messagelogger-deleted {
-    background-color: hsla(var(--red-430-hsl, 0 85% 61%) / 15%) !important;
+    background-color: hsl(3deg 86% 68%) !important;
 }

--- a/src/plugins/messageLogger/diffUtils.ts
+++ b/src/plugins/messageLogger/diffUtils.ts
@@ -10,7 +10,29 @@ export interface DiffPart {
 }
 
 export function createWordDiff(oldText: string, newText: string): DiffPart[] {
-    // checks for suffixes, so if "this this" the suffix is checked so it doesn't log wrong, LCS algorithm breaks without this lol
+    // Handle simple prefix addition: "watch" -> "watch this again"
+    if (oldText.length < newText.length && newText.startsWith(oldText)) {
+        const added = newText.slice(oldText.length);
+        const parts: DiffPart[] = [];
+        if (oldText.length > 0) {
+            parts.push({ type: "unchanged", text: oldText });
+        }
+        parts.push({ type: "added", text: added });
+        return parts;
+    }
+
+    // Handle simple suffix addition: "watch" -> "prefix watch"
+    if (oldText.length < newText.length && newText.endsWith(oldText)) {
+        const added = newText.slice(0, newText.length - oldText.length);
+        const parts: DiffPart[] = [];
+        parts.push({ type: "added", text: added });
+        if (oldText.length > 0) {
+            parts.push({ type: "unchanged", text: oldText });
+        }
+        return parts;
+    }
+
+    // Handle simple prefix removal: "watch this" -> "watch"
     if (newText.length < oldText.length && oldText.startsWith(newText)) {
         const removed = oldText.slice(newText.length);
         const parts: DiffPart[] = [];
@@ -21,7 +43,7 @@ export function createWordDiff(oldText: string, newText: string): DiffPart[] {
         return parts;
     }
 
-    // same thing as above
+    // Handle simple suffix removal: "prefix watch" -> "watch"
     if (newText.length < oldText.length && oldText.endsWith(newText)) {
         const removed = oldText.slice(0, oldText.length - newText.length);
         const parts: DiffPart[] = [];
@@ -32,7 +54,7 @@ export function createWordDiff(oldText: string, newText: string): DiffPart[] {
         return parts;
     }
 
-    // Fall back to LCS for complex cases
+    // For complex cases, fall back to LCS algorithm
     const oldChars = oldText.split("");
     const newChars = newText.split("");
 

--- a/src/plugins/messageLogger/diffUtils.ts
+++ b/src/plugins/messageLogger/diffUtils.ts
@@ -1,0 +1,93 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface DiffPart {
+    type: "added" | "removed" | "unchanged";
+    text: string;
+}
+
+export function createWordDiff(oldText: string, newText: string): DiffPart[] {
+    // checks for suffixes, so if "this this" the suffix is checked so it doesn't log wrong, LCS algorithm breaks without this lol
+    if (newText.length < oldText.length && oldText.startsWith(newText)) {
+        const removed = oldText.slice(newText.length);
+        const parts: DiffPart[] = [];
+        if (newText.length > 0) {
+            parts.push({ type: "unchanged", text: newText });
+        }
+        parts.push({ type: "removed", text: removed });
+        return parts;
+    }
+
+    // same thing as above
+    if (newText.length < oldText.length && oldText.endsWith(newText)) {
+        const removed = oldText.slice(0, oldText.length - newText.length);
+        const parts: DiffPart[] = [];
+        parts.push({ type: "removed", text: removed });
+        if (newText.length > 0) {
+            parts.push({ type: "unchanged", text: newText });
+        }
+        return parts;
+    }
+
+    // Fall back to LCS for complex cases
+    const oldChars = oldText.split("");
+    const newChars = newText.split("");
+
+    const result: DiffPart[] = [];
+    const dp: number[][] = [];
+
+    for (let i = 0; i <= oldChars.length; i++) {
+        dp[i] = [];
+        for (let j = 0; j <= newChars.length; j++) {
+            dp[i][j] = 0;
+        }
+    }
+
+    for (let i = 1; i <= oldChars.length; i++) {
+        for (let j = 1; j <= newChars.length; j++) {
+            if (oldChars[i - 1] === newChars[j - 1]) {
+                dp[i][j] = dp[i - 1][j - 1] + 1;
+            } else {
+                dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+            }
+        }
+    }
+
+    let i = oldChars.length;
+    let j = newChars.length;
+
+    const diffParts: DiffPart[] = [];
+
+    while (i > 0 || j > 0) {
+        if (i > 0 && j > 0 && oldChars[i - 1] === newChars[j - 1]) {
+            diffParts.unshift({ type: "unchanged", text: oldChars[i - 1] });
+            i--;
+            j--;
+        } else if (j > 0 && (i === 0 || dp[i][j - 1] > dp[i - 1][j])) {
+            diffParts.unshift({ type: "added", text: newChars[j - 1] });
+            j--;
+        } else if (i > 0) {
+            diffParts.unshift({ type: "removed", text: oldChars[i - 1] });
+            i--;
+        }
+    }
+
+    const groupedParts: DiffPart[] = [];
+    for (const part of diffParts) {
+        const lastPart = groupedParts[groupedParts.length - 1];
+        if (lastPart && lastPart.type === part.type) {
+            lastPart.text += part.text;
+        } else {
+            groupedParts.push(part);
+        }
+    }
+
+    return groupedParts;
+}
+
+export function createMessageDiff(previousContent: string, currentContent: string): DiffPart[] {
+    return createWordDiff(previousContent, currentContent);
+}

--- a/src/plugins/messageLogger/diffUtils.ts
+++ b/src/plugins/messageLogger/diffUtils.ts
@@ -10,7 +10,7 @@ export interface DiffPart {
 }
 
 export function createWordDiff(oldText: string, newText: string): DiffPart[] {
-    // Handle simple prefix addition: "watch" -> "watch this again"
+    // suffix shit, if oldText is shorter than newText and newText starts with oldText
     if (oldText.length < newText.length && newText.startsWith(oldText)) {
         const added = newText.slice(oldText.length);
         const parts: DiffPart[] = [];
@@ -21,7 +21,7 @@ export function createWordDiff(oldText: string, newText: string): DiffPart[] {
         return parts;
     }
 
-    // Handle simple suffix addition: "watch" -> "prefix watch"
+    // same as above
     if (oldText.length < newText.length && newText.endsWith(oldText)) {
         const added = newText.slice(0, newText.length - oldText.length);
         const parts: DiffPart[] = [];

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -297,6 +297,7 @@ export default definePlugin({
             type: OptionType.BOOLEAN,
             description: "Show visual differences between edited message versions",
             default: true,
+            restartNeeded: true,
         },
     },
 

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -327,8 +327,7 @@ export default definePlugin({
         showEditDiffs: {
             type: OptionType.BOOLEAN,
             description: "Show visual differences between edited message versions",
-            default: true,
-            restartNeeded: true,
+            default: false,
         },
     },
 

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -158,7 +158,7 @@ function renderDiffParts(diffParts: DiffPart[]) {
 }
 
 export function parseEditContent(content: string, message: Message, previousContent?: string) {
-    if (previousContent && content !== previousContent) {
+    if (previousContent && content !== previousContent && Settings.plugins.MessageLogger.showEditDiffs) {
         const diffParts = createMessageDiff(content, previousContent);
         return renderDiffParts(diffParts);
     }
@@ -292,6 +292,11 @@ export default definePlugin({
             type: OptionType.STRING,
             description: "Comma-separated list of guild IDs to ignore",
             default: "",
+        },
+        showEditDiffs: {
+            type: OptionType.BOOLEAN,
+            description: "Show visual differences between edited message versions",
+            default: true,
         },
     },
 

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -53,3 +53,9 @@
 .messagelogger-diff-removed {
     color: #F47068;
 }
+
+/* when diffs are disabled for a specific message, remove diff colors */
+.messagelogger-diff-disabled .messagelogger-diff-added,
+.messagelogger-diff-disabled .messagelogger-diff-removed {
+    color: inherit;
+}

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -2,15 +2,12 @@
     display: none;
 }
 
-.messagelogger-deleted
-:is(
-    .messagelogger-deleted-attachment,
+.messagelogger-deleted:is(.messagelogger-deleted-attachment,
     .emoji,
     [data-type="sticker"],
     [class*="embedIframe"],
     [class*="embedSpotify"],
-    [class*="imageContainer"]
-) {
+    [class*="imageContainer"]) {
     filter: grayscale(1) !important;
     transition: 150ms filter ease-in-out;
 
@@ -54,13 +51,5 @@
 }
 
 .messagelogger-diff-removed {
-    color: #F47068;
-}
-
-.theme-light .messagelogger-diff-added {
-    color: #85E89D;
-}
-
-.theme-light .messagelogger-diff-removed {
     color: #F47068;
 }

--- a/src/plugins/messageLogger/messageLogger.css
+++ b/src/plugins/messageLogger/messageLogger.css
@@ -48,3 +48,19 @@
     flex-wrap: wrap;
     gap: 16px;
 }
+
+.messagelogger-diff-added {
+    color: #85E89D;
+}
+
+.messagelogger-diff-removed {
+    color: #F47068;
+}
+
+.theme-light .messagelogger-diff-added {
+    color: #85E89D;
+}
+
+.theme-light .messagelogger-diff-removed {
+    color: #F47068;
+}


### PR DESCRIPTION
this basically just adds diffs to messages using LCS looks like this:
<img width="399" height="85" alt="image" src="https://github.com/user-attachments/assets/5605d97d-9f1b-401f-beb2-de5b6ffef991" />
and then for added:
<img width="392" height="56" alt="image" src="https://github.com/user-attachments/assets/f0c3bb77-24c0-40ee-9da4-cb1d6d990860" />
this will also show in the modal!
<img width="934" height="458" alt="image" src="https://github.com/user-attachments/assets/afcc555e-f99e-45ec-9b10-dda91647b4ee" />
idk i find this pretty useful, maybe you will too! (also i couldn't figure out how to make this a setting if someone could teach me that would be great LOL