### PR TITLE
MessageClickActions: Click actions no longer trigger on message links

### DIFF
--- a/src/plugins/messageClickActions/index.ts
+++ b/src/plugins/messageClickActions/index.ts
@@ -486,8 +486,11 @@ export default definePlugin({
     },
 
     onMessageClick(msg, channel, event) {
-        const target = event.target as HTMLElement;
-        if (target.closest('a, button, input, img, [class*="repliedTextPreview"], [class*="threadMessageAccessory"]')) return;
+        let target = event.target as HTMLElement;
+        if (target.nodeType === Node.TEXT_NODE) target = target.parentElement as HTMLElement;
+
+        // dont look, please just dont
+        if (target.closest('a, button, input, img, video, audio, [role="button"], [role="link"], [role="menuitem"], [class*="repliedTextPreview"], [class*="threadMessageAccessory"], [class*="spoilerText"], [class*="mention"]')) return;
         if (!target.closest('[class*="message"]')) return;
 
         const myId = AuthenticationStore.getId();
@@ -510,6 +513,8 @@ export default definePlugin({
         const isSingleClick = event.detail === 1 && event.button === 0;
         const isDoubleClick = event.detail === 2;
         const isTripleClick = event.detail === 3;
+
+        if (Date.now() - lastMouseDownTime > settings.store.selectionHoldTimeout) return;
 
         if (singleClickTimeout) {
             clearTimeout(singleClickTimeout);
@@ -537,8 +542,6 @@ export default definePlugin({
                 clearTimeout(singleClickTimeout);
                 singleClickTimeout = null;
             }
-
-            if (Date.now() - lastMouseDownTime > settings.store.selectionHoldTimeout) return;
 
             const executeDoubleClick = () => {
                 if (channel.guild_id && !PermissionStore.can(PermissionsBits.SEND_MESSAGES, channel)) return;

--- a/src/plugins/messageClickActions/index.ts
+++ b/src/plugins/messageClickActions/index.ts
@@ -551,7 +551,7 @@ export default definePlugin({
                 }
             };
 
-            if (canTripleClick) {
+            if (canTripleClick && canDoubleClick) {
                 if (doubleClickTimeout) {
                     clearTimeout(doubleClickTimeout);
                 }
@@ -569,13 +569,14 @@ export default definePlugin({
         }
 
         if (isSingleClick) {
+            const shouldExecuteSingle = isModifierPressed(singleClickModifier) && singleClickAction !== "NONE";
             const executeSingleClick = () => {
-                if (isModifierPressed(singleClickModifier) && singleClickAction !== "NONE") {
+                if (shouldExecuteSingle) {
                     executeAction(singleClickAction, msg, channel, event);
                 }
             };
 
-            if (canDoubleClick) {
+            if (canDoubleClick && shouldExecuteSingle) {
                 singleClickTimeout = setTimeout(() => {
                     executeSingleClick();
                     singleClickTimeout = null;

--- a/src/plugins/messageClickActions/index.ts
+++ b/src/plugins/messageClickActions/index.ts
@@ -102,7 +102,8 @@ function modifierFromKey(e: KeyboardEvent): Modifier | null {
 }
 
 function isModifierPressed(modifier: Modifier): boolean {
-    return modifier === "NONE" || pressedModifiers.has(modifier);
+    if (modifier === "NONE") return pressedModifiers.size === 0;
+    return pressedModifiers.has(modifier);
 }
 
 let doubleClickTimeout: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
fixes click actions triggering on message links, also use the double click timeout for single click