### PR TITLE
channelTabs: Allow Setting Tab Limit & Limit One Tab Per Server

### DIFF
--- a/src/equicordplugins/channelTabs/index.tsx
+++ b/src/equicordplugins/channelTabs/index.tsx
@@ -28,7 +28,7 @@ const contextMenuPatch: NavContextMenuPatchCallback = (children, props: { channe
             action={() => createTab({
                 guildId: channel.guild_id || "@me", // Normalize for DMs/Group Chats
                 channelId: channel.id
-            }, settings.store.openInNewTabAutoSwitch, messageId)}
+            }, settings.store.openInNewTabAutoSwitch, messageId, true, true)} // The true values are important for bypassing tab limits
         />
     );
 };

--- a/src/equicordplugins/channelTabs/util/constants.tsx
+++ b/src/equicordplugins/channelTabs/util/constants.tsx
@@ -201,7 +201,7 @@ export const settings = definePluginSettings({
     rapidNavigationThreshold: {
         type: OptionType.SLIDER,
         description: "Time window (in seconds) for rapid navigation. Within this time, new channels replace the current tab instead of creating new ones.",
-        markers: [1, 2, 3, 5, 10, 20, 30, 40, 50, 60], // Will not switch to makeRange because the steps are purposely irregular for visual clarity
+        markers: [1, 2, 3, 5, 10, 20, 30, 40, 50, 60],
         default: 3,
         stickToMarkers: false,
     },

--- a/src/equicordplugins/channelTabs/util/constants.tsx
+++ b/src/equicordplugins/channelTabs/util/constants.tsx
@@ -357,5 +357,13 @@ export const settings = definePluginSettings({
         description: "Open all newly created tabs in compact mode by default",
         default: false,
         restartNeeded: false
+    },
+    maxOpenTabs: {
+        type: OptionType.SLIDER,
+        description: "Maximum number of open tabs (0 = unlimited)",
+        markers: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20],
+        default: 0,
+        stickToMarkers: true,
+        restartNeeded: false
     }
 });

--- a/src/equicordplugins/channelTabs/util/constants.tsx
+++ b/src/equicordplugins/channelTabs/util/constants.tsx
@@ -358,6 +358,12 @@ export const settings = definePluginSettings({
         default: false,
         restartNeeded: false
     },
+    oneTabPerServer: {
+        type: OptionType.BOOLEAN,
+        description: "Limit to one tab per server, so opening a new channel in that server will use the existing tab.",
+        default: false,
+        restartNeeded: false
+    },
     maxOpenTabs: {
         type: OptionType.SLIDER,
         description: "Maximum number of open tabs (0 = unlimited)",

--- a/src/equicordplugins/channelTabs/util/constants.tsx
+++ b/src/equicordplugins/channelTabs/util/constants.tsx
@@ -8,7 +8,7 @@ import { definePluginSettings } from "@api/Settings";
 import { Heading } from "@components/Heading";
 import { Paragraph } from "@components/Paragraph";
 import { Logger } from "@utils/Logger";
-import { OptionType } from "@utils/types";
+import { makeRange, OptionType } from "@utils/types";
 import { SearchableSelect, useState } from "@webpack/common";
 import { JSX } from "react";
 
@@ -201,7 +201,7 @@ export const settings = definePluginSettings({
     rapidNavigationThreshold: {
         type: OptionType.SLIDER,
         description: "Time window (in seconds) for rapid navigation. Within this time, new channels replace the current tab instead of creating new ones.",
-        markers: [1, 2, 3, 5, 10, 20, 30, 40, 50, 60],
+        markers: [1, 2, 3, 5, 10, 20, 30, 40, 50, 60], // Will not switch to makeRange because the steps are purposely irregular for visual clarity
         default: 3,
         stickToMarkers: false,
     },
@@ -223,7 +223,7 @@ export const settings = definePluginSettings({
     hotkeyCount: {
         type: OptionType.SLIDER,
         description: "Number of tabs accessible via keyboard shortcuts",
-        markers: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+        markers: makeRange(1, 9, 1),
         default: 3,
         stickToMarkers: true,
     },
@@ -367,7 +367,7 @@ export const settings = definePluginSettings({
     maxOpenTabs: {
         type: OptionType.SLIDER,
         description: "Maximum number of open tabs (0 = unlimited)",
-        markers: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20],
+        markers: makeRange(0, 20, 1),
         default: 0,
         stickToMarkers: true,
         restartNeeded: false

--- a/src/equicordplugins/channelTabs/util/tabs.tsx
+++ b/src/equicordplugins/channelTabs/util/tabs.tsx
@@ -114,6 +114,26 @@ let clearGhostTabs = () => {
 };
 
 export function createTab(props: BasicChannelTabsProps | ChannelTabsProps, switchToTab?: boolean, messageId?: string, save = true) {
+    const maxTabs = settings.store.maxOpenTabs;
+    const isLimitEnabled = maxTabs > 0;
+    const wouldExceedLimit = isLimitEnabled && openTabs.length >= maxTabs;
+
+    if (wouldExceedLimit) {
+        const currentTab = openTabs.find(t => t.id === currentlyOpenTab);
+        if (currentTab) {
+            currentTab.channelId = props.channelId;
+            currentTab.guildId = props.guildId;
+            currentTab.messageId = messageId;
+            currentTab.compact = "compact" in props ? props.compact : settings.store.openNewTabsInCompactMode;
+            if (switchToTab) {
+                update(save);
+            } else {
+                moveToTab(currentTab.id);
+            }
+        }
+        return;
+    }
+
     const id = genId();
     openTabs.push({ ...props, id, messageId, compact: "compact" in props ? props.compact : settings.store.openNewTabsInCompactMode });
     if (switchToTab) moveToTab(id);

--- a/src/equicordplugins/channelTabs/util/tabs.tsx
+++ b/src/equicordplugins/channelTabs/util/tabs.tsx
@@ -114,6 +114,22 @@ let clearGhostTabs = () => {
 };
 
 export function createTab(props: BasicChannelTabsProps | ChannelTabsProps, switchToTab?: boolean, messageId?: string, save = true) {
+    // Important for the "One tab per server" feature, has to be before the maxOpenTabs check!
+    if (settings.store.oneTabPerServer && props.guildId && props.guildId !== "@me") {
+        const existingTab = openTabs.find(tab => tab.guildId === props.guildId);
+        if (existingTab) {
+            existingTab.channelId = props.channelId;
+            existingTab.messageId = messageId;
+            existingTab.compact = "compact" in props ? props.compact : settings.store.openNewTabsInCompactMode;
+            if (switchToTab) {
+                moveToTab(existingTab.id);
+            } else {
+                update(save);
+            }
+            return;
+        }
+    }
+
     const maxTabs = settings.store.maxOpenTabs;
     const isLimitEnabled = maxTabs > 0;
     const wouldExceedLimit = isLimitEnabled && openTabs.length >= maxTabs;

--- a/src/equicordplugins/channelTabs/util/tabs.tsx
+++ b/src/equicordplugins/channelTabs/util/tabs.tsx
@@ -113,9 +113,9 @@ let clearGhostTabs = () => {
     logger.warn("Clear ghost tab function not set");
 };
 
-export function createTab(props: BasicChannelTabsProps | ChannelTabsProps, switchToTab?: boolean, messageId?: string, save = true) {
+export function createTab(props: BasicChannelTabsProps | ChannelTabsProps, switchToTab?: boolean, messageId?: string, save = true, bypassOneTabPerServer = false) {
     // Important for the "One tab per server" feature, has to be before the maxOpenTabs check!
-    if (settings.store.oneTabPerServer && props.guildId && props.guildId !== "@me") {
+    if (!bypassOneTabPerServer && settings.store.oneTabPerServer && props.guildId && props.guildId !== "@me") {
         const existingTab = openTabs.find(tab => tab.guildId === props.guildId);
         if (existingTab) {
             existingTab.channelId = props.channelId;


### PR DESCRIPTION
## Changes in this PR
* Created a settings option to set a limit on tabs, so you don't overwhelm your computer by having millions of tabs open.
* Created a settings option that will limit servers to using one tab each, so quickly switching between channels you moderate won't create infinite tabs.