### PR TITLE
add/cleanChannelGroups

### DIFF
--- a/src/equicordplugins/cleanerChannelGroups/index.ts
+++ b/src/equicordplugins/cleanerChannelGroups/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "CleanerChannelGroups",
+    description: "Hides all channels in collapsed categories, even if they have unread messages.",
+    authors: [EquicordDevs.justjxke],
+    patches: [
+        {
+            find: '"placeholder-channel-id"',
+            replacement: [
+                {
+                    match: /this\.category\.isCollapsed&&\(.{0,600}?\)\?\{renderLevel:3,threadIds:(\i)\}:\{renderLevel:4,threadIds:\1\}/,
+                    replace: "this.category.isCollapsed?{renderLevel:3,threadIds:$1}:{renderLevel:4,threadIds:$1}"
+                },
+                {
+                    match: /(\i)=ev\(this\.record,\i,\i,\i,\i\.hideMutedChannels\);/,
+                    replace: "$&this.category.isCollapsed&&($1=[]);"
+                }
+            ]
+        }
+    ]
+});

--- a/src/equicordplugins/cleanerChannelGroups/index.ts
+++ b/src/equicordplugins/cleanerChannelGroups/index.ts
@@ -16,12 +16,12 @@ export default definePlugin({
             find: '"placeholder-channel-id"',
             replacement: [
                 {
-                    match: /this\.category\.isCollapsed&&\(.{0,600}?\)\?\{renderLevel:3,threadIds:(\i)\}:\{renderLevel:4,threadIds:\1\}/,
-                    replace: "this.category.isCollapsed?{renderLevel:3,threadIds:$1}:{renderLevel:4,threadIds:$1}"
+                    match: /this\.category\.isCollapsed&&\(.{0,600}?\)\?\{renderLevel:3,threadIds:/,
+                    replace: "this.category.isCollapsed?{renderLevel:3,threadIds:"
                 },
                 {
-                    match: /(\i)=ev\(this\.record,\i,\i,\i,\i\.hideMutedChannels\);/,
-                    replace: "$&this.category.isCollapsed&&($1=[]);"
+                    match: /(?<=!this.category.isCollapsed.{0,50}\i=)(\i\(this\.record,.{0,5},\i\.hideMutedChannels\);)/,
+                    replace: "this.category.isCollapsed?[]:$1"
                 }
             ]
         }


### PR DESCRIPTION
this plugin makes it so unread channels do not show when a category is minimized, this includes forums and threads and channels with threads too. making the category look clean when minimized.