### PR TITLE
feat: fix and improve ghosted plugin

### DIFF
--- a/src/equicordplugins/ghosted/Boo.tsx
+++ b/src/equicordplugins/ghosted/Boo.tsx
@@ -5,7 +5,6 @@
  */
 
 import { Channel, Message } from "@vencord/discord-types";
-import { ChannelType } from "@vencord/discord-types/enums";
 import { findByPropsLazy } from "@webpack";
 import { MessageStore, useEffect, UserStore, useState, useStateFromStores } from "@webpack/common";
 
@@ -17,7 +16,7 @@ function isChannelExempted(channel: Channel): boolean {
         .split(",")
         .map(id => id.trim())
         .filter(id => id.length > 0);
-    const isGroupDmsExempted = settings.store.ignoreGroupDms && channel.type === ChannelType.GROUP_DM;
+    const isGroupDmsExempted = settings.store.ignoreGroupDms && channel.isGroupDM();
 
     return exemptList.includes(channel.id) || isGroupDmsExempted;
 }

--- a/src/equicordplugins/ghosted/Boo.tsx
+++ b/src/equicordplugins/ghosted/Boo.tsx
@@ -19,7 +19,7 @@ function isChannelExempted(channel: Channel): boolean {
         .filter(id => id.length > 0);
     const isGroupDmsExempted = settings.store.ignoreGroupDms && channel.type === ChannelType.GROUP_DM;
 
-    return exemptList.includes(channel.id);
+    return exemptList.includes(channel.id) || isGroupDmsExempted;
 }
 
 const countedChannels = new Set<string>();

--- a/src/equicordplugins/ghosted/Boo.tsx
+++ b/src/equicordplugins/ghosted/Boo.tsx
@@ -5,19 +5,21 @@
  */
 
 import { Channel, Message } from "@vencord/discord-types";
+import { ChannelType } from "@vencord/discord-types/enums";
 import { findByPropsLazy } from "@webpack";
 import { MessageStore, useEffect, UserStore, useState, useStateFromStores } from "@webpack/common";
 
 import { cl, settings } from ".";
 import { IconGhost } from "./IconGhost";
 
-function isChannelExempted(channelId: string): boolean {
+function isChannelExempted(channel: Channel): boolean {
     const exemptList = settings.store.exemptedChannels
         .split(",")
         .map(id => id.trim())
         .filter(id => id.length > 0);
+    const isGroupDmsExempted = settings.store.ignoreGroupDms && channel.type === ChannelType.GROUP_DM;
 
-    return exemptList.includes(channelId);
+    return exemptList.includes(channel.id);
 }
 
 const countedChannels = new Set<string>();
@@ -57,21 +59,23 @@ export function getGhostedChannels(): string[] {
 }
 
 export function clearChannelFromGhost(channelId: string): void {
-    if (countedChannels.has(channelId)) {
-        countedChannels.delete(channelId);
-        setBooCount(getBooCount() - 1);
-
-        // so we can detect new messages from the other person
-        const lastMessage = MessageStore.getMessages(channelId)?.last();
-        if (lastMessage) {
-            clearedChannels.set(channelId, lastMessage.id);
-        }
-
-        // notify all listeners that this channel was cleared
-        for (const listener of clearedChannelListeners) {
-            listener(channelId);
-        }
+    if (!countedChannels.has(channelId)) {
+        return;
     }
+    countedChannels.delete(channelId);
+    setBooCount(getBooCount() - 1);
+
+    // so we can detect new messages from the other person
+    const lastMessage = MessageStore.getMessages(channelId)?.last();
+    if (lastMessage) {
+        clearedChannels.set(channelId, lastMessage.id);
+    }
+
+    // notify all listeners that this channel was cleared
+    for (const listener of clearedChannelListeners) {
+        listener(channelId);
+    }
+
 }
 
 export function isChannelCleared(channelId: string): boolean {
@@ -126,7 +130,7 @@ export function Boo({ channel }: { channel: Channel; }) {
     useEffect(() => {
         if (!state.isDataProcessed) return;
 
-        const isExempted = isChannelExempted(id);
+        const isExempted = isChannelExempted(channel);
         let wasManuallyCleared = clearedChannels.has(id);
 
         // if manually cleared, check if there's a NEW message from the other person
@@ -186,7 +190,7 @@ export function Boo({ channel }: { channel: Channel; }) {
         }
     }, [state.isCurrentUser, state.isDataProcessed, id, lastMessage?.id]);
 
-    if (!state.isDataProcessed || !currentUserId || !lastMessage || state.isCurrentUser || isChannelExempted(id) || isCleared || (settings.store.ignoreBots && lastMessage.author.bot))
+    if (!state.isDataProcessed || !currentUserId || !lastMessage || state.isCurrentUser || isChannelExempted(channel) || isCleared || (settings.store.ignoreBots && lastMessage.author.bot))
         return null;
 
     if (!settings.store.showDmIcons) return null;

--- a/src/equicordplugins/ghosted/GhostedUsersModal.tsx
+++ b/src/equicordplugins/ghosted/GhostedUsersModal.tsx
@@ -7,7 +7,6 @@
 import { classNameFactory } from "@utils/css";
 import { ModalCloseButton, ModalContent, ModalHeader, ModalRoot, ModalSize } from "@utils/modal";
 import { Channel, Message } from "@vencord/discord-types";
-import { ChannelType } from "@vencord/discord-types/enums";
 import { findByPropsLazy, findComponentByCodeLazy } from "@webpack";
 import { Avatar, Button, ChannelStore, MessageStore, React, Text, UserStore } from "@webpack/common";
 
@@ -47,7 +46,7 @@ export function getChannelDisplayName(channelId: string): string {
     const channel = ChannelStore.getChannel(channelId);
     if (!channel) return "Unknown";
 
-    if (channel.type === ChannelType.GROUP_DM) {
+    if (channel.isGroupDM()) {
         return channel?.name || "Unnamed Group";
     }
 
@@ -115,11 +114,6 @@ export function GhostedUsersModal({ modalProps, ghostedChannels: initialChannels
                             const lastMessage: Message = MessageStore.getMessages(channelId)?.last();
                             const lastMessageDate = lastMessage?.timestamp ? formatMessageDate(lastMessage.timestamp) : "";
 
-                            const isGroupDM = channel.type === ChannelType.GROUP_DM;
-                            // logic for one on one dms
-                            const recipientId = channel.recipients?.[0];
-                            const user = UserStore.getUser(recipientId);
-                            const avatarSrc = user?.getAvatarURL(undefined, 128, true) || "";
                             const displayName = getChannelDisplayName(channel.id);
                             return (
                                 <div
@@ -127,11 +121,11 @@ export function GhostedUsersModal({ modalProps, ghostedChannels: initialChannels
                                     onClick={() => handleChannelClick(channelId)}
                                     className={cl("ghosted-entry")}
                                 >
-                                    {isGroupDM ?
+                                    {channel.isGroupDM() ?
                                         <GroupDmsIcon
                                             channel={channel}
                                         /> : <Avatar
-                                            src={avatarSrc}
+                                            src={UserStore.getUser(channel.recipients?.[0])?.getAvatarURL(undefined, 128, true) || ""}
                                             size="SIZE_40"
                                             aria-label={displayName}
                                         />}

--- a/src/equicordplugins/ghosted/GhostedUsersModal.tsx
+++ b/src/equicordplugins/ghosted/GhostedUsersModal.tsx
@@ -7,7 +7,6 @@
 import { classNameFactory } from "@utils/css";
 import { ModalCloseButton, ModalContent, ModalHeader, ModalRoot, ModalSize } from "@utils/modal";
 import { Channel, Message } from "@vencord/discord-types";
-import { ChannelType } from "@vencord/discord-types/enums";
 import { findByPropsLazy, findComponentByCodeLazy } from "@webpack";
 import { Avatar, Button, ChannelStore, MessageStore, React, Text, UserStore } from "@webpack/common";
 
@@ -47,7 +46,7 @@ export function getChannelDisplayName(channelId: string): string {
     const channel = ChannelStore.getChannel(channelId);
     if (!channel) return "Unknown";
 
-    if (channel.type === ChannelType.GROUP_DM) {
+    if (channel.isGroupDM()) {
         return channel?.name || "Unnamed Group";
     }
 
@@ -115,11 +114,6 @@ export function GhostedUsersModal({ modalProps, ghostedChannels: initialChannels
                             const lastMessage: Message = MessageStore.getMessages(channelId)?.last();
                             const lastMessageDate = lastMessage?.timestamp ? formatMessageDate(lastMessage.timestamp) : "";
 
-                            const isGroupDM = channel.type === ChannelType.GROUP_DM;
-                            // logic for one on one dms
-                            const recipientId = channel.recipients?.[0];
-                            const user = UserStore.getUser(recipientId);
-                            const avatarSrc = user?.getAvatarURL(undefined, 128, true) || "";
                             const displayName = getChannelDisplayName(channel.id);
                             return (
                                 <div
@@ -127,11 +121,11 @@ export function GhostedUsersModal({ modalProps, ghostedChannels: initialChannels
                                     onClick={() => handleChannelClick(channelId)}
                                     className={cl("ghosted-entry")}
                                 >
-                                    {isGroupDM ?
+                                    {channel.isGroupDM() ?
                                         <GroupDmsIcon
                                             channel={channel}
                                         /> : <Avatar
-                                            src={avatarSrc}
+                                            src={UserStore.getUser(lastMessage.id)?.getAvatarURL(undefined, 128, true) || ""}
                                             size="SIZE_40"
                                             aria-label={displayName}
                                         />}

--- a/src/equicordplugins/ghosted/GhostedUsersModal.tsx
+++ b/src/equicordplugins/ghosted/GhostedUsersModal.tsx
@@ -93,7 +93,7 @@ export function GhostedUsersModal({ modalProps, ghostedChannels: initialChannels
                             if (isGroupDM && lastMessage) {
                                 // group dms show the last sender
                                 const lastSender = UserStore.getUser(lastMessage.author.id);
-                                displayName = lastSender?.username || "Unknown User";
+                                displayName = channel?.name || "Unnamed Group";
                                 avatarSrc = lastSender?.getAvatarURL(undefined, 128, true) || "";
                             } else {
                                 // logic for one on one dms

--- a/src/equicordplugins/ghosted/index.tsx
+++ b/src/equicordplugins/ghosted/index.tsx
@@ -35,6 +35,11 @@ export const settings = definePluginSettings({
         default: true,
         restartNeeded: false
     },
+    ignoreGroupDms: {
+        type: OptionType.BOOLEAN,
+        description: "Exclude all group dms from ghosting",
+        default: false
+    },
     exemptedChannels: {
         type: OptionType.STRING,
         description: "Comma-separated list of channel IDs to exempt from ghosting (right-click a DM channel to copy its ID)",

--- a/src/equicordplugins/ghosted/index.tsx
+++ b/src/equicordplugins/ghosted/index.tsx
@@ -6,6 +6,7 @@
 
 import "./styles.css";
 
+import { findGroupChildrenByChildId } from "@api/ContextMenu";
 import { addServerListElement, removeServerListElement, ServerListRenderPosition } from "@api/ServerList";
 import { definePluginSettings, migratePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
@@ -14,7 +15,7 @@ import { classNameFactory } from "@utils/css";
 import { closeModal, openModal } from "@utils/modal";
 import definePlugin, { OptionType } from "@utils/types";
 import { Channel } from "@vencord/discord-types";
-import { Tooltip, useEffect, useState } from "@webpack/common";
+import { Menu, Tooltip, useEffect, useState } from "@webpack/common";
 
 import { Boo, clearChannelFromGhost, getBooCount, getGhostedChannels, onBooCountChange } from "./Boo";
 import { getChannelDisplayName, GhostedUsersModal } from "./GhostedUsersModal";
@@ -120,6 +121,17 @@ function BooIndicator() {
     );
 }
 
+function makeContextItem(props) {
+    return <Menu.MenuItem
+        id="ec-ghosted-clear"
+        key="ec-ghosted-clear"
+        label="Clear ghost"
+        action={() => {
+            clearChannelFromGhost(props.channel.id);
+        }} />;
+
+}
+
 migratePluginSettings("Ghosted", "Boo");
 export default definePlugin({
     name: "Ghosted",
@@ -127,6 +139,16 @@ export default definePlugin({
     authors: [EquicordDevs.vei, Devs.sadan, EquicordDevs.justjxke, EquicordDevs.iamme],
     settings,
     dependencies: ["AudioPlayerAPI", "ServerListAPI"],
+    contextMenus: {
+        "gdm-context": (menuItems, props) => {
+            const group = findGroupChildrenByChildId("leave", menuItems, true);
+            group?.unshift(makeContextItem(props));
+        },
+        "user-context": (menuItems, props) => {
+            const group = findGroupChildrenByChildId("close-dm", menuItems);
+            group?.push(makeContextItem(props));
+        }
+    },
 
     patches: [
         {

--- a/src/equicordplugins/ghosted/index.tsx
+++ b/src/equicordplugins/ghosted/index.tsx
@@ -125,7 +125,7 @@ function makeContextItem(props) {
     return <Menu.MenuItem
         id="ec-ghosted-clear"
         key="ec-ghosted-clear"
-        label="Clear ghost"
+        label="unghost"
         action={() => {
             clearChannelFromGhost(props.channel.id);
         }}

--- a/src/equicordplugins/ghosted/index.tsx
+++ b/src/equicordplugins/ghosted/index.tsx
@@ -14,7 +14,8 @@ import { classNameFactory } from "@utils/css";
 import { closeModal, openModal } from "@utils/modal";
 import definePlugin, { OptionType } from "@utils/types";
 import { Channel } from "@vencord/discord-types";
-import { ChannelStore, MessageStore, Tooltip, useEffect, UserStore, useState } from "@webpack/common";
+import { ChannelType } from "@vencord/discord-types/enums";
+import { ChannelStore, Tooltip, useEffect, UserStore, useState } from "@webpack/common";
 
 import { Boo, clearChannelFromGhost, getBooCount, getGhostedChannels, onBooCountChange } from "./Boo";
 import { GhostedUsersModal } from "./GhostedUsersModal";
@@ -58,12 +59,7 @@ function getChannelDisplayName(channelId: string): string {
     const channel = ChannelStore.getChannel(channelId);
     if (!channel) return "Unknown";
 
-    // get last message to determine sender for group DMs
-    const lastMessage = MessageStore.getMessages(channelId)?.last();
-
-    // check if it's a group DM
-    if (channel.recipients?.length > 1 && lastMessage) {
-        // show last message sender for group DMs
+    if (channel.type === ChannelType.GROUP_DM) {
         return channel?.name || "Unnamed Group";
     }
 
@@ -143,7 +139,7 @@ migratePluginSettings("Ghosted", "Boo");
 export default definePlugin({
     name: "Ghosted",
     description: "A cute ghost will appear if you don't answer their DMs",
-    authors: [EquicordDevs.vei, Devs.sadan, EquicordDevs.justjxke],
+    authors: [EquicordDevs.vei, Devs.sadan, EquicordDevs.justjxke, EquicordDevs.iamme],
     settings,
     dependencies: ["AudioPlayerAPI", "ServerListAPI"],
 

--- a/src/equicordplugins/ghosted/index.tsx
+++ b/src/equicordplugins/ghosted/index.tsx
@@ -59,8 +59,7 @@ function getChannelDisplayName(channelId: string): string {
     // check if it's a group DM
     if (channel.recipients?.length > 1 && lastMessage) {
         // show last message sender for group DMs
-        const lastSender = UserStore.getUser(lastMessage.author.id);
-        return lastSender?.username || "Unknown User";
+        return channel?.name || "Unnamed Group";
     }
 
     // 1-on-1 DM

--- a/src/equicordplugins/ghosted/index.tsx
+++ b/src/equicordplugins/ghosted/index.tsx
@@ -14,11 +14,10 @@ import { classNameFactory } from "@utils/css";
 import { closeModal, openModal } from "@utils/modal";
 import definePlugin, { OptionType } from "@utils/types";
 import { Channel } from "@vencord/discord-types";
-import { ChannelType } from "@vencord/discord-types/enums";
-import { ChannelStore, Tooltip, useEffect, UserStore, useState } from "@webpack/common";
+import { Tooltip, useEffect, useState } from "@webpack/common";
 
 import { Boo, clearChannelFromGhost, getBooCount, getGhostedChannels, onBooCountChange } from "./Boo";
-import { GhostedUsersModal } from "./GhostedUsersModal";
+import { getChannelDisplayName, GhostedUsersModal } from "./GhostedUsersModal";
 import { IconGhost } from "./IconGhost";
 
 export const cl = classNameFactory("vc-boo-");
@@ -54,20 +53,6 @@ export const settings = definePluginSettings({
         restartNeeded: false
     }
 });
-
-function getChannelDisplayName(channelId: string): string {
-    const channel = ChannelStore.getChannel(channelId);
-    if (!channel) return "Unknown";
-
-    if (channel.type === ChannelType.GROUP_DM) {
-        return channel?.name || "Unnamed Group";
-    }
-
-    // 1-on-1 DM
-    const recipientId = channel.recipients?.[0];
-    const user = UserStore.getUser(recipientId);
-    return user?.username || "Unknown User";
-}
 
 function BooIndicator() {
     const [count, setCount] = useState(getBooCount());

--- a/src/equicordplugins/ghosted/index.tsx
+++ b/src/equicordplugins/ghosted/index.tsx
@@ -128,8 +128,8 @@ function makeContextItem(props) {
         label="Clear ghost"
         action={() => {
             clearChannelFromGhost(props.channel.id);
-        }} />;
-
+        }}
+    />;
 }
 
 migratePluginSettings("Ghosted", "Boo");

--- a/src/equicordplugins/ghosted/index.tsx
+++ b/src/equicordplugins/ghosted/index.tsx
@@ -141,7 +141,7 @@ export default definePlugin({
     description: "A cute ghost will appear if you don't answer their DMs",
     authors: [EquicordDevs.vei, Devs.sadan, EquicordDevs.justjxke],
     settings,
-    dependencies: ["AudioPlayerAPI"],
+    dependencies: ["AudioPlayerAPI", "ServerListAPI"],
 
     patches: [
         {


### PR DESCRIPTION


- [x] Display the group DM name instead of the last sender's name as ghosted.
- [x] Added serverlist API as a dependency.
- [x] Show the group DM icon instead of the last sender's icon when it's a group DM.
- [x] Allow group DMs to be disabled by excluding them from ghosting.
- [x] Add an option to clear the ghosting from the right-click menu.