### PR TITLE
ChannelTabs: fix(ish) notice overlapping

### DIFF
--- a/src/equicordplugins/channelTabs/index.tsx
+++ b/src/equicordplugins/channelTabs/index.tsx
@@ -61,8 +61,8 @@ export default definePlugin({
             find: '"AppView"',
             replacement: [
                 {
-                    match: /(\?void 0:(\i)\.channelId.{0,600})"div",{className:\i\.content/,
-                    replace: "$1$self.render,{currentChannel:$2",
+                    match: /(\?void 0:(\i)\.channelId.{0,600})"div",{(?=className:\i\.content)/,
+                    replace: "$1$self.render,{currentChannel:$2,",
                     predicate: () => settings.store.tabBarPosition === "top"
                 },
                 {

--- a/src/equicordplugins/channelTabs/style.css
+++ b/src/equicordplugins/channelTabs/style.css
@@ -70,6 +70,14 @@
     z-index: 102;
 }
 
+/* as its in the same region as notices, it needs to hide itself when a notice is shown
+   there's no permanent notices, right? */
+[class*="notice"] + .vc-channeltabs-container-top {
+    z-index: 1;
+    height: 32px;
+    overflow: hidden;
+}
+
 .vc-channeltabs-container-top-macos {
     padding-left: 80px !important;
 }


### PR DESCRIPTION
https://discord.com/channels/1173279886065029291/1421950077936865428/1462279611676364841

i genuinely tried to find something better
also old patch ate one of the classes, oops 