### PR TITLE
channelTabs: Introduce Compat for Future/Experimental Pages

### DIFF
--- a/src/equicordplugins/channelTabs/components/ChannelTab.tsx
+++ b/src/equicordplugins/channelTabs/components/ChannelTab.tsx
@@ -15,7 +15,7 @@ import { Avatar, ChannelStore, ContextMenuApi, GuildStore, PresenceStore, ReadSt
 import { JSX } from "react";
 
 import { ChannelTabsProps, closeTab, isTabSelected, moveDraggedTabs, moveToTab, openedTabs, settings } from "../util";
-import { CircleQuestionIcon, DiscoveryIcon, EnvelopeIcon, FriendsIcon, NitroIcon, QuestIcon, ShopIcon } from "../util/icons";
+import { ActivityIcon, CircleQuestionIcon, DiscoveryIcon, EnvelopeIcon, FriendsIcon, ICYMIIcon, NitroIcon, QuestIcon, ShopIcon } from "../util/icons";
 import { TabContextMenu } from "./ContextMenus";
 
 const ThreeDots = findComponentByCodeLazy(".dots,", "dotRadius:");
@@ -204,7 +204,9 @@ function ChannelTabContent(props: ChannelTabsProps & {
             "__shop__": { label: "Shop", Icon: ShopIcon },
             "__library__": { label: "Library", Icon: () => LibraryIcon(20, 20) },
             "__discovery__": { label: "Discovery", Icon: DiscoveryIcon },
-            "__nitro__": { label: "Nitro", Icon: NitroIcon }
+            "__nitro__": { label: "Nitro", Icon: NitroIcon },
+            "__icymi__": { label: "ICYMI", Icon: ICYMIIcon },
+            "__activity__": { label: "Activity", Icon: ActivityIcon },
         };
 
         const pageConfig = specialPagesConfig[channelId];

--- a/src/equicordplugins/channelTabs/index.tsx
+++ b/src/equicordplugins/channelTabs/index.tsx
@@ -122,6 +122,9 @@ export default definePlugin({
                 } else if (path === "/channels/@me") {
                     channelId = "__friends__";
                     guildId = "@me";
+                } else if (path === "/channels/@me/activity") {
+                    channelId = "__activity__";
+                    guildId = "@me";
                 } else if (path.includes("/shop")) {
                     channelId = "__shop__";
                     guildId = "@me";
@@ -133,6 +136,9 @@ export default definePlugin({
                     guildId = "@me";
                 } else if (path.includes("/store")) {
                     channelId = "__nitro__";
+                    guildId = "@me";
+                } else if (path.includes("/icymi")) {
+                    channelId = "__icymi__";
                     guildId = "@me";
                 } else {
                     // Unknown page without channelId - ignore

--- a/src/equicordplugins/channelTabs/util/bookmarks.ts
+++ b/src/equicordplugins/channelTabs/util/bookmarks.ts
@@ -29,7 +29,9 @@ export function bookmarkPlaceholderName(bookmark: Omit<Bookmark | BookmarkFolder
             "__shop__": "Shop",
             "__library__": "Library",
             "__discovery__": "Discovery",
-            "__nitro__": "Nitro"
+            "__nitro__": "Nitro",
+            "__icymi__": "ICYMI",
+            "__activity__": "Activity",
         };
 
         return specialPagesMap[channelId] || "Special Page";

--- a/src/equicordplugins/channelTabs/util/icons.ts
+++ b/src/equicordplugins/channelTabs/util/icons.ts
@@ -13,4 +13,6 @@ export const EnvelopeIcon = findComponentByCodeLazy("M1.16 5.02c-.1.28");
 export const DiscoveryIcon = findComponentByCodeLazy("M7.74 9.3A2 2 0 0 1 9.3 7.75l7.22");
 export const NitroIcon = findComponentByCodeLazy("M16.23 12c0 1.29-.95 2.25");
 export const FriendsIcon = findComponentByCodeLazy("12h1a8");
+export const ICYMIIcon = findComponentByCodeLazy("0-.66-1.75h-4.81a");
+export const ActivityIcon = findComponentByCodeLazy("17.3 9 16.8 9 15.92V8.1Z");
 export const CircleQuestionIcon = findComponentByCodeLazy("10.58l-3.3-3.3a1");

--- a/src/equicordplugins/channelTabs/util/tabs.tsx
+++ b/src/equicordplugins/channelTabs/util/tabs.tsx
@@ -372,7 +372,9 @@ export function moveToTab(id: number) {
             "__shop__": "/shop",
             "__library__": "/library",
             "__discovery__": "/discovery",
-            "__nitro__": "/store"
+            "__nitro__": "/store",
+            "__icymi__": "/icymi",
+            "__activity__": "/channels/@me/activity",
         };
 
         const route = routeMap[tab.channelId];
@@ -500,7 +502,9 @@ export function navigateToBookmark(ch: BasicChannelTabsProps) {
                 "__shop__": "/shop",
                 "__library__": "/library",
                 "__discovery__": "/discovery",
-                "__nitro__": "/store"
+                "__nitro__": "/store",
+                "__icymi__": "/icymi",
+                "__activity__": "/channels/@me/activity",
             };
 
             const route = routeMap[ch.channelId];


### PR DESCRIPTION
## Changes in this PR
* Added compatibility for some experimental pages that may rollout to stable in the future:
    * ICYMI Desktop (2025-10_icymi_desktop_client)
    * Activity Standalone Page (2025-10_desktop_land_and_learn)