### PR TITLE
MessageLogger: Only show diffs option if enabled + switch to definePluginSettings.

### DIFF
--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -80,7 +80,8 @@ const patchMessageContextMenu: NavContextMenuPatchCallback = (
         );
     }
 
-    // toggle per-message diff rendering when the message has an edit history
+    // toggle per-message diff rendering when the message
+    // has an edit history and the setting is enabled
     if (editHistory?.length && settings.store.showEditDiffs) {
         const isDisabled = disabledDiffMessages.has(id);
         children.push(
@@ -92,10 +93,10 @@ const patchMessageContextMenu: NavContextMenuPatchCallback = (
                 action={() => {
                     if (isDisabled) disabledDiffMessages.delete(id);
                     else disabledDiffMessages.add(id);
-                    // also toggle a CSS class on the message element for an immediate visual effect (basically shows things work lol)
+                    // Also toggle a CSS class on the message element for immediate visual effect
                     const domElement = document.getElementById(`chat-messages-${channel_id}-${id}`);
                     domElement?.classList.toggle("messagelogger-diff-disabled", disabledDiffMessages.has(id));
-                    // force a re-render without mutating message fields
+                    // Force a re-render without mutating message fields
                     updateMessage(channel_id, id);
                 }}
             />,

--- a/src/plugins/messageLogger/index.tsx
+++ b/src/plugins/messageLogger/index.tsx
@@ -11,7 +11,7 @@ import {
     NavContextMenuPatchCallback,
 } from "@api/ContextMenu";
 import { updateMessage } from "@api/MessageUpdater";
-import { Settings } from "@api/Settings";
+import { definePluginSettings } from "@api/Settings";
 import { disableStyle, enableStyle } from "@api/Styles";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { Devs, VC_SUPPORT_CATEGORY_ID, VENBOT_USER_ID } from "@utils/constants";
@@ -41,7 +41,7 @@ const styles = findByPropsLazy("edited", "communicationDisabled", "isSystemMessa
 const disabledDiffMessages = new Set<string>();
 
 function addDeleteStyle() {
-    if (Settings.plugins.MessageLogger.deleteStyle === "text") {
+    if (settings.store.deleteStyle === "text") {
         enableStyle(textStyle);
         disableStyle(overlayStyle);
     } else {
@@ -81,7 +81,7 @@ const patchMessageContextMenu: NavContextMenuPatchCallback = (
     }
 
     // toggle per-message diff rendering when the message has an edit history
-    if (editHistory?.length) {
+    if (editHistory?.length && settings.store.showEditDiffs) {
         const isDisabled = disabledDiffMessages.has(id);
         children.push(
             <Menu.MenuItem
@@ -186,7 +186,7 @@ function renderDiffParts(diffParts: DiffPart[]) {
 
 export function parseEditContent(content: string, message: Message, previousContent?: string) {
     const perMessageDiffEnabled = !disabledDiffMessages.has(message.id);
-    if (previousContent && content !== previousContent && Settings.plugins.MessageLogger.showEditDiffs && perMessageDiffEnabled) {
+    if (previousContent && content !== previousContent && settings.store.showEditDiffs && perMessageDiffEnabled) {
         const diffParts = createMessageDiff(content, previousContent);
         return renderDiffParts(diffParts);
     }
@@ -202,11 +202,76 @@ export function parseEditContent(content: string, message: Message, previousCont
     });
 }
 
+const settings = definePluginSettings({
+    deleteStyle: {
+        type: OptionType.SELECT,
+        description: "The style of deleted messages",
+        default: "text",
+        options: [
+            { label: "Red text", value: "text", default: true },
+            { label: "Red overlay", value: "overlay" },
+        ],
+        onChange: () => addDeleteStyle(),
+    },
+    logDeletes: {
+        type: OptionType.BOOLEAN,
+        description: "Whether to log deleted messages",
+        default: true,
+    },
+    collapseDeleted: {
+        type: OptionType.BOOLEAN,
+        description: "Whether to collapse deleted messages, similar to blocked messages",
+        default: false,
+        restartNeeded: true,
+    },
+    logEdits: {
+        type: OptionType.BOOLEAN,
+        description: "Whether to log edited messages",
+        default: true,
+    },
+    inlineEdits: {
+        type: OptionType.BOOLEAN,
+        description: "Whether to display edit history as part of message content",
+        default: true,
+    },
+    ignoreBots: {
+        type: OptionType.BOOLEAN,
+        description: "Whether to ignore messages by bots",
+        default: false,
+    },
+    ignoreSelf: {
+        type: OptionType.BOOLEAN,
+        description: "Whether to ignore messages by yourself",
+        default: false,
+    },
+    ignoreUsers: {
+        type: OptionType.STRING,
+        description: "Comma-separated list of user IDs to ignore",
+        default: "",
+    },
+    ignoreChannels: {
+        type: OptionType.STRING,
+        description: "Comma-separated list of channel IDs to ignore",
+        default: "",
+    },
+    ignoreGuilds: {
+        type: OptionType.STRING,
+        description: "Comma-separated list of guild IDs to ignore",
+        default: "",
+    },
+    showEditDiffs: {
+        type: OptionType.BOOLEAN,
+        description: "Show visual differences between edited message versions",
+        default: false,
+    },
+});
+
 export default definePlugin({
     name: "MessageLogger",
     description: "Temporarily logs deleted and edited messages.",
     authors: [Devs.rushii, Devs.Ven, Devs.AutumnVN, Devs.Nickyux, Devs.Kyuuhachi],
     dependencies: ["MessageUpdaterAPI"],
+    settings,
 
     contextMenus: {
         message: patchMessageContextMenu,
@@ -236,7 +301,9 @@ export default definePlugin({
                     oldMsg === newMsg,
             );
 
-            return Settings.plugins.MessageLogger.inlineEdits && (
+            const { showEditDiffs, inlineEdits } = settings.use(["showEditDiffs", "inlineEdits"]);
+
+            return inlineEdits && (
                 <React.Fragment key={disabledDiffMessages.has(messageId) ? `diff-off-${messageId}` : `diff-on-${messageId}`}>
                     {message.editHistory?.map((edit, idx) => {
                         const nextContent = idx === (message.editHistory?.length ?? 0) - 1
@@ -265,70 +332,6 @@ export default definePlugin({
             timestamp: new Date(newMessage.edited_timestamp),
             content: oldMessage.content,
         };
-    },
-
-    options: {
-        deleteStyle: {
-            type: OptionType.SELECT,
-            description: "The style of deleted messages",
-            default: "text",
-            options: [
-                { label: "Red text", value: "text", default: true },
-                { label: "Red overlay", value: "overlay" },
-            ],
-            onChange: () => addDeleteStyle(),
-        },
-        logDeletes: {
-            type: OptionType.BOOLEAN,
-            description: "Whether to log deleted messages",
-            default: true,
-        },
-        collapseDeleted: {
-            type: OptionType.BOOLEAN,
-            description: "Whether to collapse deleted messages, similar to blocked messages",
-            default: false,
-            restartNeeded: true,
-        },
-        logEdits: {
-            type: OptionType.BOOLEAN,
-            description: "Whether to log edited messages",
-            default: true,
-        },
-        inlineEdits: {
-            type: OptionType.BOOLEAN,
-            description: "Whether to display edit history as part of message content",
-            default: true,
-        },
-        ignoreBots: {
-            type: OptionType.BOOLEAN,
-            description: "Whether to ignore messages by bots",
-            default: false,
-        },
-        ignoreSelf: {
-            type: OptionType.BOOLEAN,
-            description: "Whether to ignore messages by yourself",
-            default: false,
-        },
-        ignoreUsers: {
-            type: OptionType.STRING,
-            description: "Comma-separated list of user IDs to ignore",
-            default: "",
-        },
-        ignoreChannels: {
-            type: OptionType.STRING,
-            description: "Comma-separated list of channel IDs to ignore",
-            default: "",
-        },
-        ignoreGuilds: {
-            type: OptionType.STRING,
-            description: "Comma-separated list of guild IDs to ignore",
-            default: "",
-        },
-        showEditDiffs: {
-            type: OptionType.BOOLEAN,
-            description: "Show visual differences between edited message versions",
-            default: false,
-        },
     },
 
     handleDelete(
@@ -381,7 +384,7 @@ export default definePlugin({
             ignoreGuilds,
             logEdits,
             logDeletes,
-        } = Settings.plugins.MessageLogger;
+        } = settings.store;
         const myId = UserStore.getCurrentUser().id;
 
         return (
@@ -616,7 +619,7 @@ export default definePlugin({
                 match: /if\((\i)\.blocked\)return \i\.\i\.MESSAGE_GROUP_BLOCKED;/,
                 replace: '$&else if($1.deleted) return"MESSAGE_GROUP_DELETED";',
             },
-            predicate: () => Settings.plugins.MessageLogger.collapseDeleted,
+            predicate: () => settings.store.collapseDeleted,
         },
         {
             // Message group rendering
@@ -631,7 +634,7 @@ export default definePlugin({
                     replace: '$&$1.type==="MESSAGE_GROUP_DELETED"?$self.DELETED_MESSAGE_COUNT:',
                 },
             ],
-            predicate: () => Settings.plugins.MessageLogger.collapseDeleted,
+            predicate: () => settings.store.collapseDeleted,
         },
     ],
 });


### PR DESCRIPTION
#364 but without the conflicts and also switches to using proper settings syntax with `definePluginSettings`.