### PR TITLE
[Feat] jellyfinRichPresence: Enabled Ability to Use Series Cover

### DIFF
--- a/src/equicordplugins/jellyfinRichPresence/index.tsx
+++ b/src/equicordplugins/jellyfinRichPresence/index.tsx
@@ -80,6 +80,14 @@ const settings = definePluginSettings({
             { label: "Custom", value: "custom" },
         ],
     },
+    coverType: {
+        description: "Choose which cover to display when watching a TV show",
+        type: OptionType.SELECT,
+        options: [
+            { label: "Series Cover", value: "series", default: true },
+            { label: "Episode Cover", value: "episode" },
+        ],
+    },
     customName: {
         description: "Custom Rich Presence name (only used if 'Custom' is selected).\nOptions: {name}, {series}, {season}, {episode}, {artist}, {album}, {year}",
         type: OptionType.STRING,
@@ -137,7 +145,7 @@ function setActivity(activity: Activity | null) {
 export default definePlugin({
     name: "JellyfinRichPresence",
     description: "Rich presence for Jellyfin media server",
-    authors: [EquicordDevs.vmohammad, Devs.SerStars],
+    authors: [EquicordDevs.vmohammad, Devs.SerStars, Devs.ZcraftElite],
 
     settingsAboutComponent: () => (
         <>
@@ -203,7 +211,13 @@ export default definePlugin({
             if (playState?.IsPaused) return null;
 
             const imageUrl = item.ImageTags?.Primary
-                ? `${baseUrl}/Items/${item.Id}/Images/Primary`
+                ? `${baseUrl}/Items/${
+                    item.Type === "Episode" &&
+                    item.SeriesId &&
+                    settings.store.coverType === "series"
+                        ? item.SeriesId
+                        : item.Id
+                }/Images/Primary`
                 : undefined;
 
             return {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -64,6 +64,10 @@ export interface Dev {
  * If you are fine with attribution but don't want the badge, add badge: false
  */
 export const Devs = /* #__PURE__*/ Object.freeze({
+    ZcraftElite: {
+        name: "ZcraftElite",
+        id: 926788037785047050n
+    },
     Ven: {
         name: "V",
         id: 343383572805058560n


### PR DESCRIPTION
## Changes in this Pull Request
* Enabled the ability for the user to use the series cover (which is more similar to the movie cover) instead of the episode cover when watching an episode.
* Added myself as a contributor to the plugin.