### PR TITLE
NoBlockedMessages: Fix thread crash loop and fix base Discord thread starter oversight.

### DIFF
--- a/src/plugins/noBlockedMessages/index.ts
+++ b/src/plugins/noBlockedMessages/index.ts
@@ -206,7 +206,9 @@ export default definePlugin({
                 shouldKeep && newChannelStream.push({ ...item, content: filteredContent });
             } else {
                 const isMessage = ["MESSAGE", "THREAD_STARTER_MESSAGE"].includes(item.type);
-                const shouldKeep = !isMessage || this.shouldKeepMessage(item.content)[0];
+                const isThreadStarter = item.type === "THREAD_STARTER_MESSAGE";
+                const message = (isMessage && (isThreadStarter ? actualStarterMessage : item.content)) || null;
+                const shouldKeep = !isMessage || this.shouldKeepMessage(message)[0];
                 shouldKeep && newChannelStream.push(item);
             }
         });

--- a/src/plugins/noBlockedMessages/index.ts
+++ b/src/plugins/noBlockedMessages/index.ts
@@ -172,8 +172,9 @@ export default definePlugin({
         channelStream.forEach(item => {
             const isBlockedGroup = item.type === "MESSAGE_GROUP_BLOCKED";
             const isIgnoredGroup = item.type === "MESSAGE_GROUP_IGNORED";
+            const isThreadStarter = item.type === "THREAD_STARTER_MESSAGE";
             const hasThreadStarter = (isBlockedGroup || isIgnoredGroup) && item.content?.[0]?.type === "THREAD_STARTER_MESSAGE";
-            const threadCreatorMessage = (hasThreadStarter && (item.content?.[0]?.content as Message)) || null;
+            const threadCreatorMessage = (isThreadStarter && (item.content as Message)) || (hasThreadStarter && (item.content?.[0]?.content as Message)) || null;
             const actualStarterMessage = (threadCreatorMessage?.messageReference && ReferencedMessageStore.getMessageByReference(threadCreatorMessage.messageReference)?.message) || null;
             let skipStarter = false;
 
@@ -206,7 +207,6 @@ export default definePlugin({
                 shouldKeep && newChannelStream.push({ ...item, content: filteredContent });
             } else {
                 const isMessage = ["MESSAGE", "THREAD_STARTER_MESSAGE"].includes(item.type);
-                const isThreadStarter = item.type === "THREAD_STARTER_MESSAGE";
                 const message = (isMessage && (isThreadStarter ? actualStarterMessage : item.content)) || null;
                 const shouldKeep = !isMessage || this.shouldKeepMessage(message)[0];
                 shouldKeep && newChannelStream.push(item);

--- a/src/plugins/quickReply/index.ts
+++ b/src/plugins/quickReply/index.ts
@@ -141,7 +141,7 @@ function getNextMessage(isUp: boolean, isReply: boolean) {
         if (!isReply && m.author.id !== meId) return false; // editing only own messages
         if (!MessageTypeSets.REPLYABLE.has(m.type) || m.hasFlag(MessageFlags.EPHEMERAL)) return false;
         if (settings.store.ignoreBlockedAndIgnored && RelationshipStore.isBlockedOrIgnored(m.author.id)) return false;
-        if (hasNoBlockedMessages && NoBlockedMessagesPlugin.isBlocked(m)) return false;
+        if (hasNoBlockedMessages && NoBlockedMessagesPlugin.isNegative(m)) return false;
 
         return true;
     });

--- a/src/plugins/quickReply/index.ts
+++ b/src/plugins/quickReply/index.ts
@@ -141,7 +141,7 @@ function getNextMessage(isUp: boolean, isReply: boolean) {
         if (!isReply && m.author.id !== meId) return false; // editing only own messages
         if (!MessageTypeSets.REPLYABLE.has(m.type) || m.hasFlag(MessageFlags.EPHEMERAL)) return false;
         if (settings.store.ignoreBlockedAndIgnored && RelationshipStore.isBlockedOrIgnored(m.author.id)) return false;
-        if (hasNoBlockedMessages && NoBlockedMessagesPlugin.isNegative(m)) return false;
+        if (hasNoBlockedMessages && NoBlockedMessagesPlugin.isSuppressed(m)) return false;
 
         return true;
     });


### PR DESCRIPTION
Fixed an issue where not defining the specific settings in `settings.use()` caused an infinite render recursion specifically when expanding a collapsed ignored/blocked message group containing a thread starter message. Still not sure why the settings need to be defined, but whatever.

Also added functionality to extract the thread starter message from the ignored/blocked group and insert it into the channel stream on its own if the thread starter message author is not ignored/blocked but the thread starter is. This is because Discord attributes the thread starter message to the thread starter even if it's another user's message.