### PR TITLE
AutoJump (Returns)

### DIFF
--- a/src/equicordplugins/AutoJump/index.tsx
+++ b/src/equicordplugins/AutoJump/index.tsx
@@ -1,0 +1,70 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { Menu, ChannelStore, NavigationRouter, MessageActions, MessageStore, ComponentDispatch } from "@webpack/common";
+
+interface ChannelSelectEvent {
+    type: "CHANNEL_SELECT";
+    channelId: string | null;
+    guildId: string | null;
+    messageId?: string | null;
+}
+
+let lastChannelId = "0";
+
+function autoJump(channel: any) {
+    const guildId = channel.guild_id ?? "@me";
+    const channelId = channel.id;
+
+    if (channelId === lastChannelId) return;
+
+    lastChannelId = channelId;
+
+    ComponentDispatch.dispatch("SCROLLTO_PRESENT");
+}
+
+const MenuPatch: NavContextMenuPatchCallback = (children, { channel }) => {
+    children.push(
+        <Menu.MenuItem
+            id="auto-jump"
+            label="Jump to Last Message"
+            action={() => ComponentDispatch.dispatch("SCROLLTO_PRESENT")}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "AutoJump",
+    description: "Automatically jumps to the last message when selecting a channel.",
+    authors: [EquicordDevs.omaw],
+    
+    contextMenus: {
+        "channel-context": MenuPatch,
+        "user-context": MenuPatch,
+        "thread-context": MenuPatch
+    },
+    
+    flux: {
+        async CHANNEL_SELECT(event: ChannelSelectEvent) {
+            const { guildId, channelId, messageId } = event;
+            
+            if (!guildId || !channelId) return;
+            if (lastChannelId === channelId) return;
+            if (messageId) {
+                lastChannelId = channelId;
+                return;
+            }
+            
+            const channel = ChannelStore.getChannel(channelId);
+            if (!channel) return;
+            
+            autoJump(channel);
+        }
+    }
+});

--- a/src/equicordplugins/AutoJump/index.tsx
+++ b/src/equicordplugins/AutoJump/index.tsx
@@ -1,3 +1,9 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { EquicordDevs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { ComponentDispatch } from "@webpack/common";
@@ -17,3 +23,5 @@ export default definePlugin({
         }
     }
 });
+
+

--- a/src/equicordplugins/AutoJump/index.tsx
+++ b/src/equicordplugins/AutoJump/index.tsx
@@ -7,7 +7,7 @@
 import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { EquicordDevs } from "@utils/constants";
 import definePlugin from "@utils/types";
-import { Menu, ChannelStore, NavigationRouter, MessageActions, MessageStore, ComponentDispatch } from "@webpack/common";
+import { Menu, ChannelStore, ComponentDispatch } from "@webpack/common";
 
 interface ChannelSelectEvent {
     type: "CHANNEL_SELECT";

--- a/src/equicordplugins/AutoJump/index.tsx
+++ b/src/equicordplugins/AutoJump/index.tsx
@@ -29,7 +29,7 @@ function autoJump(channel: any) {
     ComponentDispatch.dispatch("SCROLLTO_PRESENT");
 }
 
-const MenuPatch: NavContextMenuPatchCallback = (children, { channel }) => {
+const MenuPatch: NavContextMenuPatchCallback = (children) => {
     children.push(
         <Menu.MenuItem
             id="auto-jump"

--- a/src/equicordplugins/AutoJump/index.tsx
+++ b/src/equicordplugins/AutoJump/index.tsx
@@ -6,14 +6,29 @@
 
 import { EquicordDevs } from "@utils/constants";
 import definePlugin from "@utils/types";
-import { ComponentDispatch } from "@webpack/common";
+import { Menu, ComponentDispatch } from "@webpack/common";
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 
 let lastChannelId: string | null = null;
+const MenuPatch: NavContextMenuPatchCallback = (children) => {
+    children.push(
+        <Menu.MenuItem
+            id="auto-jump"
+            label="Jump to Last Message"
+            action={() => ComponentDispatch.dispatch("SCROLLTO_PRESENT")}
+        />
+    );
+};
 
 export default definePlugin({
     name: "AutoJump",
     description: "Automatically jump to the bottom when switching channels.",
     authors: [EquicordDevs.omaw],
+    contextMenus: {
+        "channel-context": MenuPatch,
+        "user-context": MenuPatch,
+        "thread-context": MenuPatch
+    },
     flux: {
         CHANNEL_SELECT({ channelId, messageId }) {
             if (!channelId || messageId || lastChannelId === channelId) return;

--- a/src/equicordplugins/AutoJump/index.tsx
+++ b/src/equicordplugins/AutoJump/index.tsx
@@ -1,70 +1,19 @@
-/*
- * Vencord, a Discord client mod
- * Copyright (c) 2024 Vendicated and contributors
- * SPDX-License-Identifier: GPL-3.0-or-later
- */
-
-import { NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { EquicordDevs } from "@utils/constants";
 import definePlugin from "@utils/types";
-import { Menu, ChannelStore, ComponentDispatch } from "@webpack/common";
+import { ComponentDispatch } from "@webpack/common";
 
-interface ChannelSelectEvent {
-    type: "CHANNEL_SELECT";
-    channelId: string | null;
-    guildId: string | null;
-    messageId?: string | null;
-}
+let lastChannelId: string | null = null;
 
-let lastChannelId = "0";
-
-function autoJump(channel: any) {
-    const guildId = channel.guild_id ?? "@me";
-    const channelId = channel.id;
-
-    if (channelId === lastChannelId) return;
-
-    lastChannelId = channelId;
-
-    ComponentDispatch.dispatch("SCROLLTO_PRESENT");
-}
-
-const MenuPatch: NavContextMenuPatchCallback = (children) => {
-    children.push(
-        <Menu.MenuItem
-            id="auto-jump"
-            label="Jump to Last Message"
-            action={() => ComponentDispatch.dispatch("SCROLLTO_PRESENT")}
-        />
-    );
-};
-
+// credits to prism for removing useless pieces of code 
 export default definePlugin({
     name: "AutoJump",
-    description: "Automatically jumps to the last message when selecting a channel.",
+    description: "Automatically jump to the bottom when switching channels.",
     authors: [EquicordDevs.omaw],
-    
-    contextMenus: {
-        "channel-context": MenuPatch,
-        "user-context": MenuPatch,
-        "thread-context": MenuPatch
-    },
-    
     flux: {
-        async CHANNEL_SELECT(event: ChannelSelectEvent) {
-            const { guildId, channelId, messageId } = event;
-            
-            if (!guildId || !channelId) return;
-            if (lastChannelId === channelId) return;
-            if (messageId) {
-                lastChannelId = channelId;
-                return;
-            }
-            
-            const channel = ChannelStore.getChannel(channelId);
-            if (!channel) return;
-            
-            autoJump(channel);
+        CHANNEL_SELECT({ channelId, messageId }) {
+            if (!channelId || messageId || lastChannelId === channelId) return;
+            lastChannelId = channelId;
+            ComponentDispatch.dispatch("SCROLLTO_PRESENT");
         }
     }
 });

--- a/src/equicordplugins/AutoJump/index.tsx
+++ b/src/equicordplugins/AutoJump/index.tsx
@@ -10,7 +10,6 @@ import { ComponentDispatch } from "@webpack/common";
 
 let lastChannelId: string | null = null;
 
-// credits to prism for removing useless pieces of code 
 export default definePlugin({
     name: "AutoJump",
     description: "Automatically jump to the bottom when switching channels.",
@@ -23,5 +22,3 @@ export default definePlugin({
         }
     }
 });
-
-


### PR DESCRIPTION
- Fixes Issue with not being able to jump to Inbox message(s).
- Uses a more reliable method which doesn't disrupt any activity on Discord
- Ensures it doesn't jump for most recent message(s) when changing.
- Adds Context Menu Options for (Thread, DM,  & Channel)
- Discord has a really annoying issue where you have to constantly scroll this is useful for people with themes having it automated is better for users.