### PR TITLE
fix(serverListIndicators): edge case for "custom theme"

### DIFF
--- a/src/plugins/serverListIndicators/styles.css
+++ b/src/plugins/serverListIndicators/styles.css
@@ -20,6 +20,10 @@
     transition: border-radius 0.15s ease-out, background-color 0.15s ease-out;
 }
 
+.custom-theme-background #vc-indicators-indicator-items {
+    background-color: var(--background-mod-strong);
+}
+
 #vc-indicators-indicator-items::before {
     position: absolute;
     content: "";


### PR DESCRIPTION
When using discord's "Nitro Custom Themes", every other sidebar button uses a different palette by discord. 