### PR TITLE
feat: add OldSettings plugin

### DIFF
--- a/src/equicordplugins/oldSettings/index.ts
+++ b/src/equicordplugins/oldSettings/index.ts
@@ -1,0 +1,30 @@
+import { FluxDispatcher } from "@webpack/common";
+import definePlugin from "@utils/types";
+
+const EXPERIMENT_ID = "2025-09-user-settings-redesign-1";
+
+export default definePlugin({
+    name: "OldSettings",
+    description: "Restores the classic settings menu by disabling the 2025 redesign experiment.\nYou need to reopen the settings menu to see the changes.",
+    authors: [
+        {
+            name: "sankoofa",
+            id: 279448683672502274n
+        }
+    ],
+
+    start() {
+        FluxDispatcher.dispatch({
+            type: "APEX_EXPERIMENT_OVERRIDE_CREATE",
+            experimentName: EXPERIMENT_ID,
+            variantId: 0
+        });
+    },
+
+    stop() {
+        FluxDispatcher.dispatch({
+            type: "APEX_EXPERIMENT_OVERRIDE_DELETE",
+            experimentName: EXPERIMENT_ID
+        });
+    }
+});


### PR DESCRIPTION
basically restores the classic user settings menu by overriding the 2025 redesign experiment (`2025-09-user-settings-redesign-1`)
this was created in response to the request made here: [settings button](https://discord.com/channels/1173279886065029291/1455056594352996544)

