### PR TITLE
added DiscordProximity plugin

### DIFF
--- a/src/plugins/discordProximity/README.md
+++ b/src/plugins/discordProximity/README.md
@@ -1,0 +1,104 @@
+Support for a client side proximity chat protocol I designed yesterday.
+
+## Why?
+
+There are previously no Discord-based proximity chat clients, so I might as well as write it.
+
+I have read the code of conduct:
+- Nothing similar to this existed for Discord
+- This plugin has not been requested
+- The plugin does not depend on any external APIs or bots.
+- I'm not opening a request because I've already wrote the plugin, I'm here just to ask if Vencord would like to include it.
+- I have checked that changing local volume 20 times a second will not spam Discord with API requests, setting update requests are only triggered by changes made by the user.
+
+### Showcase
+
+https://github.com/user-attachments/assets/fa02ff46-4a46-470b-a71d-e58ddadc79d5
+
+### How This Works
+
+The main idea behind it is similar to ARRPC.
+1. The game client (e.g. Minecraft) starts a websocket server at `ws://127.0.0.1:25560/api/subscriptions`
+2. This plugin connects to the websocket server
+3. This plugin sends the list of users in the VC to the game client.
+4. The game client calculates the **volume multiplier**, and sends it back to the plugin.
+5. The plugin updates the user volumes accordingly.
+
+The plugin resets all use volumes to their original volumes when the game closes, or when the user leaves the VC.
+
+### The Protocol
+
+Messages are JSON formatted
+```json
+{
+	"t": "string",
+	"c": "any"
+}
+```
+
+Here are the message types that can be sent:
+
+#### connected
+
+WS server -> plugin when the connection is made
+
+```json
+{
+  "t": "connected",
+  "c": null
+}
+```
+
+#### sub
+
+Plugin -> WS server when you join a VC, or someone new joined a VC.
+
+```json
+{
+  "t": "sub",
+  "c": [ "12345678910", "list of discord ids..."]
+}
+```
+
+#### unsub
+
+Plugin -> WS server when someone leaves a VC.
+
+```json
+{
+  "t": "unsub",
+  "c": [ "12345678910", "list of discord ids..."]
+}
+```
+
+#### clear
+
+Plugin -> WS server when a connection is opened, to clear all previous subscription info.
+
+```json
+{
+  "t": "clear",
+  "c": null
+}
+```
+
+#### set
+
+WS server -> plugin to set a user volume by giving a volume multiplier, the multiplier is typically between 0 and 1.
+
+```json
+{
+  "t": "set",
+  "c": 0.456
+}
+```
+
+All other stuff not specified above are up to client implementation.
+
+### Example Implementation
+
+[DiscordProximity for Minecraft Forge 1.8.9](https://github.com/Siriusmart/DiscordProximity).
+
+Unless your game has a Discord linking feature, you might want a **nameserver** to map Discord IDs to in-game names in your implementaiton.
+
+For the Forge mod, I used [this single-source-file nameserver](https://github.com/Siriusmart/proximity-nameserver) and a [Discord bot](https://github.com/siriusmart/merlin) to allow users to set their IGN.

--- a/src/plugins/discordProximity/index.tsx
+++ b/src/plugins/discordProximity/index.tsx
@@ -1,0 +1,245 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import { Logger } from "@utils/Logger";
+import definePlugin from "@utils/types";
+import { findByPropsLazy } from "@webpack";
+import { ChannelStore, SelectedChannelStore, UserStore } from "@webpack/common";
+
+const whosThere = {};
+const whosThereReverse = {};
+let originalVolumes = {};
+
+// connection to game
+// undefined if not connected or closed
+// Websocket otherwise
+let ws : WebSocket | undefined;
+// bindWS() is called with a generation
+// generation is incremented when a connection closes
+// if the global generation != the generation bindWS() is ran with
+// bindWS() quits recursively calling itself
+// so there are only one bindWS() recursively calling itself at any given moment
+let generation = 0;
+
+const localVolumeSetter = findByPropsLazy("setLocalVolume");
+const localVolumeGetter = findByPropsLazy("getLocalVolume");
+
+// undo everything the plugin has done
+function restore(): void {
+    // resets user volume to how it was before starting the connection
+    for (const [user, volume] of Object.entries(originalVolumes)) {
+        localVolumeSetter.setLocalVolume(user, volume);
+    }
+
+    // clears this
+    originalVolumes = {};
+
+    // close any opened connections
+    if (ws !== undefined) {
+        ws.close();
+        ws = undefined;
+        generation++;
+    }
+
+    new Logger("DiscordProximity").log("Restored user volumes");
+}
+
+// runs after connection opened
+function connect(): void {
+    // nothing here for now
+}
+
+function bindWS(localGen: number): void {
+    const myId = UserStore.getCurrentUser().id;
+    if (generation !== localGen) return;
+    // no longer in VC
+    if (whosThereReverse[myId] === undefined) return;
+
+    try {
+        ws = new WebSocket("ws://127.0.0.1:25560/api/subscription");
+        ws.onopen = function () {
+            new Logger("DiscordProximity").log("Connected to proximity websocket.");
+            connect();
+            this.send(JSON.stringify({
+                t: "clear",
+                c: 0
+            }));
+
+            const targets = Object.keys(whosThere[whosThereReverse[myId]]).filter(id => id !== myId);
+
+            if (targets.length !== 0) {
+                this.send(JSON.stringify({
+                    t: "sub",
+                    c: targets
+                }));
+            }
+        };
+
+        let connected = false;
+
+        ws.onmessage = ({ data }) => {
+            data = JSON.parse(data);
+
+            switch (data.t) {
+                case "connected": {
+                    connected = true;
+                    break;
+                }
+                case "set": {
+                    if (!connected) break;
+
+                    const content: {
+                        [key: string]: number;
+                    } = data.c;
+
+                    for (const [userId, multiplier] of Object.entries(content)) {
+                        if (originalVolumes[userId] === undefined) {
+                            originalVolumes[userId] = localVolumeGetter.getLocalVolume(userId);
+                        }
+
+                        localVolumeSetter.setLocalVolume(userId, originalVolumes[userId] * multiplier);
+                    }
+                }
+
+            }
+        };
+
+        // retry in 10 seconds
+        ws.onclose = () => {
+            ws = undefined;
+            restore();
+        };
+
+        ws.onerror = () => {
+            if (generation !== localGen) {
+                ws = undefined;
+                restore();
+            } else {
+                setTimeout(() => bindWS(localGen), 10000);
+            }
+        };
+    } catch (e) {
+        ws = undefined;
+        setTimeout(() => bindWS(localGen), 10000);
+    }
+}
+
+// skidded from the TTS vc join announcer thing
+interface VoiceState {
+    userId: string;
+    channelId?: string;
+    oldChannelId?: string;
+    deaf: boolean;
+    mute: boolean;
+    selfDeaf: boolean;
+    selfMute: boolean;
+}
+
+export default definePlugin({
+    name: "DiscordProximity",
+    description: "Proximity voice chat plugin for Discord.",
+        authors: [Devs.Siriusmart],
+
+    start: () => {
+        generation++;
+        bindWS(generation);
+    },
+
+    stop: () => {
+        generation++;
+        restore();
+    },
+
+    // dunno what this does, stolen from another plugin
+    // but it works, thats all that matters
+    flux: {
+        VOICE_STATE_UPDATES({ voiceStates }: { voiceStates: VoiceState[]; }) {
+            const myId = UserStore.getCurrentUser().id;
+            const myChanId = SelectedChannelStore.getVoiceChannelId();
+
+            if (ChannelStore.getChannel(myChanId!)?.type === 13 /* Stage Channel */) return;
+
+            // dunno why this loop is requried
+            // again i just copied their code
+            for (const state of voiceStates) {
+                // state is any changes in VC states
+                if (state.channelId == null) {
+                    // this means someone has left the VC
+                    try {
+                        // if the volume of this user has been modified, reset it to its original volume
+                        if (originalVolumes[state.userId] !== undefined) {
+                            localVolumeSetter.setLocalVolume(state.userId, originalVolumes[state.userId]);
+                        }
+
+                        delete whosThereReverse[state.userId];
+
+                        if (ws !== undefined && myChanId === state.oldChannelId && state.userId !== myId) {
+                            ws.send(JSON.stringify({ t: "unsub", c: [state.userId] }));
+                        }
+
+                        // remove user from the vc he left
+                        if (state.oldChannelId != null) {
+                            delete whosThere[state.oldChannelId][state.userId];
+                            if (Object.keys(whosThere[state.oldChannelId]).length === 0) {
+                                delete whosThere[state.oldChannelId];
+                            }
+                        }
+                    } catch (e) {
+                        new Logger("DiscordProximity").error(e);
+                    }
+
+                    if (ws !== undefined && myChanId === state.oldChannelId && state.userId !== myId) {
+                        ws.send(JSON.stringify({ t: "unsub", c: [state.userId] }));
+                        if (originalVolumes[state.userId] !== undefined) {
+                            localVolumeSetter.setLocalVolume(state.userId, originalVolumes[state.userId]);
+                        }
+                    }
+
+                    // if you left the vc, close the connection and restore everything
+                    if (state.userId === myId) {
+                        if (ws !== undefined) {
+                            ws.close();
+                            ws = undefined;
+                        }
+
+                        generation++;
+
+                        restore();
+                    }
+                } else {
+                    // if the user only moved channels
+                    // then remove him from his old channel
+                    if (state.oldChannelId != null && state.oldChannelId !== state.channelId) {
+                        try {
+                            delete whosThereReverse[state.userId];
+                            delete whosThere[state.oldChannelId][state.userId];
+
+                            if (ws !== undefined && myChanId === state.oldChannelId && state.userId !== myId) {
+                                ws.send(JSON.stringify({ t: "unsub", c: [state.userId] }));
+                            }
+                        } catch (e) {
+                            new Logger("DiscordProximity").error(e);
+                        }
+                    }
+                    whosThereReverse[state.userId] = state.channelId;
+                    whosThere[state.channelId] ??= {};
+                    whosThere[state.channelId][state.userId] = true;
+
+                    if (ws !== undefined && myChanId === state.channelId && state.userId !== myId) {
+                        ws.send(JSON.stringify({ t: "sub", c: [state.userId] }));
+                    }
+
+                    // if you joined a vc, start the connection
+                    if (ws === undefined && state.userId === myId) {
+                        generation++;
+                        bindWS(generation);
+                    }
+                }
+            }
+        }
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -625,6 +625,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "thororen",
         id: 848339671629299742n
     },
+    Siriusmart: {
+        name: "Siriusmart",
+        id: 623823202073706496n
+    },
 } satisfies Record<string, Dev>);
 
 export const EquicordDevs = Object.freeze({


### PR DESCRIPTION
Taken from the plugin README

---

Support for a client side proximity chat protocol I designed yesterday.

## Why?

There are previously no Discord-based proximity chat clients, so I might as well as write it.

I have read the code of conduct:
- Nothing similar to this existed for Discord
- This plugin has not been previously rejected
- The plugin does not depend on any external APIs or bots.
- I'm not opening a request because I've already wrote the plugin, I'm here just to ask if Vencord would like to include it.
- I have checked that changing local volume 20 times a second will not spam Discord with API requests, setting update requests are only triggered by changes made by the user.

### Showcase
(unmute the video)

https://github.com/user-attachments/assets/fa02ff46-4a46-470b-a71d-e58ddadc79d5

### How This Works

The main idea behind it is similar to ARRPC.
1. The game client (e.g. Minecraft) starts a websocket server at `ws://127.0.0.1:25560/api/subscriptions`
2. This plugin connects to the websocket server
3. This plugin sends the list of users in the VC to the game client.
4. The game client calculates the **volume multiplier**, and sends it back to the plugin.
5. The plugin updates the user volumes accordingly.

The plugin resets all use volumes to their original volumes when the game closes, or when the user leaves the VC.

### The Protocol

Messages are JSON formatted
```json
{
	"t": "string",
	"c": "any"
}
```

Here are the message types that can be sent:

#### connected

WS server -> plugin when the connection is made

```json
{
  "t": "connected",
  "c": null
}
```

#### sub

Plugin -> WS server when you join a VC, or someone new joined a VC.

```json
{
  "t": "sub",
  "c": [ "12345678910", "list of discord ids..."]
}
```

#### unsub

Plugin -> WS server when someone leaves a VC.

```json
{
  "t": "unsub",
  "c": [ "12345678910", "list of discord ids..."]
}
```

#### clear

Plugin -> WS server when a connection is opened, to clear all previous subscription info.

```json
{
  "t": "clear",
  "c": null
}
```

#### set

WS server -> plugin to set a user volume by giving a volume multiplier, the multiplier is typically between 0 and 1.

```json
{
  "t": "set",
  "c": 0.456
}
```

All other stuff not specified above are up to client implementation.

### Example Implementation

[DiscordProximity for Minecraft Forge 1.8.9](https://github.com/Siriusmart/DiscordProximity).

Unless your game has a Discord linking feature, you might want a **nameserver** to map Discord IDs to in-game names in your implementaiton.

For the Forge mod, I used [this single-source-file nameserver](https://github.com/Siriusmart/proximity-nameserver) and a [Discord bot](https://github.com/siriusmart/merlin) to allow users to set their IGN.
