### PR TITLE
Hide blocked users in Active Now, VC, and server tooltips

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -64,6 +64,10 @@ export interface Dev {
  * If you are fine with attribution but don't want the badge, add badge: false
  */
 export const Devs = /* #__PURE__*/ Object.freeze({
+    KamiRu:{
+        id: 819191621676695563n,
+        name: "KamiRu"
+    },
     Ven: {
         name: "V",
         id: 343383572805058560n


### PR DESCRIPTION
Extend ClientSideBlock to hide blocked users in more places
### before
<img width="422" height="377" alt="1" src="https://github.com/user-attachments/assets/c4a6208a-ec24-46b5-846f-081be6d520ae" />
<img width="288" height="275" alt="2" src="https://github.com/user-attachments/assets/8170796e-a55b-46a9-87d2-efbe289ffc98" />
<img width="176" height="92" alt="3" src="https://github.com/user-attachments/assets/f29621ff-f1b1-42b8-9811-c2771600b2eb" />

###after
<img width="420" height="340" alt="1(fix)" src="https://github.com/user-attachments/assets/6abe7fe3-79c1-4ab4-beda-89c036c20153" />
<img width="300" height="195" alt="2(fix)" src="https://github.com/user-attachments/assets/11d1c4c3-ee0e-4508-b291-190ed02394d1" />
<img width="173" height="45" alt="3(fix)" src="https://github.com/user-attachments/assets/6bbbef49-2eb4-48af-9573-b90987c305a4" />
