### PR TITLE
add: CleanUserArea

### DIFF
--- a/src/equicordplugins/cleanUserArea/index.ts
+++ b/src/equicordplugins/cleanUserArea/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "CleanUserArea",
+    description: "Hide nameplate in the user area",
+    authors: [EquicordDevs.Prism],
+    patches: [
+        {
+            find: "#{intl::ACCOUNT_SPEAKING_WHILE_MUTED}",
+            replacement: {
+                match: /nameplate:(\i),hovered/,
+                replace: "nameplate:$self.hideNameplate($1),hovered",
+            },
+        },
+    ],
+
+    hideNameplate() {
+        return null;
+    },
+});

--- a/src/equicordplugins/cleanUserArea/index.ts
+++ b/src/equicordplugins/cleanUserArea/index.ts
@@ -15,13 +15,9 @@ export default definePlugin({
         {
             find: "#{intl::ACCOUNT_SPEAKING_WHILE_MUTED}",
             replacement: {
-                match: /nameplate:(\i),hovered/,
-                replace: "nameplate:$self.hideNameplate($1),hovered",
+                match: /nameplate:\i,hovered/,
+                replace: "nameplate:null,hovered",
             },
         },
     ],
-
-    hideNameplate() {
-        return null;
-    },
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1182,6 +1182,10 @@ export const EquicordDevs = Object.freeze({
         name: "Vei",
         id: 239414094799699968n
     },
+    Prism: {
+        name: "Prism",
+        id: 390884143749136386n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
disables the nameplate in the user area so its cleaner for ur eyes and doesnt annoy u anymore

**Before:**
<img width="377" height="72" alt="Discord_Qq83ioD6iA" src="https://github.com/user-attachments/assets/293401c9-4e42-4bd3-bf69-fe447126fb6e" />

**After:**
<img width="373" height="68" alt="Discord_7848SPgX3R" src="https://github.com/user-attachments/assets/1cc30314-7122-4aca-91f9-28d0bf4dad30" />

the main idea is that it allows you to disable the nameplate in the user area while keeping nameplates enabled elsewhere. if you dont want to turn it off completely but prefer not to see it there
