### PR TITLE
adds vimMotions plugin

### DIFF
--- a/src/equicordplugins/vimMotions/README.md
+++ b/src/equicordplugins/vimMotions/README.md
@@ -1,0 +1,37 @@
+# VimMotions
+
+a plugin that brings **Vim-style motions** to Discord.
+switch between *Insert* and *Normal* modes, and control chat scrolling using Vim keybinds.
+
+---
+
+## ✨ Features
+
+- `Esc` → switch to **Normal mode**
+- `i` → switch back to **Insert mode**
+- `j` → scroll **down**
+- `k` → scroll **up**
+- `0` → scroll to **top**
+- `$` → scroll to **bottom**
+
+status bar shows the current mode:
+- **-- NORMAL --** (in red)
+- **-- INSERT --** (in green)
+
+---
+
+## 📷 Preview
+
+![Preview 1](https://cdn.discordapp.com/attachments/1418462424629252136/1418462437275078738/image.png?ex=68ce3596&is=68cce416&hm=0623c92e4f7d45af5a6f4d3f365f3b61fb4cf4624b02b7171f27913376f9d0e3&)
+![Preview 2](https://cdn.discordapp.com/attachments/1418462424629252136/1418462536075968512/image.png?ex=68ce35ae&is=68cce42e&hm=1c9d925fabf8c31f800880ea87c67ceee6279c73d1e4399783c9565d4418793c&)
+
+---
+
+## 🛠️ Authors
+- [@aouad](https://github.com/agorismo) (Discord ID: `186553138721980416`)
+
+---
+
+## ⚠️ Notes
+- works on **Discord Stable**, **PTB** and **Canary**.
+- if no header (`toolbar`/`titleBar`) is found, status bar falls back to a small fixed element in the top-left.

--- a/src/equicordplugins/vimMotions/index.ts
+++ b/src/equicordplugins/vimMotions/index.ts
@@ -1,0 +1,108 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 aouad
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import definePlugin from "@utils/types";
+import { Devs } from "@utils/constants";
+
+export default definePlugin({
+    name: "VimMotions",
+    description: "Adds vim-style motions.",
+    authors: [Devs.auoad],
+    patches: [],
+
+    start() {
+        document.addEventListener("keydown", handleKey, { capture: true });
+        createStatusBar();
+    },
+
+    stop() {
+        document.removeEventListener("keydown", handleKey, { capture: true });
+        removeStatusBar();
+    }
+});
+
+let mode: "normal" | "insert" = "insert";
+let statusEl: HTMLDivElement | null = null;
+
+function setMode(newMode: "normal" | "insert") {
+    mode = newMode;
+    if (statusEl) {
+        statusEl.innerText = newMode === "normal" ? "-- NORMAL --" : "-- INSERT --";
+        statusEl.style.color = newMode === "normal" ? "red" : "green";
+    }
+}
+
+function createStatusBar() {
+    if (statusEl) return;
+
+    const el = document.createElement("div");
+    el.style.marginLeft = "12px";
+    el.style.fontFamily = "monospace";
+    el.style.fontSize = "14px";
+    el.style.fontWeight = "bold";
+    el.style.color = "green";
+    el.innerText = "-- INSERT --";
+
+    const toolbar = document.querySelector('div[class*="toolbar"]');
+    if (toolbar) {
+        toolbar.prepend(el);
+    } else {
+        el.style.position = "fixed";
+        el.style.top = "10px";
+        el.style.left = "60px";
+        document.body.appendChild(el);
+    }
+
+    statusEl = el;
+}
+
+function removeStatusBar() {
+    statusEl?.remove();
+    statusEl = null;
+}
+
+function getChatScroller(): HTMLElement | null {
+    const inner = document.querySelector('[data-list-id="chat-messages"]');
+    if (!inner) return null;
+    return inner.closest("div[class*='scrollerBase']") as HTMLElement;
+}
+
+function handleKey(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+        setMode("normal");
+        e.preventDefault();
+        return;
+    }
+    if (mode === "normal" && e.key === "i") {
+        setMode("insert");
+        e.preventDefault();
+        return;
+    }
+
+    if (mode !== "normal") return;
+
+    const scroller = getChatScroller();
+    if (!scroller) return;
+
+    switch (e.key) {
+        case "j":
+            scroller.scrollTop += 40;
+            e.preventDefault();
+            break;
+        case "k":
+            scroller.scrollTop -= 40;
+            e.preventDefault();
+            break;
+        case "0":
+            scroller.scrollTop = 0;
+            e.preventDefault();
+            break;
+        case "$":
+            scroller.scrollTop = scroller.scrollHeight;
+            e.preventDefault();
+            break;
+    }
+}


### PR DESCRIPTION
## ✨ Summary
it introduces *Insert* and *Normal* modes, and allows scrolling in chat using Vim keybinds.  

## 🔑 Keybinds
- `Esc` → switch to **Normal mode**
- `i` → switch back to **Insert mode**
- `j` → scroll **down**
- `k` → scroll **up**
- `0` → scroll **to top**
- `$` → scroll **to bottom**

## 📷 Preview
![1](https://cdn.discordapp.com/attachments/1418462424629252136/1418462437275078738/image.png?ex=68ce3596&is=68cce416&hm=0623c92e4f7d45af5a6f4d3f365f3b61fb4cf4624b02b7171f27913376f9d0e3&)  
![2](https://cdn.discordapp.com/attachments/1418462424629252136/1418462536075968512/image.png?ex=68ce35ae&is=68cce42e&hm=1c9d925fabf8c31f800880ea87c67ceee6279c73d1e4399783c9565d4418793c&)  

## 🛠️ Notes
- works on **Discord Stable**, **PTB** and **Canary**.
- if no header (`toolbar`/`titleBar`) is found, the status bar falls back to the top-left corner.
