### PR TITLE
fix(img2gif): keep original aspect ratio and filename

### DIFF
--- a/src/equicordplugins/imgToGif/index.tsx
+++ b/src/equicordplugins/imgToGif/index.tsx
@@ -78,7 +78,7 @@ async function resolveImage(options: CommandArgument[], ctx: CommandContext): Pr
 export default definePlugin({
     name: "ImgToGif",
     description: "Adds a /imgtogif slash command to create a gif from any image",
-    authors: [EquicordDevs.zyqunix],
+    authors: [EquicordDevs.zyqunix, EquicordDevs.neoarz],
     commands: [
         {
             inputType: ApplicationCommandInputType.BUILT_IN,
@@ -108,8 +108,22 @@ export default definePlugin({
 
                     const avatar = await loadImage(image);
 
-                    const gifHeight = height ?? DEFAULT_RESOLUTION;
-                    const gifWidth = width ?? DEFAULT_RESOLUTION;
+                    let gifWidth: number;
+                    let gifHeight: number;
+
+                    if (width && height) {
+                        gifWidth = width;
+                        gifHeight = height;
+                    } else if (width) {
+                        gifWidth = width;
+                        gifHeight = Math.round((avatar.height / avatar.width) * width);
+                    } else if (height) {
+                        gifHeight = height;
+                        gifWidth = Math.round((avatar.width / avatar.height) * height);
+                    } else {
+                        gifWidth = avatar.width;
+                        gifHeight = avatar.height;
+                    }
 
                     const gif = GIFEncoder();
                     const canvas = document.createElement("canvas");
@@ -134,7 +148,8 @@ export default definePlugin({
                     }
 
                     gif.finish();
-                    const file = new File([gif.bytesView()], "converted.gif", { type: "image/gif" });
+                    const originalName = image.name ? image.name.replace(/\.[^/.]+$/, "") : "converted";
+                    const file = new File([new Uint8Array(gif.bytesView())], `${originalName}.gif`, { type: "image/gif" });
                     setTimeout(() => UploadHandler.promptToUpload([file], cmdCtx.channel, DraftType.ChannelMessage), 10);
                 } catch (err) {
                     UploadManager.clearAll(cmdCtx.channel.id, DraftType.SlashCommand);

--- a/src/equicordplugins/imgToGif/index.tsx
+++ b/src/equicordplugins/imgToGif/index.tsx
@@ -78,7 +78,7 @@ async function resolveImage(options: CommandArgument[], ctx: CommandContext): Pr
 export default definePlugin({
     name: "ImgToGif",
     description: "Adds a /imgtogif slash command to create a gif from any image",
-    authors: [EquicordDevs.zyqunix, EquicordDevs.neoarz],
+    authors: [EquicordDevs.zyqunix],
     commands: [
         {
             inputType: ApplicationCommandInputType.BUILT_IN,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1189,10 +1189,6 @@ export const EquicordDevs = Object.freeze({
     square: {
         name: "square",
         id: 219363409097916416n
-    },
-    neoarz: {
-        name: "neoarz",
-        id: 1015372540937502851n
     }
 } satisfies Record<string, Dev>);
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1189,6 +1189,10 @@ export const EquicordDevs = Object.freeze({
     square: {
         name: "square",
         id: 219363409097916416n
+    },
+    neoarz: {
+        name: "neoarz",
+        id: 1015372540937502851n
     }
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
first time contributing, let me know if there is any way i can make this better!!!

here is an example of the before and after:

# Before 
<img width="1064" height="910" alt="CleanShot 2025-11-08 at 00 27 05@2x" src="https://github.com/user-attachments/assets/f595d61d-2727-410a-8485-bb3b8de563fb" />




# After 
<img width="1268" height="296" alt="CleanShot 2025-11-08 at 00 28 27@2x" src="https://github.com/user-attachments/assets/8cb8f2da-808d-4fe2-8d71-1acbd97c7f2e" />
