### PR TITLE
 Add idle auto-restart plugin for Equicord/Equibop

### DIFF
--- a/src/equicordplugins/idleAutoRestart/index.ts
+++ b/src/equicordplugins/idleAutoRestart/index.ts
@@ -17,7 +17,7 @@
  */
 
 import { definePluginSettings } from "@api/Settings";
-import { Devs } from "@utils/constants";
+import { Devs, EquicordDevs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 
 const settings = definePluginSettings({
@@ -88,7 +88,7 @@ export default definePlugin({
     name: "IdleAutoRestart",
     description:
         "Automatically restarts the client after being idle for a configurable amount of time.",
-    authors: [Devs.Ven],
+    authors: [EquicordDevs.SteelTech],
     settings,
 
     start() {

--- a/src/equicordplugins/idleAutoRestart/index.ts
+++ b/src/equicordplugins/idleAutoRestart/index.ts
@@ -42,9 +42,8 @@ export default definePlugin({
     name: "IdleAutoRestart",
     description:
         "Automatically restarts the client after being idle for a configurable amount of time, but avoids restarting while you are in VC.",
-    authors: [EquicordDevs.SteelTech ?? Devs.Ven],
+    authors: [EquicordDevs.SteelTech],
     settings,
-
 
     start() {
         lastActivity = Date.now();

--- a/src/equicordplugins/idleAutoRestart/index.ts
+++ b/src/equicordplugins/idleAutoRestart/index.ts
@@ -8,7 +8,7 @@ import { definePluginSettings } from "@api/Settings";
 import { Devs, EquicordDevs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType } from "@utils/types";
-import { SelectedChannelStore, UserStore } from "@webpack/common";
+import { VoiceStateStore, UserStore } from "@webpack/common";
 
 const logger = new Logger("IdleAutoRestart");
 
@@ -34,14 +34,9 @@ function onActivity() {
     lastActivity = Date.now();
 }
 
-function isInVoice(): boolean {
-    return !!SelectedChannelStore.getVoiceChannelId();
-}
-
 export default definePlugin({
     name: "IdleAutoRestart",
-    description:
-        "Automatically restarts the client after being idle for a configurable amount of time, but avoids restarting while you are in VC.",
+    description: "Automatically restarts the client after being idle for a configurable amount of time, but avoids restarting while you are in VC.",
     authors: [EquicordDevs.SteelTech],
     settings,
 
@@ -57,7 +52,7 @@ export default definePlugin({
         intervalId = setInterval(() => {
             if (!settings.store.isEnabled) return;
 
-            if (isInVoice()) {
+            if (VoiceStateStore.isCurrentClientInVoiceChannel()) {
                 return;
             }
 

--- a/src/equicordplugins/idleAutoRestart/index.ts
+++ b/src/equicordplugins/idleAutoRestart/index.ts
@@ -1,0 +1,104 @@
+/*
+ * Vencord, a modification for Discord's desktop app
+ * Copyright (c) 2022 Vendicated and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { Devs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+
+const settings = definePluginSettings({
+    enabled: {
+        description: "Enable automatic restart after idle",
+        type: OptionType.BOOLEAN,
+        default: true,
+    },
+    idleMinutes: {
+        description: "Minutes of no input before restart",
+        type: OptionType.SLIDER,
+        markers: [5, 10, 15, 30, 60, 120],
+        default: 30,
+        stickToMarkers: false,
+    },
+});
+
+let lastActivity = Date.now();
+let intervalId: number | null = null;
+let listenersAttached = false;
+
+function updateActivity() {
+    lastActivity = Date.now();
+}
+
+function attachListeners() {
+    if (listenersAttached) return;
+    listenersAttached = true;
+
+    window.addEventListener("mousemove", updateActivity);
+    window.addEventListener("keydown", updateActivity);
+    window.addEventListener("mousedown", updateActivity);
+    window.addEventListener("wheel", updateActivity, { passive: true });
+}
+
+function detachListeners() {
+    if (!listenersAttached) return;
+    listenersAttached = false;
+
+    window.removeEventListener("mousemove", updateActivity);
+    window.removeEventListener("keydown", updateActivity);
+    window.removeEventListener("mousedown", updateActivity);
+    window.removeEventListener("wheel", updateActivity as any);
+}
+
+function startTimer() {
+    if (intervalId != null) return;
+
+    intervalId = window.setInterval(() => {
+        if (!settings.store.enabled) return;
+
+        const idleMs = settings.store.idleMinutes * 60 * 1000;
+        const sinceActivity = Date.now() - lastActivity;
+
+        if (sinceActivity >= idleMs) {
+            location.reload();
+        }
+    }, 30 * 1000);
+}
+
+function stopTimer() {
+    if (intervalId == null) return;
+    window.clearInterval(intervalId);
+    intervalId = null;
+}
+
+export default definePlugin({
+    name: "IdleAutoRestart",
+    description:
+        "Automatically restarts the client after being idle for a configurable amount of time.",
+    authors: [Devs.Ven],
+    settings,
+
+    start() {
+        lastActivity = Date.now();
+        attachListeners();
+        startTimer();
+    },
+
+    stop() {
+        stopTimer();
+        detachListeners();
+    },
+});

--- a/src/equicordplugins/idleAutoRestart/index.ts
+++ b/src/equicordplugins/idleAutoRestart/index.ts
@@ -13,7 +13,7 @@ import { SelectedChannelStore, UserStore } from "@webpack/common";
 const logger = new Logger("IdleAutoRestart");
 
 const settings = definePluginSettings({
-    enabled: {
+    isEnabled: {
         description: "Enable automatic restart after idle",
         type: OptionType.BOOLEAN,
         default: true,
@@ -55,7 +55,7 @@ export default definePlugin({
 
         if (intervalId) clearInterval(intervalId);
         intervalId = setInterval(() => {
-            if (!settings.store.enabled) return;
+            if (!settings.store.isEnabled) return;
 
             if (isInVoice()) {
                 return;


### PR DESCRIPTION
 Summary
- Adds a new Equicord plugin `IdleAutoRestart` that automatically restarts the client after a configurable period of user inactivity
- Exposes simple settings:
  - **Enable auto-restart** (boolean)
  - **Idle timeout** in minutes before triggering a restart (slider)
- Tracks basic user activity (mouse / keyboard / wheel) and reloads the client once the configured idle time is exceeded
---
 Motivation
After updating Equicord/Equibop users often keep the client open for long periods without restarting so new patches and settings aren’t applied until they manually reload. Request [Request Forum Discord](https://discord.com/channels/1173279886065029291/1448237680830840852)
This plugin solves that by:
- Watching for user inactivity
- Automatically restarting the client when the user has been idle longer than a configured threshold
- Letting users keep Discord open 24/7 but still benefit from updates in a timely way
---
 Implementation Details
- New plugin: `src/equicordplugins/idleAutoRestart/index.ts`
- Uses `definePluginSettings` to provide:
  - `enabled`: `boolean` - toggles the behavior on/off
  - `idleMinutes`: `number` - minutes of inactivity before restart
- Listens for:
  - `mousemove`
  - `keydown`
  - `mousedown`
  - `wheel`
- Keeps a `lastActivity` timestamp every 30 seconds:
  - Compares `Date.now() - lastActivity` against `idleMinutes * 60 * 1000`
  - If exceeded and enabled calls `location.reload()` to restart the client
---
 Usage
1. Enable the **IdleAutoRestart** plugin in the Equicord plugins tab
2. Configure:
   - **Minutes of no input before restart**
   - Toggle **Enable automatic restart after idle**
3. Leave the client running when you walk away for longer than the configured idle time the client will auto-restart and apply updates.