### PR TITLE
fix: vcNarratorCustom user leave voice event filtering bug 

### DIFF
--- a/src/equicordplugins/vcNarratorCustom/index.tsx
+++ b/src/equicordplugins/vcNarratorCustom/index.tsx
@@ -1058,19 +1058,6 @@ export default definePlugin({
             }
         },
 
-        AUDIO_TOGGLE_SELF_MUTE() {
-            const myId = UserStore.getCurrentUser().id;
-            const s = VoiceStateStore.getVoiceStateForUser(myId) as VoiceState | undefined;
-            const chanId = s?.channelId;
-            if (!s || !chanId) return;
-        },
-
-        AUDIO_TOGGLE_SELF_DEAF() {
-            const myId = UserStore.getCurrentUser().id;
-            const s = VoiceStateStore.getVoiceStateForUser(myId) as VoiceState | undefined;
-            const chanId = s?.channelId;
-            if (!s || !chanId) return;
-        },
     },
 
     settingsAboutComponent({ tempSettings: s }: { tempSettings?: any; }) {

--- a/src/equicordplugins/vcNarratorCustom/index.tsx
+++ b/src/equicordplugins/vcNarratorCustom/index.tsx
@@ -992,10 +992,12 @@ export default definePlugin({
                 if (!isMe && !affectsMyChannel) continue;
 
                 // Keep snapshots in sync for join/leave/move without announcing state changes.
-                if (oldChannelId !== myChanId && channelId === myChanId) {
-                    voiceStateSnapshot.set(userId, normalizeState(state));
-                } else if (oldChannelId === myChanId && channelId !== myChanId) {
-                    voiceStateSnapshot.delete(userId);
+                if (myChanId) {
+                    if (oldChannelId !== myChanId && channelId === myChanId) {
+                        voiceStateSnapshot.set(userId, normalizeState(state));
+                    } else if (oldChannelId === myChanId && channelId !== myChanId) {
+                        voiceStateSnapshot.delete(userId);
+                    }
                 }
 
                 // Join/leave/move announcements (existing behavior)


### PR DESCRIPTION
## Summary
Fixed a bug with vcNarratorCustom to only announce join/leave for the user's actual active voice channel

## Why it only happened on “leave” before
> When `myChanId` was `null` (not actually in VC), some VOICE_STATE_UPDATES I suspect that some events emitting with `channelId = null` but `oldChannelId = anything` set (a leave), it would read as them leaving your null channel and trigger an event.

## Changes

**Change 1: stricter `myChanId` resolution (with safe fallback)**
```diff
-            const myGuildId = SelectedGuildStore.getGuildId();
-            const myChanId = SelectedChannelStore.getVoiceChannelId();
             const myId = UserStore.getCurrentUser().id;
+            const myGuildId = SelectedGuildStore.getGuildId();
+            const myVoiceState = VoiceStateStore.getVoiceStateForUser(myId) as VoiceState | undefined;
+            let myChanId = myVoiceState?.channelId;
+            if (!myChanId) {
+                const selectedChanId = SelectedChannelStore.getVoiceChannelId();
+                if (selectedChanId) {
+                    const states = VoiceStateStore.getVoiceStatesForChannel?.(selectedChanId) as Record<string, VoiceState> | undefined;
+                    if (states?.[myId]?.channelId === selectedChanId) {
+                        myChanId = selectedChanId;
+                    }
+                }
+            }
```

**Change 2: added a guard to skip non‑self events when not in VC**
```diff
                 const isMe = userId === myId;
+                if (!isMe && !myChanId) continue;
                 if (isMe && channelId !== myLastChannelId) {
                     oldChannelId = myLastChannelId;
                     myLastChannelId = channelId ?? undefined;
```

**Change 3: Removed these no-ops since they're not more helpful than the built in mute and deafen sounds for a user's own audio

```diff
-        AUDIO_TOGGLE_SELF_MUTE() {
-            const chanId = SelectedChannelStore.getVoiceChannelId()!;
-            const s = VoiceStateStore.getVoiceStateForChannel(
-                chanId
-            ) as VoiceState;
-            if (!s) return;
-        },
 
-        AUDIO_TOGGLE_SELF_DEAF() {
-            const chanId = SelectedChannelStore.getVoiceChannelId()!;
-            const s = VoiceStateStore.getVoiceStateForChannel(
-                chanId
-            ) as VoiceState;
-            if (!s) return;
-        },
```

## Testing
Not run (not requested).
