### PR TITLE
NoBlockedMessages & TypingIndicator: Allow AutoMod & Allow Hiding Ignored Typing

### DIFF
--- a/src/plugins/typingIndicator/index.tsx
+++ b/src/plugins/typingIndicator/index.tsx
@@ -68,7 +68,7 @@ function TypingIndicator({ channelId, guildId }: { channelId: string; guildId: s
     const myId = UserStore.getCurrentUser()?.id;
 
     const typingUsersArray = Object.keys(typingUsers).filter(id =>
-        id !== myId && !(RelationshipStore.isBlocked(id) && !settings.store.includeBlockedUsers)
+        id !== myId && !(RelationshipStore.isBlocked(id) && !settings.store.includeBlockedUsers) && !(RelationshipStore.isIgnored(id) && !settings.store.includeIgnoredUsers)
     );
     const [a, b, c] = typingUsersArray;
     let tooltipText: string;
@@ -145,6 +145,11 @@ const settings = definePluginSettings({
         description: "Whether to show the typing indicator for muted channels.",
         default: false
     },
+    includeIgnoredUsers: {
+        type: OptionType.BOOLEAN,
+        description: "Whether to show the typing indicator for ignored users.",
+        default: false
+    },
     includeBlockedUsers: {
         type: OptionType.BOOLEAN,
         description: "Whether to show the typing indicator for blocked users.",
@@ -168,17 +173,16 @@ export default definePlugin({
     settings,
 
     patches: [
-        // Normal channel
         {
+            // Normal channel.
             find: "UNREAD_IMPORTANT:",
             replacement: {
                 match: /\.Children\.count.+?:null(?<=,channel:(\i).+?)/,
                 replace: "$&,$self.TypingIndicator($1.id,$1.getGuildId())"
             }
         },
-        // Theads
         {
-            // This is the thread "spine" that shows in the left
+            // Thread "spine" that shows in the left.
             find: "M0 15H2c0 1.6569",
             replacement: {
                 match: /mentionsCount:\i.+?null(?<=channel:(\i).+?)/,


### PR DESCRIPTION
Adds a default `true` setting to allow AutoMod through NoBlockedMessages & adds a default `false` option to TypingIndicator to allow typing from ignored users to cause the indicator to show up.

Also fixes the divider filter in NoBlockedMessages to also filter date dividers and any other type.