### PR TITLE
feat: allow auto streaming of camera devices

### DIFF
--- a/packages/discord-types/src/stores/MediaEngineStore.d.ts
+++ b/packages/discord-types/src/stores/MediaEngineStore.d.ts
@@ -1,10 +1,37 @@
 import { FluxStore } from "..";
 
 export class MediaEngineStore extends FluxStore {
-    isSelfMute(): boolean;
-    isSelfDeaf(): boolean;
+    isAdvancedVoiceActivitySupported(): boolean;
+    isAecDumpSupported(): boolean;
+    isAnyLocalVideoAutoDisabled(): boolean;
+    isAutomaticGainControlSupported(): boolean;
+    isDeaf(): boolean;
+    isEnableHardwareMuteNotice(): boolean;
+    isEnabled(): boolean;
+    isExperimentalEncodersSupported(): boolean;
+    isHardwareMute(): boolean;
+    isInputProfileCustom(): boolean;
+    isInteractionRequired(): boolean;
+    isLocalMute(): boolean;
     isLocalMute(userId): boolean;
+    isLocalVideoAutoDisabled(userId): boolean;
     isLocalVideoDisabled(userId): boolean;
+    isLocalVideoDisabled(): boolean;
+    isMediaFilterSettingLoading(): boolean;
+    isMute(): boolean;
+    isNativeAudioPermissionReady(): boolean;
+    isNoiseCancellationError(): boolean;
+    isNoiseCancellationSupported(): boolean;
+    isNoiseSuppressionSupported(): boolean;
+    isScreenSharing(): boolean;
+    isSelfDeaf(): boolean;
+    isSelfMute(): boolean;
+    isSelfMutedTemporarily(): boolean;
+    isSimulcastSupported(): boolean;
+    isSoundSharing(): boolean;
+    isSupported(): boolean;
+    isVideoAvailable(): boolean;
+    isVideoEnabled(): boolean;
 
     setAv1Enabled(AV1: boolean): void;
     setH265Enabled(H265: boolean): void;

--- a/src/equicordplugins/instantScreenshare/index.tsx
+++ b/src/equicordplugins/instantScreenshare/index.tsx
@@ -10,39 +10,86 @@ import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { VoiceState } from "@vencord/discord-types";
 import { findByCodeLazy } from "@webpack";
-import { ChannelStore, PermissionsBits, PermissionStore, SelectedChannelStore, UserStore } from "@webpack/common";
+import { ChannelStore, MediaEngineStore, PermissionsBits, PermissionStore, SelectedChannelStore, UserStore, VoiceActions } from "@webpack/common";
 
 import { getCurrentMedia, settings } from "./utils";
 
+
 const startStream = findByCodeLazy('type:"STREAM_START"');
 
+
 let hasStreamed;
+
 
 async function autoStartStream() {
     const selected = SelectedChannelStore.getVoiceChannelId();
     if (!selected) return;
     const channel = ChannelStore.getChannel(selected);
 
-    if (channel.type === 13 || !PermissionStore.can(PermissionsBits.STREAM, channel)) return;
+
+    // Skip stage channels (type 13)
+    if (channel.type === 13) return;
+
+
+    // For guild voice channels, check stream permissions
+    // For DM/Group DM calls (type 1, 3), no permission check needed
+    const isGuildChannel = channel.guild_id != null;
+    if (isGuildChannel && !PermissionStore.can(PermissionsBits.STREAM, channel)) return;
+
+
+    // Handle auto mute/deafen settings (only toggle if not already muted/deafened)
+    if (settings.store.autoDeafen && !MediaEngineStore.isSelfDeaf()) {
+        // Deafen also mutes you automatically
+        VoiceActions.toggleSelfDeaf();
+    } else if (settings.store.autoMute && !MediaEngineStore.isSelfMute()) {
+        // Only mute if not deafening (since deafen already mutes)
+        VoiceActions.toggleSelfMute();
+    }
+
 
     const streamMedia = await getCurrentMedia();
 
-    startStream(channel.guild_id, selected, {
-        "pid": null,
-        "sourceId": streamMedia.id,
-        "sourceName": streamMedia.name,
-        "audioSourceId": null,
-        "sound": true,
-        "previewDisabled": false
-    });
+
+    // Check if this is a video device (camera/capture card)
+    if (streamMedia.type === "video_device") {
+        // For video devices, Discord expects:
+        // 1. sourceId prefixed with "camera:"
+        // 2. sourceName without the emoji prefix
+        // 3. audioSourceId set to the device name (for audio from capture card)
+        const streamParams = {
+            "pid": null,
+            "sourceId": `camera:${streamMedia.id}`, // Add "camera:" prefix
+            "sourceName": streamMedia.name,
+            "audioSourceId": streamMedia.name, // Use device name for audio
+            "sound": true,
+            "previewDisabled": false
+        };
+
+
+        startStream(channel.guild_id ?? null, selected, streamParams);
+    } else {
+        // For desktop sources, use the original logic
+        startStream(channel.guild_id ?? null, selected, {
+            "pid": null,
+            "sourceId": streamMedia.id,
+            "sourceName": streamMedia.name,
+            "audioSourceId": null,
+            "sound": true,
+            "previewDisabled": false
+        });
+    }
 }
+
 
 export default definePlugin({
     name: "InstantScreenshare",
-    description: "Instantly screenshare when joining a voice channel",
-    authors: [Devs.HAHALOSAH, Devs.thororen],
+    description: "Instantly screenshare when joining a voice channel with support for desktop sources, windows, and video input devices (cameras, capture cards)",
+    authors: [Devs.HAHALOSAH, Devs.thororen, Devs.mart],
     getCurrentMedia,
     settings,
+
+
+
     settingsAboutComponent: () => (
         <>
             <HeadingSecondary>For Linux</HeadingSecondary>
@@ -50,6 +97,10 @@ export default definePlugin({
                 For Wayland it only pops up the screenshare select
                 <br />
                 For X11 it may or may not work :shrug:
+            </Paragraph>
+            <HeadingSecondary>Video Devices</HeadingSecondary>
+            <Paragraph>
+                Supports cameras and capture cards (like Elgato HD60X) when enabled in settings
             </Paragraph>
         </>
     ),
@@ -60,17 +111,21 @@ export default definePlugin({
                 const { userId, channelId } = state;
                 if (userId !== myId) continue;
 
+
                 if (channelId && !hasStreamed) {
                     hasStreamed = true;
                     await autoStartStream();
                 }
 
+
                 if (!channelId) {
                     hasStreamed = false;
                 }
+
 
                 break;
             }
         }
     },
 });
+

--- a/src/equicordplugins/instantScreenshare/index.tsx
+++ b/src/equicordplugins/instantScreenshare/index.tsx
@@ -66,9 +66,15 @@ export default definePlugin({
                 <br />
                 For X11 it may or may not work :shrug:
             </Paragraph>
+            <br />
             <HeadingSecondary>Video Devices</HeadingSecondary>
             <Paragraph>
                 Supports cameras and capture cards (like Elgato HD60X) when enabled in settings
+            </Paragraph>
+            <br />
+            <HeadingSecondary>Regarding Sound & Preview Settings</HeadingSecondary>
+            <Paragraph>
+                We use the settings set and used by discord to decide if stream preview and sound should be enabled or not
             </Paragraph>
         </>
     ),

--- a/src/equicordplugins/instantScreenshare/utils.tsx
+++ b/src/equicordplugins/instantScreenshare/utils.tsx
@@ -138,4 +138,3 @@ function SettingSection() {
         </section>
     );
 }
-

--- a/src/equicordplugins/instantScreenshare/utils.tsx
+++ b/src/equicordplugins/instantScreenshare/utils.tsx
@@ -19,7 +19,7 @@ interface PickerProps {
 
 const getDesktopSources = findByCodeLazy("desktop sources");
 const configModule = findByPropsLazy("getOutputVolume");
-
+const log = new Logger("InstantScreenShare");
 export const settings = definePluginSettings({
     streamMedia: {
         type: OptionType.COMPONENT,
@@ -56,12 +56,14 @@ export async function getCurrentMedia() {
             }));
             sources.push(...videoSources);
         } catch (e) {
-            new Logger("InstantScreenShare").warn("Failed to get video devices:", e);
+            new log.warn("Failed to get video devices:", e);
         }
     }
 
     const streamMedia = sources.find(screen => screen.id === settings.store.streamMedia);
     if (streamMedia) return streamMedia;
+
+    log.error(`Stream Media "${settings.store.streamMedia}" not found. Resetting to default.`);
 
     settings.store.streamMedia = sources[0];
     return sources[0];
@@ -108,7 +110,7 @@ function ScreenSetting() {
                     }));
                     sources.push(...videoSources);
                 } catch (e) {
-                    new Logger("InstantScreenShare").warn("Failed to get video devices:", e);
+                    log.warn("Failed to get video devices:", e);
                 }
             }
 

--- a/src/equicordplugins/instantScreenshare/utils.tsx
+++ b/src/equicordplugins/instantScreenshare/utils.tsx
@@ -44,10 +44,7 @@ export const settings = definePluginSettings({
 
 export async function getCurrentMedia() {
     const media = MediaEngineStore.getMediaEngine();
-    const sources = [
-        ...(await getDesktopSources(media, ["screen"], null) ?? []),
-        ...(await getDesktopSources(media, ["window", "application"], null) ?? []),
-    ];
+    const sources = await getDesktopSources(media, ["screen", "window"], null) ?? [];
 
     if (settings.store.includeVideoDevices) {
         try {
@@ -58,8 +55,8 @@ export async function getCurrentMedia() {
                 type: "video_device"
             }));
             sources.push(...videoSources);
-        } catch (error) {
-            new Logger("InstantScreenShare").warn("Failed to get video devices:", error);
+        } catch (e) {
+            new Logger("InstantScreenShare").warn("Failed to get video devices:", e);
         }
     }
 
@@ -99,10 +96,7 @@ function ScreenSetting() {
         let active = true;
         async function fetchMedia() {
             setLoading(true);
-            const sources = [
-                ...(await getDesktopSources(media, ["screen"], null) ?? []),
-                ...(await getDesktopSources(media, ["window", "application"], null) ?? []),
-            ];
+            const sources = await getDesktopSources(media, ["screen", "window"], null) ?? [];
 
             if (includeVideoDevices) {
                 try {
@@ -113,8 +107,8 @@ function ScreenSetting() {
                         type: "video_device"
                     }));
                     sources.push(...videoSources);
-                } catch (error) {
-                    new Logger("InstantScreenShare").warn("Failed to get video devices:", error);
+                } catch (e) {
+                    new Logger("InstantScreenShare").warn("Failed to get video devices:", e);
                 }
             }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -626,10 +626,6 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "thororen",
         id: 848339671629299742n
     },
-    mart: {
-        name: "mja00",
-        id: 108698087769260032n
-    }
 } satisfies Record<string, Dev>);
 
 export const EquicordDevs = Object.freeze({
@@ -1177,6 +1173,10 @@ export const EquicordDevs = Object.freeze({
     ZcraftElite: {
         name: "ZcraftElite",
         id: 926788037785047050n
+    },
+    mart: {
+        name: "mja00",
+        id: 108698087769260032n
     },
 } satisfies Record<string, Dev>);
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -626,6 +626,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "thororen",
         id: 848339671629299742n
     },
+    mart: {
+        name: "mja00",
+        id: 108698087769260032n
+    }
 } satisfies Record<string, Dev>);
 
 export const EquicordDevs = Object.freeze({


### PR DESCRIPTION
This PR improves on the existing InstantScreenshare plugin and allows users to optionally stream camera devices. The most common use case for this is most likely selecting capture cards to stream. 

It also allows the plugin to work in group chats and DM voice calls. 