### PR TITLE
feat(MessagePeek): add plugin

### DIFF
--- a/src/equicordplugins/messagePeek/index.tsx
+++ b/src/equicordplugins/messagePeek/index.tsx
@@ -1,0 +1,193 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { DecoratorProps } from "@api/MemberListDecorators";
+import { Devs, EquicordDevs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
+import definePlugin from "@utils/types";
+import { Channel, Message } from "@vencord/discord-types";
+import { MessageFlags } from "@vencord/discord-types/enums";
+import { findCssClassesLazy, findExportedComponentLazy } from "@webpack";
+import { MessageStore, SnowflakeUtils, UserStore } from "@webpack/common";
+
+const cl = classNameFactory("vc-message-peek-");
+
+const PrivateChannelClasses = findCssClassesLazy("subtext", "channel", "interactive");
+const ActivityClasses = findCssClassesLazy("textWithIconContainer", "icon", "truncated", "container", "textXs");
+
+const ImageIcon = findExportedComponentLazy("ImageIcon");
+const AttachmentIcon = findExportedComponentLazy("AttachmentIcon");
+const WaveformIcon = findExportedComponentLazy("WaveformIcon");
+const StickerIcon = findExportedComponentLazy("StickerIcon");
+const GifIcon = findExportedComponentLazy("GifIcon");
+const VideoIcon = findExportedComponentLazy("VideoIcon");
+
+type IconComponent = React.ComponentType<{ size: string; className?: string; }>;
+
+interface Attachment {
+    content_type?: string;
+}
+
+function getAttachmentType(attachment: Attachment): "image" | "gif" | "video" | "file" {
+    const contentType = attachment.content_type ?? "";
+    if (contentType === "image/gif") return "gif";
+    if (contentType.startsWith("image/")) return "image";
+    if (contentType.startsWith("video/")) return "video";
+    return "file";
+}
+
+function getAttachmentInfo(attachments: Attachment[]): { type: "image" | "gif" | "video" | "file"; count: number; } {
+    let gif = 0, image = 0, video = 0;
+
+    for (const attachment of attachments) {
+        const type = getAttachmentType(attachment);
+        if (type === "gif") gif++;
+        else if (type === "image") image++;
+        else if (type === "video") video++;
+    }
+
+    const total = attachments.length;
+    if (gif === total) return { type: "gif", count: gif };
+    if (image === total) return { type: "image", count: image };
+    if (video === total) return { type: "video", count: video };
+
+    return { type: "file", count: total };
+}
+
+function formatRelativeTime(timestamp: number): string {
+    const now = Date.now();
+    const diff = now - timestamp;
+
+    const minutes = Math.max(1, Math.floor(diff / 60000));
+    const hours = Math.floor(diff / 3600000);
+    const days = Math.floor(diff / 86400000);
+    const months = Math.floor(days / 30);
+    const years = Math.floor(days / 365);
+
+    if (years > 0) return `${years}y`;
+    if (months > 0) return `${months}mo`;
+    if (days > 0) return `${days}d`;
+    if (hours > 0) return `${hours}h`;
+    return `${minutes}m`;
+}
+
+const attachmentIcons: Record<string, IconComponent> = {
+    image: ImageIcon,
+    gif: GifIcon,
+    video: VideoIcon,
+    file: AttachmentIcon
+};
+
+const attachmentLabels: Record<string, string> = {
+    image: "image",
+    gif: "GIF",
+    video: "video",
+    file: "file"
+};
+
+const containerStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: 4
+};
+
+const iconWrapperStyle: React.CSSProperties = {
+    display: "flex",
+    marginTop: 0.8
+};
+
+export default definePlugin({
+    name: "MessagePeek",
+    description: "Shows the last message preview and timestamp in the Direct Messages list.",
+    authors: [Devs.prism, EquicordDevs.justjxke],
+    patches: [
+        {
+            find: "PrivateChannel.renderAvatar",
+            replacement: {
+                match: /,subText:(\i)\.isSystemDM\(\).{0,500}:null,(?=name:)/,
+                replace: ",subText:$self.getMessagePreview($1),"
+            }
+        }
+    ],
+
+    renderMemberListDecorator({ channel }: DecoratorProps) {
+        if (!channel) return null;
+
+        const lastMessage: Message | undefined = MessageStore.getLastMessage(channel.id);
+        if (!lastMessage) return null;
+
+        const timestamp = SnowflakeUtils.extractTimestamp(lastMessage.id);
+        const relativeTime = formatRelativeTime(timestamp);
+
+        return (
+            <span className={cl("timestamp")}>{relativeTime}</span>
+        );
+    },
+
+    getMessagePreview(channel: Channel) {
+        if (channel.isSystemDM()) {
+            return (
+                <div className={PrivateChannelClasses.subtext}>
+                    Official Discord Message
+                </div>
+            );
+        }
+
+        if (channel.isMultiUserDM()) {
+            return (
+                <div className={PrivateChannelClasses.subtext}>
+                    {channel.recipients.length + 1} Members
+                </div>
+            );
+        }
+
+        const lastMessage: Message | undefined = MessageStore.getLastMessage(channel.id);
+        if (!lastMessage) return null;
+
+        const currentUser = UserStore.getCurrentUser();
+        const isOwnMessage = lastMessage.author.id === currentUser.id;
+        const authorName = isOwnMessage ? "You" : (lastMessage.author.globalName ?? lastMessage.author.username);
+
+        let content: string;
+        let Icon: IconComponent | null = null;
+
+        if (lastMessage.content) {
+            if (/https?:\/\/(\S+\.gif|tenor\.com|giphy\.com)/i.test(lastMessage.content)) {
+                content = "sent a GIF";
+                Icon = GifIcon;
+            } else {
+                content = lastMessage.content;
+            }
+        } else if (lastMessage.flags & MessageFlags.IS_VOICE_MESSAGE) {
+            content = "voice message";
+            Icon = WaveformIcon;
+        } else if (lastMessage.attachments?.length) {
+            const { type, count } = getAttachmentInfo(lastMessage.attachments);
+            Icon = attachmentIcons[type];
+            const label = attachmentLabels[type];
+            content = type === "gif"
+                ? (count > 1 ? `${count} GIFs` : "GIF")
+                : `${count} ${label}${count > 1 ? "s" : ""}`;
+        } else if (lastMessage.stickerItems?.length) {
+            const sticker = lastMessage.stickerItems[0];
+            content = sticker.name;
+            Icon = StickerIcon;
+        } else {
+            return null;
+        }
+
+        return (
+            <div className={PrivateChannelClasses.subtext}>
+                <div className={`${ActivityClasses.container} ${ActivityClasses.textXs}`} style={containerStyle}>
+                    <span className={ActivityClasses.truncated}>{authorName}: {content}</span>
+                    {Icon && <span style={iconWrapperStyle}><Icon size="xxs" className={ActivityClasses.icon} /></span>}
+                </div>
+            </div>
+        );
+    }
+});

--- a/src/equicordplugins/messagePeek/index.tsx
+++ b/src/equicordplugins/messagePeek/index.tsx
@@ -11,6 +11,7 @@ import { isPluginEnabled } from "@api/PluginManager";
 import betterActivities from "@equicordplugins/betterActivities";
 import { Devs, EquicordDevs } from "@utils/constants";
 import { classNameFactory } from "@utils/css";
+import { classes } from "@utils/misc";
 import definePlugin from "@utils/types";
 import { Activity, ApplicationStream, Channel, Message, OnlineStatus, User } from "@vencord/discord-types";
 import { MessageFlags } from "@vencord/discord-types/enums";
@@ -163,7 +164,7 @@ function MessagePreviewContent({ channel }: { channel: Channel; }) {
     const Icon = content.icon ? Icons[content.icon] : null;
 
     return (
-        <div className={`${ActivityClasses.container} ${ActivityClasses.textXs} ${cl("preview")}`}>
+        <div className={classes(ActivityClasses.container, ActivityClasses.textXs, cl("preview"))}>
             <span className={ActivityClasses.truncated}>{authorName}: {content.text}</span>
             {Icon && (
                 <span className={cl("icon")}>

--- a/src/equicordplugins/messagePeek/index.tsx
+++ b/src/equicordplugins/messagePeek/index.tsx
@@ -12,94 +12,119 @@ import { classNameFactory } from "@utils/css";
 import definePlugin from "@utils/types";
 import { Channel, Message } from "@vencord/discord-types";
 import { MessageFlags } from "@vencord/discord-types/enums";
-import { findCssClassesLazy, findExportedComponentLazy } from "@webpack";
-import { MessageStore, SnowflakeUtils, UserStore } from "@webpack/common";
+import { findByPropsLazy, findCssClassesLazy, findExportedComponentLazy } from "@webpack";
+import { ChannelStore, MessageStore, SnowflakeUtils, UserStore,useStateFromStores } from "@webpack/common";
 
 const cl = classNameFactory("vc-message-peek-");
 
 const PrivateChannelClasses = findCssClassesLazy("subtext", "channel", "interactive");
 const ActivityClasses = findCssClassesLazy("textWithIconContainer", "icon", "truncated", "container", "textXs");
+const MessageActions = findByPropsLazy("fetchMessages", "sendMessage");
 
-const ImageIcon = findExportedComponentLazy("ImageIcon");
-const AttachmentIcon = findExportedComponentLazy("AttachmentIcon");
-const WaveformIcon = findExportedComponentLazy("WaveformIcon");
-const StickerIcon = findExportedComponentLazy("StickerIcon");
-const GifIcon = findExportedComponentLazy("GifIcon");
-const VideoIcon = findExportedComponentLazy("VideoIcon");
+const Icons = {
+    image: findExportedComponentLazy("ImageIcon"),
+    file: findExportedComponentLazy("AttachmentIcon"),
+    voice: findExportedComponentLazy("WaveformIcon"),
+    sticker: findExportedComponentLazy("StickerIcon"),
+    gif: findExportedComponentLazy("GifIcon"),
+    video: findExportedComponentLazy("VideoIcon"),
+};
 
-type IconComponent = React.ComponentType<{ size: string; className?: string; }>;
-
-interface Attachment {
-    content_type?: string;
-}
-
-function getAttachmentType(attachment: Attachment): "image" | "gif" | "video" | "file" {
-    const contentType = attachment.content_type ?? "";
+function getAttachmentType(contentType = ""): "image" | "gif" | "video" | "file" {
     if (contentType === "image/gif") return "gif";
     if (contentType.startsWith("image/")) return "image";
     if (contentType.startsWith("video/")) return "video";
     return "file";
 }
 
-function getAttachmentInfo(attachments: Attachment[]): { type: "image" | "gif" | "video" | "file"; count: number; } {
-    let gif = 0, image = 0, video = 0;
-
-    for (const attachment of attachments) {
-        const type = getAttachmentType(attachment);
-        if (type === "gif") gif++;
-        else if (type === "image") image++;
-        else if (type === "video") video++;
-    }
-
-    const total = attachments.length;
-    if (gif === total) return { type: "gif", count: gif };
-    if (image === total) return { type: "image", count: image };
-    if (video === total) return { type: "video", count: video };
-
-    return { type: "file", count: total };
-}
-
 function formatRelativeTime(timestamp: number): string {
-    const now = Date.now();
-    const diff = now - timestamp;
-
-    const minutes = Math.max(1, Math.floor(diff / 60000));
+    const diff = Date.now() - timestamp;
+    const minutes = Math.floor(diff / 60000);
     const hours = Math.floor(diff / 3600000);
     const days = Math.floor(diff / 86400000);
-    const months = Math.floor(days / 30);
-    const years = Math.floor(days / 365);
 
-    if (years > 0) return `${years}y`;
-    if (months > 0) return `${months}mo`;
+    if (days >= 365) return `${Math.floor(days / 365)}y`;
+    if (days >= 30) return `${Math.floor(days / 30)}mo`;
     if (days > 0) return `${days}d`;
     if (hours > 0) return `${hours}h`;
-    return `${minutes}m`;
+    return `${Math.max(1, minutes)}m`;
 }
 
-const attachmentIcons: Record<string, IconComponent> = {
-    image: ImageIcon,
-    gif: GifIcon,
-    video: VideoIcon,
-    file: AttachmentIcon
-};
+function pluralize(count: number, singular: string, plural = singular + "s") {
+    return count === 1 ? `1 ${singular}` : `${count} ${plural}`;
+}
 
-const attachmentLabels: Record<string, string> = {
-    image: "image",
-    gif: "GIF",
-    video: "video",
-    file: "file"
-};
+function getMessageContent(message: Message): { text: string; icon?: keyof typeof Icons; } | null {
+    if (message.content) {
+        if (/https?:\/\/(\S+\.gif|tenor\.com|giphy\.com)/i.test(message.content)) {
+            return { text: "sent a GIF", icon: "gif" };
+        }
+        return { text: message.content };
+    }
 
-const containerStyle: React.CSSProperties = {
-    display: "flex",
-    alignItems: "center",
-    gap: 4
-};
+    if (message.flags & MessageFlags.IS_VOICE_MESSAGE) {
+        return { text: "voice message", icon: "voice" };
+    }
 
-const iconWrapperStyle: React.CSSProperties = {
-    display: "flex",
-    marginTop: 0.8
-};
+    if (message.attachments?.length) {
+        const types = message.attachments.map(a => getAttachmentType(a.content_type));
+        const allSame = types.every(t => t === types[0]);
+        const count = types.length;
+
+        if (allSame) {
+            const type = types[0];
+            const labels = { gif: "GIF", image: "image", video: "video", file: "file" };
+            return { text: pluralize(count, labels[type]), icon: type };
+        }
+        return { text: pluralize(count, "file"), icon: "file" };
+    }
+
+    if (message.stickerItems?.length) {
+        return { text: message.stickerItems[0].name, icon: "sticker" };
+    }
+
+    return null;
+}
+
+function MessagePreview({ channel }: { channel: Channel; }) {
+    const lastMessage = useStateFromStores([MessageStore], () => MessageStore.getLastMessage(channel.id) as Message | undefined);
+
+    if (channel.isSystemDM()) {
+        return <div className={PrivateChannelClasses.subtext}>Official Discord Message</div>;
+    }
+
+    if (channel.isMultiUserDM()) {
+        return <div className={PrivateChannelClasses.subtext}>{channel.recipients.length + 1} Members</div>;
+    }
+
+    if (!lastMessage) return null;
+
+    const content = getMessageContent(lastMessage);
+    if (!content) return null;
+
+    const currentUser = UserStore.getCurrentUser();
+    const isOwnMessage = lastMessage.author.id === currentUser.id;
+    const authorName = isOwnMessage ? "You" : (lastMessage.author.globalName ?? lastMessage.author.username);
+    const Icon = content.icon ? Icons[content.icon] : null;
+
+    return (
+        <div className={PrivateChannelClasses.subtext}>
+            <div className={`${ActivityClasses.container} ${ActivityClasses.textXs} ${cl("preview")}`}>
+                <span className={ActivityClasses.truncated}>{authorName}: {content.text}</span>
+                {Icon && <span className={cl("icon")}><Icon size="xxs" className={ActivityClasses.icon} /></span>}
+            </div>
+        </div>
+    );
+}
+
+function Timestamp({ channel }: { channel: Channel; }) {
+    const lastMessage = useStateFromStores([MessageStore], () => MessageStore.getLastMessage(channel.id) as Message | undefined);
+
+    if (!lastMessage) return null;
+
+    const timestamp = SnowflakeUtils.extractTimestamp(lastMessage.id);
+    return <span className={cl("timestamp")}>{formatRelativeTime(timestamp)}</span>;
+}
 
 export default definePlugin({
     name: "MessagePeek",
@@ -115,79 +140,21 @@ export default definePlugin({
         }
     ],
 
+    async start() {
+        const channels = ChannelStore.getSortedPrivateChannels();
+        for (const channel of channels) {
+            if (!MessageStore.getLastMessage(channel.id)) {
+                await MessageActions.fetchMessages({ channelId: channel.id, limit: 1 });
+            }
+        }
+    },
+
     renderMemberListDecorator({ channel }: DecoratorProps) {
         if (!channel) return null;
-
-        const lastMessage: Message | undefined = MessageStore.getLastMessage(channel.id);
-        if (!lastMessage) return null;
-
-        const timestamp = SnowflakeUtils.extractTimestamp(lastMessage.id);
-        const relativeTime = formatRelativeTime(timestamp);
-
-        return (
-            <span className={cl("timestamp")}>{relativeTime}</span>
-        );
+        return <Timestamp channel={channel} />;
     },
 
     getMessagePreview(channel: Channel) {
-        if (channel.isSystemDM()) {
-            return (
-                <div className={PrivateChannelClasses.subtext}>
-                    Official Discord Message
-                </div>
-            );
-        }
-
-        if (channel.isMultiUserDM()) {
-            return (
-                <div className={PrivateChannelClasses.subtext}>
-                    {channel.recipients.length + 1} Members
-                </div>
-            );
-        }
-
-        const lastMessage: Message | undefined = MessageStore.getLastMessage(channel.id);
-        if (!lastMessage) return null;
-
-        const currentUser = UserStore.getCurrentUser();
-        const isOwnMessage = lastMessage.author.id === currentUser.id;
-        const authorName = isOwnMessage ? "You" : (lastMessage.author.globalName ?? lastMessage.author.username);
-
-        let content: string;
-        let Icon: IconComponent | null = null;
-
-        if (lastMessage.content) {
-            if (/https?:\/\/(\S+\.gif|tenor\.com|giphy\.com)/i.test(lastMessage.content)) {
-                content = "sent a GIF";
-                Icon = GifIcon;
-            } else {
-                content = lastMessage.content;
-            }
-        } else if (lastMessage.flags & MessageFlags.IS_VOICE_MESSAGE) {
-            content = "voice message";
-            Icon = WaveformIcon;
-        } else if (lastMessage.attachments?.length) {
-            const { type, count } = getAttachmentInfo(lastMessage.attachments);
-            Icon = attachmentIcons[type];
-            const label = attachmentLabels[type];
-            content = type === "gif"
-                ? (count > 1 ? `${count} GIFs` : "GIF")
-                : `${count} ${label}${count > 1 ? "s" : ""}`;
-        } else if (lastMessage.stickerItems?.length) {
-            const sticker = lastMessage.stickerItems[0];
-            content = sticker.name;
-            Icon = StickerIcon;
-        } else {
-            return null;
-        }
-
-        return (
-            <div className={PrivateChannelClasses.subtext}>
-                <div className={`${ActivityClasses.container} ${ActivityClasses.textXs}`} style={containerStyle}>
-                    <span className={ActivityClasses.truncated}>{authorName}: {content}</span>
-                    {Icon && <span style={iconWrapperStyle}><Icon size="xxs" className={ActivityClasses.icon} /></span>}
-                </div>
-            </div>
-        );
+        return <MessagePreview channel={channel} />;
     }
 });

--- a/src/equicordplugins/messagePeek/index.tsx
+++ b/src/equicordplugins/messagePeek/index.tsx
@@ -7,6 +7,8 @@
 import "./style.css";
 
 import { DecoratorProps } from "@api/MemberListDecorators";
+import { isPluginEnabled } from "@api/PluginManager";
+import betterActivities from "@equicordplugins/betterActivities";
 import { Devs, EquicordDevs } from "@utils/constants";
 import { classNameFactory } from "@utils/css";
 import definePlugin from "@utils/types";
@@ -69,26 +71,10 @@ interface MessageContent {
     icon?: IconType;
 }
 
-interface BetterActivitiesPlugin {
-    started: boolean;
-    patchActivityList: (props: { activities: Activity[]; user: User; hideTooltip: boolean; }) => React.ReactNode;
-}
-
-function getBetterActivities(): BetterActivitiesPlugin | null {
-    const plugin = Vencord.Plugins.plugins.BetterActivities;
-    if (!plugin?.started) return null;
-
-    const betterActivities = plugin as unknown as BetterActivitiesPlugin;
-    if (typeof betterActivities.patchActivityList !== "function") return null;
-
-    return betterActivities;
-}
-
 function getActivityIcons(activities: Activity[] | null, user: User): React.ReactNode {
     if (!activities?.length) return null;
 
-    const betterActivities = getBetterActivities();
-    if (!betterActivities) return null;
+    if (!isPluginEnabled(betterActivities.name)) return null;
 
     return betterActivities.patchActivityList({
         activities,

--- a/src/equicordplugins/messagePeek/index.tsx
+++ b/src/equicordplugins/messagePeek/index.tsx
@@ -24,7 +24,7 @@ const MessageActions = findByPropsLazy("fetchMessages", "sendMessage");
 const Icons = {
     image: findExportedComponentLazy("ImageIcon"),
     file: findExportedComponentLazy("AttachmentIcon"),
-    voice: findExportedComponentLazy("WaveformIcon"),
+    voice: findExportedComponentLazy("MicrophoneIcon"),
     sticker: findExportedComponentLazy("StickerIcon"),
     gif: findExportedComponentLazy("GifIcon"),
     video: findExportedComponentLazy("VideoIcon"),

--- a/src/equicordplugins/messagePeek/style.css
+++ b/src/equicordplugins/messagePeek/style.css
@@ -1,0 +1,17 @@
+.vc-message-peek-timestamp {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 16px;
+    color: var(--text-normal);
+}
+
+[class*="interactiveSelected__"] .vc-message-peek-timestamp {
+    color: var(--white);
+}
+
+[class*="interactive__"]:hover .vc-message-peek-timestamp {
+    display: none;
+}

--- a/src/equicordplugins/messagePeek/style.css
+++ b/src/equicordplugins/messagePeek/style.css
@@ -30,3 +30,18 @@
 [class*="interactive__"]:hover .vc-message-peek-icon svg path {
     fill: var(--white) !important;
 }
+
+.vc-message-peek-activity-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.vc-message-peek-activity-row>[class*="textXs"] {
+    flex: 1;
+    min-width: 0;
+}
+
+.vc-message-peek-activity-row>[class*="vc-bactivities-row"] {
+    flex-shrink: 0;
+}

--- a/src/equicordplugins/messagePeek/style.css
+++ b/src/equicordplugins/messagePeek/style.css
@@ -15,3 +15,18 @@
 [class*="interactive__"]:hover .vc-message-peek-timestamp {
     display: none;
 }
+
+.vc-message-peek-preview {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.vc-message-peek-icon {
+    display: flex;
+    margin-top: 0.8px;
+}
+
+[class*="interactive__"]:hover .vc-message-peek-icon svg path {
+    fill: var(--white) !important;
+}


### PR DESCRIPTION
replaces _2025-12-desktop-message-previews_ experiment

<img width="239" height="57" alt="image" src="https://github.com/user-attachments/assets/5e78e4ac-da58-4117-8be0-12f839999117" />

and more just like the original one