### PR TITLE
fix(mediaPlaybackSpeed): update color vars, fix alignment

### DIFF
--- a/src/equicordplugins/mediaPlaybackSpeed/styles.css
+++ b/src/equicordplugins/mediaPlaybackSpeed/styles.css
@@ -2,6 +2,7 @@
     background-color: transparent;
     height: 100%;
     z-index: 2;
+    line-height: 0;
     color: var(--interactive-text-default);
 }
 

--- a/src/equicordplugins/mediaPlaybackSpeed/styles.css
+++ b/src/equicordplugins/mediaPlaybackSpeed/styles.css
@@ -2,9 +2,9 @@
     background-color: transparent;
     height: 100%;
     z-index: 2;
-    color: var(--interactive-icon-default);
+    color: var(--interactive-text-default);
 }
 
 .vc-media-playback-speed-icon:hover {
-    color: var(--interactive-icon-active);
+    color: var(--interactive-text-hover);
 }


### PR DESCRIPTION
Updates the CSS vars to fix this

<img width="473" height="75" alt="image" src="https://github.com/user-attachments/assets/103ae85b-b011-4b1d-992e-3bf3814a930d" />

<img width="503" height="72" alt="image" src="https://github.com/user-attachments/assets/af6ead9c-1340-49ce-aa2e-482576f7f3fd" />

Now fixes the alignment too:

<img width="460" height="69" alt="image" src="https://github.com/user-attachments/assets/4932d397-fd28-435c-b312-276e7b0bbdea" />

I also checked the other types of media and it works for them too.

<hr>

Btw GitHub is absolutely cooked I had to create the org to fork it because it said I already have a fork which is not true??

<img width="448" height="197" alt="image" src="https://github.com/user-attachments/assets/ba90f30d-4a5d-4e0d-8dd5-81a59560d607" />

I can only assume this is because it would be a fork of a fork and I already forked the root repo but still stupid.