### PR TITLE
Fix clips (kinda)

### DIFF
--- a/src/equicordplugins/clipsEnhancements.discordDesktop/index.tsx
+++ b/src/equicordplugins/clipsEnhancements.discordDesktop/index.tsx
@@ -43,6 +43,12 @@ const settings = definePluginSettings({
         default: true,
         restartNeeded: true
     },
+    ignorePlatformRestriction: {
+        type: OptionType.BOOLEAN,
+        description: "Allow Platform Restricted Clipping (may cause save errors)",
+        default: true,
+        restartNeeded: true
+    },
     clipsLink: {
         type: OptionType.COMPONENT,
         description: "",
@@ -95,7 +101,7 @@ export default definePlugin({
             find: "2022-11_clips_experiment",
             replacement: {
                 match: /defaultConfig:\{enableClips:!\d,ignorePlatformRestriction:!\d,showClipsHeaderEntrypoint:!\d,enableScreenshotKeybind:!\d,enableVoiceOnlyClips:!\d,enableAdvancedSignals:!\d\}/,
-                replace: "defaultConfig:{enableClips:!0,ignorePlatformRestriction:!0,showClipsHeaderEntrypoint:!0,enableScreenshotKeybind:$self.settings.store.enableScreenshotKeybind,enableVoiceOnlyClips:$self.settings.store.enableVoiceOnlyClips,enableAdvancedSignals:$self.settings.store.enableAdvancedSignals}"
+                replace: "defaultConfig:{enableClips:!0,ignorePlatformRestriction:$self.settings.store.ignorePlatformRestriction,showClipsHeaderEntrypoint:!0,enableScreenshotKeybind:$self.settings.store.enableScreenshotKeybind,enableVoiceOnlyClips:$self.settings.store.enableVoiceOnlyClips,enableAdvancedSignals:$self.settings.store.enableAdvancedSignals}"
             }
         },
         {

--- a/src/equicordplugins/clipsEnhancements.discordDesktop/index.tsx
+++ b/src/equicordplugins/clipsEnhancements.discordDesktop/index.tsx
@@ -134,7 +134,9 @@ export default definePlugin({
         extraFramerates.forEach(framerate => newFramerates.push({
             id: `${framerate}fps`,
             value: framerate,
-            label: `${framerate} FPS`
+            label: getIntlMessage("SCREENSHARE_FPS_ABBREVIATED", {
+                fps: framerate
+            })
         }));
 
         return newFramerates.sort((a, b) => a.value - b.value);

--- a/src/equicordplugins/clipsEnhancements.discordDesktop/index.tsx
+++ b/src/equicordplugins/clipsEnhancements.discordDesktop/index.tsx
@@ -113,7 +113,7 @@ export default definePlugin({
         }
     ],
 
-    patchTimeslots(timeslots) {
+    patchTimeslots(timeslots: { id: string; value: number; label: string; }[]) {
         const newTimeslots = [...timeslots];
 
         extraTimeslots.forEach(timeslot => newTimeslots.push({
@@ -124,22 +124,20 @@ export default definePlugin({
             })
         }));
 
-        return newTimeslots.toSorted();
+        return newTimeslots.sort((a, b) => a.value - b.value);
     },
 
-    patchFramerates(framerates) {
+    patchFramerates(framerates: { id: string; value: number; label: string; }[]) {
         const newFramerates = [...framerates];
 
         // Lower framerates than 15FPS have adverse affects on compression, 3 minute clips at 10FPS skyrocket the filesize to 200mb!!
         extraFramerates.forEach(framerate => newFramerates.push({
             id: `${framerate}fps`,
             value: framerate,
-            label: getIntlMessage("SCREENSHARE_FPS_ABBREVIATED", {
-                count: framerate
-            })
+            label: `${framerate} FPS`
         }));
 
-        return newFramerates.toSorted();
+        return newFramerates.sort((a, b) => a.value - b.value);
     },
 
     getApplicationId(activityName: string) {


### PR DESCRIPTION
The issues we have are due to some limitations with discord. The problem is that, since we're hacking in a bypass for their platform restricted clipping, a lot of stuff breaks when you're not clipping a supported game. E.g. Changing the FPS doesn't work, thumbnails don't save, etc.
I've added an option to disable this which should prevent these issues completely as long as you're not trying to clip an unsupported window. I'm not sure if there's a better way to fix this but if there is then I'm too dumb to figure it out. ignorePlatformRestriction is still enabled by default because I think more people would benefit from having it on than not.