### PR TITLE
feat: Add visual indicators to distinguish Vencord and Equicord plugins

### DIFF
--- a/src/components/settings/AddonCard.tsx
+++ b/src/components/settings/AddonCard.tsx
@@ -35,6 +35,7 @@ interface Props {
     setEnabled: (enabled: boolean) => void;
     disabled?: boolean;
     isNew?: boolean;
+    sourceBadge?: ReactNode;
     onMouseEnter?: MouseEventHandler<HTMLDivElement>;
     onMouseLeave?: MouseEventHandler<HTMLDivElement>;
 
@@ -43,7 +44,7 @@ interface Props {
     author?: ReactNode;
 }
 
-export function AddonCard({ disabled, isNew, name, infoButton, footer, author, enabled, setEnabled, description, onMouseEnter, onMouseLeave }: Props) {
+export function AddonCard({ disabled, isNew, sourceBadge, name, infoButton, footer, author, enabled, setEnabled, description, onMouseEnter, onMouseLeave }: Props) {
     const titleRef = useRef<HTMLDivElement>(null);
     const titleContainerRef = useRef<HTMLDivElement>(null);
     const { truncated, containerRef } = useTruncatedText(description ? description.toString() : "");
@@ -72,6 +73,7 @@ export function AddonCard({ disabled, isNew, name, infoButton, footer, author, e
                                 {name}
                             </div>
                         </div>
+                        {sourceBadge}
                         {isNew && <AddonBadge text="NEW" color="#ED4245" />}
                     </Text>
 

--- a/src/components/settings/tabs/plugins/PluginCard.tsx
+++ b/src/components/settings/tabs/plugins/PluginCard.tsx
@@ -16,6 +16,8 @@ import { findByPropsLazy } from "@webpack";
 import { React, showToast, Toasts } from "@webpack/common";
 import { Settings } from "Vencord";
 
+import { PluginMeta } from "~plugins";
+
 import { openPluginModal } from "./PluginModal";
 
 const logger = new Logger("PluginCard");
@@ -35,6 +37,8 @@ interface PluginCardProps extends React.HTMLProps<HTMLDivElement> {
 
 export function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, onMouseLeave, isNew }: PluginCardProps) {
     const settings = Settings.plugins[plugin.name];
+    const pluginMeta = PluginMeta[plugin.name];
+    const isEquicordPlugin = pluginMeta?.folderName?.startsWith("src/equicordplugins/") ?? false;
 
     const isEnabled = () => isPluginEnabled(plugin.name);
 
@@ -88,9 +92,36 @@ export function PluginCard({ plugin, disabled, onRestartNeeded, onMouseEnter, on
         settings.enabled = !wasEnabled;
     }
 
+    const sourceBadge = isEquicordPlugin ? (
+        <img
+            src="https://equicord.org/assets/favicon.png"
+            alt="Equicord"
+            title="Equicord Plugin"
+            style={{
+                width: "20px",
+                height: "20px",
+                marginLeft: "8px",
+                borderRadius: "2px"
+            }}
+        />
+    ) : (
+        <img
+            src="https://vencord.dev/assets/favicon-dark.png"
+            alt="Vencord"
+            title="Vencord Plugin"
+            style={{
+                width: "20px",
+                height: "20px",
+                marginLeft: "8px",
+                borderRadius: "2px"
+            }}
+        />
+    );
+
     return (
         <AddonCard
             name={plugin.name}
+            sourceBadge={sourceBadge}
             description={plugin.description}
             isNew={isNew}
             enabled={isEnabled()}

--- a/src/components/settings/tabs/plugins/index.tsx
+++ b/src/components/settings/tabs/plugins/index.tsx
@@ -98,7 +98,9 @@ const enum SearchStatus {
     ALL,
     ENABLED,
     DISABLED,
-    NEW
+    NEW,
+    EQUICORD,
+    VENCORD
 }
 
 function ExcludedPluginsList({ search }: { search: string; }) {
@@ -187,9 +189,14 @@ export default function PluginSettings() {
     const pluginFilter = (plugin: typeof Plugins[keyof typeof Plugins]) => {
         const { status } = searchValue;
         const enabled = Vencord.Plugins.isPluginEnabled(plugin.name);
+        const pluginMeta = PluginMeta[plugin.name];
+        const isEquicordPlugin = pluginMeta?.folderName?.startsWith("src/equicordplugins/") ?? false;
+
         if (enabled && status === SearchStatus.DISABLED) return false;
         if (!enabled && status === SearchStatus.ENABLED) return false;
         if (status === SearchStatus.NEW && !newPlugins?.includes(plugin.name)) return false;
+        if (status === SearchStatus.EQUICORD && !isEquicordPlugin) return false;
+        if (status === SearchStatus.VENCORD && isEquicordPlugin) return false;
         if (!search.length) return true;
 
         return (
@@ -362,7 +369,9 @@ export default function PluginSettings() {
                             { label: "Show All", value: SearchStatus.ALL, default: true },
                             { label: "Show Enabled", value: SearchStatus.ENABLED },
                             { label: "Show Disabled", value: SearchStatus.DISABLED },
-                            { label: "Show New", value: SearchStatus.NEW }
+                            { label: "Show New", value: SearchStatus.NEW },
+                            { label: "Show Equicord", value: SearchStatus.EQUICORD },
+                            { label: "Show Vencord", value: SearchStatus.VENCORD }
                         ]}
                         serialize={String}
                         select={onStatusChange}


### PR DESCRIPTION
1. add icons to plugin cards to visually distinguish between vencord and equicord plugins
2. add filter options to show only vencord and or equicord plugins