### PR TITLE
feat(plugin): Add GuildExport plugin

### DIFF
--- a/src/equicordplugins/guildExport/ExportModal.tsx
+++ b/src/equicordplugins/guildExport/ExportModal.tsx
@@ -1,0 +1,193 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Button } from "@components/Button";
+import { Divider } from "@components/Divider";
+import { Heading } from "@components/Heading";
+import { Margins } from "@utils/margins";
+import {
+    ModalCloseButton,
+    ModalContent,
+    ModalFooter,
+    ModalHeader,
+    ModalProps,
+    ModalRoot,
+    ModalSize,
+} from "@utils/modal";
+import {
+    Checkbox,
+    React,
+    SearchableSelect,
+    Slider,
+    TextInput
+} from "@webpack/common";
+
+import { settings } from "./index";
+
+interface ExportModalProps {
+    modalProps: ModalProps;
+    guild: { id: string; name: string };
+    onExport: (guildId: string) => void;
+}
+
+export function ExportModal({ modalProps, guild, onExport }: ExportModalProps) {
+    const s = settings.use();
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.MEDIUM}>
+            <ModalHeader>
+                <Heading tag="h2" style={{ flexGrow: 1 }}>
+                    Export Guild "{guild.name}"
+                </Heading>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+
+            <ModalContent className={Margins.bottom20}>
+                <section className={Margins.bottom16}>
+                    <Heading tag="h3">Export Mode</Heading>
+                    <SearchableSelect
+                        options={[
+                            { label: "Folder", value: "Folder" },
+                            { label: "Zip (Save)", value: "ZipSave" },
+                            { label: "Zip (Send)", value: "ZipSend" },
+                        ]}
+                        value={s.exportMode as any}
+                        onChange={v => settings.store.exportMode = v as any}
+                    />
+                </section>
+
+                {s.exportMode === "Folder" && (
+                    <section className={Margins.bottom16}>
+                        <Heading tag="h3">Export Directory</Heading>
+                        <TextInput
+                            value={s.exportDirectory}
+                            placeholder="C:\GuildExports"
+                            onChange={v => settings.store.exportDirectory = v}
+                        />
+                    </section>
+                )}
+
+                {s.exportMode === "ZipSend" && (
+                    <section className={Margins.bottom16}>
+                        <Heading tag="h3">Send to Channel ID</Heading>
+                        <TextInput
+                            value={s.sendToChannelId}
+                            placeholder="1234567890..."
+                            onChange={v => settings.store.sendToChannelId = v}
+                        />
+                    </section>
+                )}
+
+                <Divider className={Margins.bottom16} />
+
+                <Heading tag="h3" className={Margins.bottom8}>What to export</Heading>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "8px" }}>
+                    <Checkbox
+                        value={s.exportInfo}
+                        onChange={(_e, v) => settings.store.exportInfo = v}
+                    >
+                        Info
+                    </Checkbox>
+                    <Checkbox
+                        value={s.exportChannels}
+                        onChange={(_e, v) => settings.store.exportChannels = v}
+                    >
+                        Channels
+                    </Checkbox>
+                    <Checkbox
+                        value={s.exportRoles}
+                        onChange={(_e, v) => settings.store.exportRoles = v}
+                    >
+                        Roles
+                    </Checkbox>
+                    <Checkbox
+                        value={s.exportAutomod}
+                        onChange={(_e, v) => settings.store.exportAutomod = v}
+                    >
+                        Automod
+                    </Checkbox>
+                    <Checkbox
+                        value={s.exportBans}
+                        onChange={(_e, v) => settings.store.exportBans = v}
+                    >
+                        Banned Users
+                    </Checkbox>
+                    <Checkbox
+                        value={s.exportMembers}
+                        onChange={(_e, v) => settings.store.exportMembers = v}
+                    >
+                        Members
+                    </Checkbox>
+                    <Checkbox
+                        value={s.exportEmojis}
+                        onChange={(_e, v) => settings.store.exportEmojis = v}
+                    >
+                        Emojis
+                    </Checkbox>
+                    <Checkbox
+                        value={s.exportStickers}
+                        onChange={(_e, v) => settings.store.exportStickers = v}
+                    >
+                        Stickers
+                    </Checkbox>
+                    <Checkbox
+                        value={s.exportSounds}
+                        onChange={(_e, v) => settings.store.exportSounds = v}
+                    >
+                        Sounds
+                    </Checkbox>
+                </div>
+
+                <Divider className={Margins.top16} />
+                <Divider className={Margins.bottom16} />
+
+                <section className={Margins.bottom16}>
+                    <Heading tag="h3">Export files as</Heading>
+                    <SearchableSelect
+                        options={[
+                            { label: "IDs (Unique, Safe)", value: "IDs" },
+                            { label: "Names (Sanitized)", value: "Names" },
+                        ]}
+                        value={s.filenameFormat as any}
+                        onChange={v => settings.store.filenameFormat = v as any}
+                    />
+                </section>
+
+                <section className={Margins.bottom16}>
+                    <Heading tag="h3">Delay between actions (ms)</Heading>
+                    <Slider
+                        markers={[0, 100, 250, 500, 1000, 2000]}
+                        minValue={0}
+                        maxValue={2000}
+                        initialValue={s.actionDelay}
+                        onValueChange={v => settings.store.actionDelay = Math.round(v)}
+                        onValueRender={v => `${Math.round(v)}ms`}
+                        stickToMarkers={false}
+                    />
+                </section>
+            </ModalContent>
+
+            <ModalFooter>
+                <Button
+                    onClick={() => {
+                        onExport(guild.id);
+                        modalProps.onClose();
+                    }}
+                    variant="positive"
+                >
+                    Export
+                </Button>
+                <div style={{ width: "16px" }} />
+                <Button
+                    onClick={modalProps.onClose}
+                    variant="link"
+                >
+                    Cancel
+                </Button>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/equicordplugins/guildExport/exporters/assetExporter.ts
+++ b/src/equicordplugins/guildExport/exporters/assetExporter.ts
@@ -1,0 +1,144 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { EmojiStore, GuildStore, IconUtils, RestAPI, SoundboardStore, StickersStore } from "@webpack/common";
+
+import { ExporterFunc } from "./types";
+import { downloadAsset, removeNullValues, sanitize, sleep } from "./utils";
+
+export const exportEmojis: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting emojis...");
+    let emojis = EmojiStore.getGuildEmoji(ctx.guildId);
+
+    if (!emojis || emojis.length === 0) {
+        ctx.logger.info("Emojis not found in store, fetching from API...");
+        try {
+            const resp = await RestAPI.get({
+                url: `/guilds/${ctx.guildId}/emojis`
+            });
+            if (resp.ok && Array.isArray(resp.body)) {
+                emojis = resp.body;
+            }
+        } catch (e) {
+            ctx.logger.error("Failed to fetch emojis from API", e);
+        }
+    }
+
+    const emojiList = emojis || [];
+    ctx.logger.info(`Found ${emojiList.length} emojis`);
+    await ctx.save("emojis.json", JSON.stringify(removeNullValues(emojiList), null, 2));
+
+    for (const emoji of emojiList) {
+        const ext = emoji.animated ? ".gif" : ".png";
+        const endpoint = window.GLOBAL_ENV.MEDIA_PROXY_ENDPOINT;
+        const url = `https:${endpoint}/emojis/${emoji.id}${ext}?size=512&quality=lossless`;
+        const name = ctx.filenameFormat === "Names" ? `${sanitize(emoji.name)}_${emoji.id}` : emoji.id;
+
+        ctx.logger.info(`Downloading emoji: ${emoji.name} (${emoji.id})`);
+        await downloadAsset(url, `emojis/${name}${ext}`, ctx);
+        if (ctx.actionDelay > 0) await sleep(ctx.actionDelay);
+    }
+};
+
+export const exportStickers: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting stickers...");
+    let stickers = StickersStore.getStickersByGuildId(ctx.guildId);
+
+    if (!stickers || stickers.length === 0) {
+        ctx.logger.info("Stickers not found in store, fetching from API...");
+        try {
+            const resp = await RestAPI.get({
+                url: `/guilds/${ctx.guildId}/stickers`
+            });
+            if (resp.ok && Array.isArray(resp.body)) {
+                stickers = resp.body;
+            }
+        } catch (e) {
+            ctx.logger.error("Failed to fetch stickers from API", e);
+        }
+    }
+
+    const stickerList = stickers || [];
+    ctx.logger.info(`Found ${stickerList.length} stickers`);
+    await ctx.save("stickers.json", JSON.stringify(removeNullValues(stickerList), null, 2));
+
+    for (const sticker of stickerList) {
+        // Handle both API (format_type) and Store (formatType) camelCase/snake_case
+        const formatType = sticker.format_type ?? (sticker as any).formatType;
+        const ext = formatType === 4 ? ".gif" : ".png";
+        const url = `https://cdn.discordapp.com/stickers/${sticker.id}${ext}`;
+        const name = ctx.filenameFormat === "Names" ? `${sanitize(sticker.name)}_${sticker.id}` : sticker.id;
+
+        ctx.logger.info(`Downloading sticker: ${sticker.name} (${sticker.id})`);
+        await downloadAsset(url, `stickers/${name}${ext}`, ctx);
+        if (ctx.actionDelay > 0) await sleep(ctx.actionDelay);
+    }
+};
+
+export const exportSounds: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting soundboard sounds...");
+    let sounds = SoundboardStore.getSoundsForGuild(ctx.guildId);
+
+    if (!sounds || sounds.length === 0) {
+        ctx.logger.info("Sounds not found in store, fetching from API...");
+        try {
+            const resp = await RestAPI.get({
+                url: `/guilds/${ctx.guildId}/soundboard-sounds`
+            });
+            if (resp.ok && resp.body?.items) {
+                sounds = resp.body.items;
+            }
+        } catch (e) {
+            ctx.logger.error("Failed to fetch sounds from API", e);
+        }
+    }
+
+    const soundList = (sounds || []) as any[];
+    ctx.logger.info(`Found ${soundList.length} soundboard sounds`);
+
+    const processedSounds = soundList.map(sound => {
+        const { user, ...rest } = sound;
+        return {
+            ...rest,
+            user_id: user?.id || rest.user_id || rest.userId
+        };
+    });
+
+    await ctx.save("sounds.json", JSON.stringify(removeNullValues(processedSounds), null, 2));
+
+    for (const sound of soundList) {
+        const soundId = (sound as any).sound_id || (sound as any).soundId;
+        const soundName = sound.name || "Unknown Sound";
+        const url = `https://cdn.discordapp.com/soundboard-sounds/${soundId}`;
+        const name = ctx.filenameFormat === "Names" ? `${sanitize(soundName)}_${soundId}` : soundId;
+
+        ctx.logger.info(`Downloading sound: ${soundName} (${soundId})`);
+        await downloadAsset(url, `sounds/${name}.mp3`, ctx);
+        if (ctx.actionDelay > 0) await sleep(ctx.actionDelay);
+    }
+};
+
+export const exportGuildAssets: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting guild assets (Icon/Banner)...");
+    const guild = GuildStore.getGuild(ctx.guildId);
+    if (!guild) return;
+
+    if (guild.icon) {
+        const iconUrl = IconUtils.getGuildIconURL(guild);
+        if (iconUrl) {
+            const ext = iconUrl.includes(".gif") ? ".gif" : ".png";
+            await downloadAsset(iconUrl, `icon${ext}`, ctx);
+        }
+    }
+
+    if (guild.banner) {
+        const bannerUrl = IconUtils.getGuildBannerURL(guild);
+        if (bannerUrl) {
+            const ext = bannerUrl.includes(".gif") ? ".gif" : ".png";
+            await downloadAsset(bannerUrl, `banner${ext}`, ctx);
+        }
+    }
+};

--- a/src/equicordplugins/guildExport/exporters/banExporter.ts
+++ b/src/equicordplugins/guildExport/exporters/banExporter.ts
@@ -1,0 +1,49 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { RestAPI } from "@webpack/common";
+
+import { ExporterFunc } from "./types";
+import { removeNullValues, sleep } from "./utils";
+
+export const exportBans: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting bans...");
+    const url = `/guilds/${ctx.guildId}/bans`;
+    ctx.logger.info(`Fetching bans from ${url}`);
+    try {
+        let allBans: any[] = [];
+        let after: string | null = null;
+        let hasMore = true;
+
+        while (hasMore) {
+            const query: any = { limit: 1000 };
+            if (after) query.after = after;
+
+            const resp = await (RestAPI as any).get({ url, query });
+            if (resp.ok) {
+                const bans = resp.body || [];
+                allBans = [...allBans, ...bans];
+                ctx.logger.info(`Fetched ${bans.length} bans (Total: ${allBans.length})`);
+
+                if (bans.length < 1000) {
+                    hasMore = false;
+                } else {
+                    after = bans[bans.length - 1].user.id;
+                }
+            } else {
+                ctx.logger.error(`Failed to fetch bans: ${resp.status} - ${resp.body?.message || JSON.stringify(resp.body)}`);
+                hasMore = false;
+            }
+            if (hasMore) await sleep(ctx.actionDelay || 500);
+        }
+
+        ctx.logger.info(`Successfully fetched ${allBans.length} bans`);
+        await ctx.save("bans.json", JSON.stringify(removeNullValues(allBans), null, 2));
+    } catch (e: any) {
+        ctx.logger.error(`Failed to fetch guild bans: ${e?.message || e}`, e);
+    }
+    await sleep(ctx.actionDelay);
+};

--- a/src/equicordplugins/guildExport/exporters/channelExporter.ts
+++ b/src/equicordplugins/guildExport/exporters/channelExporter.ts
@@ -1,0 +1,17 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { GuildChannelStore } from "@webpack/common";
+
+import { ExporterFunc } from "./types";
+import { removeNullValues, sleep } from "./utils";
+
+export const exportChannels: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting channels...");
+    const channels = GuildChannelStore.getChannels(ctx.guildId) || [];
+    await ctx.save("channels.json", JSON.stringify(removeNullValues(channels), null, 2));
+    await sleep(ctx.actionDelay);
+};

--- a/src/equicordplugins/guildExport/exporters/infoExporter.ts
+++ b/src/equicordplugins/guildExport/exporters/infoExporter.ts
@@ -1,0 +1,47 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { GuildMemberCountStore, GuildStore, UserGuildSettingsStore } from "@webpack/common";
+
+import { ExporterFunc } from "./types";
+import { removeNullValues, sleep } from "./utils";
+
+export const exportInfo: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting general information...");
+    const guild = GuildStore.getGuild(ctx.guildId);
+    if (!guild) return;
+
+    const info = {
+        id: guild.id,
+        name: guild.name,
+        icon: guild.icon,
+        description: guild.description,
+        ownerId: guild.ownerId,
+        verificationLevel: guild.verificationLevel,
+        rulesChannelId: guild.rulesChannelId,
+        publicUpdatesChannelId: guild.publicUpdatesChannelId,
+        preferredLocale: guild.preferredLocale,
+        features: guild.features,
+        vanityURLCode: guild.vanityURLCode,
+        nsfwLevel: guild.nsfwLevel,
+        premiumTier: guild.premiumTier,
+        premiumSubscriberCount: (guild as any).premiumSubscriberCount,
+        totalMembers: GuildMemberCountStore.getMemberCount(ctx.guildId),
+        activeMembers: (GuildMemberCountStore as any).getOnlineCount?.(ctx.guildId) || (GuildMemberCountStore as any).getOnlineMemberCount?.(ctx.guildId),
+    };
+    await ctx.save("info.json", JSON.stringify(removeNullValues(info), null, 2));
+
+    try {
+        const guildSettings = (UserGuildSettingsStore as any).getAllSettings?.()?.[ctx.guildId];
+        if (guildSettings) {
+            await ctx.save("settings.json", JSON.stringify(removeNullValues(guildSettings), null, 2));
+        }
+    } catch (e) {
+        ctx.logger.warn("Failed to fetch guild settings", e);
+    }
+
+    await sleep(ctx.actionDelay);
+};

--- a/src/equicordplugins/guildExport/exporters/memberExporter.ts
+++ b/src/equicordplugins/guildExport/exporters/memberExporter.ts
@@ -1,0 +1,42 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { GuildMemberStore, RestAPI } from "@webpack/common";
+
+import { ExporterFunc } from "./types";
+import { removeNullValues, sleep } from "./utils";
+
+export const exportMembers: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting members...");
+    // Try to get members from store first
+    let members = GuildMemberStore.getMembers(ctx.guildId);
+
+    if (!members || members.length <= 1) { // 1 might just be the current user
+        ctx.logger.info("Members not found or incomplete in store, fetching from API...");
+        try {
+            // Discord's internal RestAPI usually needs the full path or it handles prefixes
+            // We'll try the most likely path
+            const resp = await RestAPI.get({
+                url: `/guilds/${ctx.guildId}/members`,
+                query: { limit: 1000 }
+            });
+
+            if (resp.ok && Array.isArray(resp.body)) {
+                members = resp.body;
+            } else if (resp.ok && resp.body?.members) {
+                 members = resp.body.members;
+            }
+        } catch (e) {
+            ctx.logger.error("Failed to fetch members from API", e);
+        }
+    }
+
+    const memberList = members || [];
+    ctx.logger.info(`Found ${memberList.length} members`);
+    await ctx.save("members.json", JSON.stringify(removeNullValues(memberList), null, 2));
+
+    await sleep(ctx.actionDelay);
+};

--- a/src/equicordplugins/guildExport/exporters/roleExporter.ts
+++ b/src/equicordplugins/guildExport/exporters/roleExporter.ts
@@ -1,0 +1,32 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Constants, GuildRoleStore, RestAPI } from "@webpack/common";
+
+import { ExporterFunc } from "./types";
+import { removeNullValues, sleep } from "./utils";
+
+export const exportRoles: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting roles...");
+    const roles = GuildRoleStore.getRolesSnapshot(ctx.guildId) || [];
+    await ctx.save("roles.json", JSON.stringify(removeNullValues(roles), null, 2));
+    await sleep(ctx.actionDelay);
+};
+
+export const exportAutomod: ExporterFunc = async ctx => {
+    ctx.setProgress("Exporting automod rules...");
+    try {
+        const automodRules = await RestAPI.get({
+            url: (Constants.Endpoints as any).GUILD_AUTOMOD_RULES(ctx.guildId)
+        });
+        if (automodRules.ok) {
+            await ctx.save("automod.json", JSON.stringify(removeNullValues(automodRules.body), null, 2));
+        }
+    } catch (e) {
+        ctx.logger.warn("Failed to fetch automod rules", e);
+    }
+    await sleep(ctx.actionDelay);
+};

--- a/src/equicordplugins/guildExport/exporters/types.ts
+++ b/src/equicordplugins/guildExport/exporters/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface ExporterContext {
+    guildId: string;
+    actionDelay: number;
+    filenameFormat: "IDs" | "Names";
+    save: (path: string, data: Uint8Array | string) => Promise<void>;
+    logger: any;
+    setProgress: (status: string, type?: string) => void;
+}
+
+export type ExporterFunc = (ctx: ExporterContext) => Promise<void>;

--- a/src/equicordplugins/guildExport/exporters/utils.ts
+++ b/src/equicordplugins/guildExport/exporters/utils.ts
@@ -1,0 +1,73 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { getNative } from "../nativeUtils";
+import { ExporterContext } from "./types";
+
+export const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export const sanitize = (name: string) => name.replace(/[<>:"/\\|?*]/g, "_");
+
+export async function downloadAsset(url: string, path: string, ctx: ExporterContext) {
+    try {
+        const native = getNative();
+        let uint8: Uint8Array | null = null;
+
+        if (native?.fetchAsset) {
+            uint8 = await native.fetchAsset(url);
+        } else {
+            const resp = await fetch(url);
+            if (resp.ok) {
+                uint8 = new Uint8Array(await resp.arrayBuffer());
+            } else {
+                ctx.logger.error(`Failed to download asset: ${url} (Status: ${resp.status})`);
+                return;
+            }
+        }
+
+        if (uint8) {
+            ctx.logger.info(`Saving asset to ${path} (${uint8.length} bytes)`);
+            await ctx.save(path, uint8);
+        } else {
+            ctx.logger.error(`Failed to fetch asset (empty data): ${url}`);
+        }
+    } catch (e) {
+        ctx.logger.error(`Error downloading asset: ${url}`, e);
+    }
+}
+
+/**
+ * Recursively removes null values, empty strings, and empty objects/arrays
+ */
+export function removeNullValues<T>(obj: T): T | null {
+    if (obj === null || obj === undefined || (typeof obj === "string" && obj === "")) {
+        return null;
+    }
+
+    if (Array.isArray(obj)) {
+        const cleanedArray = obj
+            .map(item => removeNullValues(item))
+            .filter(item => item !== null && item !== undefined);
+
+        return cleanedArray.length > 0 ? (cleanedArray as unknown as T) : null;
+    }
+
+    if (typeof obj === "object") {
+        const result: any = {};
+        let hasProps = false;
+
+        for (const [key, value] of Object.entries(obj)) {
+            const cleanedValue = removeNullValues(value);
+            if (cleanedValue !== null && cleanedValue !== undefined) {
+                result[key] = cleanedValue;
+                hasProps = true;
+            }
+        }
+        return hasProps ? (result as T) : null;
+    }
+
+    return obj;
+}

--- a/src/equicordplugins/guildExport/index.tsx
+++ b/src/equicordplugins/guildExport/index.tsx
@@ -1,0 +1,313 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { popNotice, showNotice } from "@api/Notices";
+import { definePluginSettings } from "@api/Settings";
+import { Logger } from "@utils/Logger";
+import { openModal } from "@utils/modal";
+import definePlugin, { OptionType } from "@utils/types";
+import {
+    GuildStore,
+    Menu,
+    MessageActions,
+    showToast,
+    Toasts } from "@webpack/common";
+import { zipSync } from "fflate";
+
+import * as AssetEx from "./exporters/assetExporter";
+import * as BanEx from "./exporters/banExporter";
+import * as ChanEx from "./exporters/channelExporter";
+import * as InfoEx from "./exporters/infoExporter";
+import * as MemberEx from "./exporters/memberExporter";
+import * as RoleEx from "./exporters/roleExporter";
+import { ExporterContext } from "./exporters/types";
+import { sanitize } from "./exporters/utils";
+import { ExportModal } from "./ExportModal";
+import { getNative } from "./nativeUtils";
+
+const logger = new Logger("GuildExport", "#7289da");
+const EXPORT_NOTICE_BUTTON_TEXT = "Abort Export";
+
+export const settings = definePluginSettings({
+    exportDirectory: {
+        type: OptionType.STRING,
+        description: "The directory to export data to (if not using ZIP)",
+        default: "C:\\GuildExports",
+        restartNeeded: false,
+    },
+    exportMode: {
+        type: OptionType.SELECT,
+        description: "How to export the data",
+        options: [
+            { label: "Folder", value: "Folder" },
+            { label: "Zip (Save)", value: "ZipSave", default: true },
+            { label: "Zip (Send)", value: "ZipSend" },
+        ],
+        restartNeeded: false,
+    },
+    sendToChannelId: {
+        type: OptionType.STRING,
+        description: "Channel ID to send the ZIP to (if using Zip (Send))",
+        default: "",
+        restartNeeded: false,
+    },
+    exportInfo: {
+        type: OptionType.BOOLEAN,
+        description: "Export general guild info",
+        default: true,
+        restartNeeded: false,
+    },
+    exportChannels: {
+        type: OptionType.BOOLEAN,
+        description: "Export channels and their structures",
+        default: true,
+        restartNeeded: false,
+    },
+    exportRoles: {
+        type: OptionType.BOOLEAN,
+        description: "Export roles and their permissions",
+        default: true,
+        restartNeeded: false,
+    },
+    exportAutomod: {
+        type: OptionType.BOOLEAN,
+        description: "Export automod rules",
+        default: true,
+        restartNeeded: false,
+    },
+    exportBans: {
+        type: OptionType.BOOLEAN,
+        description: "Export banned users",
+        default: true,
+        restartNeeded: false,
+    },
+    exportMembers: {
+        type: OptionType.BOOLEAN,
+        description: "Export members (cached only)",
+        default: true,
+        restartNeeded: false,
+    },
+    exportEmojis: {
+        type: OptionType.BOOLEAN,
+        description: "Export custom emojis",
+        default: true,
+        restartNeeded: false,
+    },
+    exportStickers: {
+        type: OptionType.BOOLEAN,
+        description: "Export custom stickers",
+        default: true,
+        restartNeeded: false,
+    },
+    exportSounds: {
+        type: OptionType.BOOLEAN,
+        description: "Export soundboard sounds",
+        default: true,
+        restartNeeded: false,
+    },
+    filenameFormat: {
+        type: OptionType.SELECT,
+        description: "How to name exported asset files",
+        options: [
+            { label: "IDs (Unique, Safe)", value: "IDs", default: true },
+            { label: "Names (Sanitized)", value: "Names" },
+        ],
+        restartNeeded: false,
+    },
+    actionDelay: {
+        type: OptionType.SLIDER,
+        description: "Delay between API calls and asset downloads (ms)",
+        markers: [0, 100, 250, 500, 1000, 2000],
+        default: 250,
+        restartNeeded: false,
+    },
+});
+
+async function exportGuildData(guildId: string) {
+    const guild = GuildStore.getGuild(guildId);
+    if (!guild) {
+        showToast("Guild not found", Toasts.Type.FAILURE);
+        return;
+    }
+
+    const s = settings.store;
+    showToast(`Exporting ${guild.name}...`, Toasts.Type.MESSAGE);
+    logger.info(`Starting export for guild: ${guild.name} (${guildId})`);
+
+    const setProgress = (status: string, type = "GENERIC") => {
+        logger.info(status);
+        popNotice();
+        showNotice(
+            <div style={{ padding: "8px 0" }}>
+                <strong>Exporting {guild.name}...</strong>
+                <div style={{ marginTop: "4px", fontSize: "12px", color: "var(--text-muted)" }}>
+                    {status}
+                </div>
+            </div>,
+            EXPORT_NOTICE_BUTTON_TEXT,
+            () => {
+                popNotice();
+                showToast("Export aborted", Toasts.Type.MESSAGE);
+            }
+        );
+    };
+
+    showNotice(
+        <div style={{ padding: "8px 0" }}>
+            <strong>Exporting {guild.name}...</strong>
+            <div style={{ marginTop: "4px", fontSize: "12px", color: "var(--text-muted)" }}>
+                Please wait while we gather all the data. Large servers may take a while.
+            </div>
+        </div>,
+        EXPORT_NOTICE_BUTTON_TEXT,
+        () => {
+            popNotice();
+            showToast("Export aborted", Toasts.Type.MESSAGE);
+        }
+    );
+
+    try {
+        const zipData: Record<string, Uint8Array> = {};
+        const native = getNative();
+        const exportToFolder = s.exportMode === "Folder" && native;
+
+        if (s.exportMode === "Folder" && !native) {
+            showToast("Direct folder export is not supported on Web. Falling back to ZIP.", Toasts.Type.MESSAGE);
+        }
+
+        const save = async (path: string, data: string | Uint8Array | undefined) => {
+            if (data === undefined) return;
+            const uint8 = typeof data === "string" ? new TextEncoder().encode(data) : data;
+            if (exportToFolder) {
+                logger.info(`Saving to folder: ${path} (${uint8.length} bytes)`);
+                await native!.saveFile(s.exportDirectory, path, data);
+            } else {
+                logger.info(`Adding to ZIP: ${path} (${uint8.length} bytes)`);
+                zipData[path] = uint8;
+            }
+        };
+
+        const ctx: ExporterContext = {
+            guildId,
+            actionDelay: s.actionDelay,
+            filenameFormat: s.filenameFormat as any,
+            save,
+            logger,
+            setProgress,
+        };
+
+        if (s.exportInfo) await InfoEx.exportInfo(ctx);
+        if (s.exportRoles) await RoleEx.exportRoles(ctx);
+        if (s.exportChannels) await ChanEx.exportChannels(ctx);
+        if (s.exportAutomod) await RoleEx.exportAutomod(ctx);
+        if (s.exportBans) await BanEx.exportBans(ctx);
+        if (s.exportMembers) await MemberEx.exportMembers(ctx);
+        if (s.exportInfo) await AssetEx.exportGuildAssets(ctx);
+        if (s.exportEmojis) await AssetEx.exportEmojis(ctx);
+        if (s.exportStickers) await AssetEx.exportStickers(ctx);
+        if (s.exportSounds) await AssetEx.exportSounds(ctx);
+
+        // Generate and download ZIP or finish Folder export
+        if (!exportToFolder) {
+            const zipped = zipSync(zipData);
+            const fileName = `${sanitize(guild.name)}_export.zip`;
+
+            if (s.exportMode === "ZipSend" && s.sendToChannelId) {
+                const file = new File([zipped as any], fileName, { type: "application/zip" });
+                try {
+                    // @ts-ignore
+                    const { CloudUploader } = await import("@webpack/common");
+                    if (CloudUploader) {
+                        CloudUploader.upload({
+                            channelId: s.sendToChannelId,
+                            file: { file, platform: 1 },
+                            draftType: 0
+                        });
+                    } else {
+                        // Fallback attempt with MessageActions if CloudUploader not found
+                        MessageActions.sendMessage(s.sendToChannelId, { content: "", invalidEmojis: [], validNonShortcutEmojis: [] }, null, {
+                            uploads: [{ file, platform: 1 }]
+                        });
+                    }
+                } catch (e) {
+                    logger.error("Failed to send ZIP to channel", e);
+                    showToast("Failed to send ZIP. Downloading instead.", Toasts.Type.FAILURE);
+                    const blob = new Blob([zipped as any], { type: "application/zip" });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement("a");
+                    a.href = url;
+                    a.download = fileName;
+                    a.click();
+                    URL.revokeObjectURL(url);
+                }
+            } else {
+                const blob = new Blob([zipped as any], { type: "application/zip" });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement("a");
+                a.href = url;
+                a.download = fileName;
+                a.click();
+                URL.revokeObjectURL(url);
+            }
+        }
+
+        showToast(`Exported ${guild.name} successfully!`, Toasts.Type.SUCCESS);
+        logger.info(`Export completed for guild: ${guild.name}`);
+
+        popNotice();
+        showNotice(
+            <div style={{ padding: "8px 0" }}>
+                <strong>Export Finished!</strong>
+                <div style={{ marginTop: "4px", fontSize: "12px", color: "var(--text-muted)" }}>
+                    Successfully exported {guild.name}.
+                </div>
+            </div>,
+            "Close",
+            () => popNotice()
+        );
+    } catch (error) {
+        logger.error("Failed to export guild data", error);
+        showToast("Failed to export guild data", Toasts.Type.FAILURE);
+
+        popNotice();
+        showNotice(
+            <div style={{ padding: "8px 0" }}>
+                <strong>Export Failed!</strong>
+                <div style={{ marginTop: "4px", fontSize: "12px", color: "var(--text-muted)" }}>
+                    {String(error)}
+                </div>
+            </div>,
+            "Close",
+            () => popNotice()
+        );
+    }
+}
+
+const GuildContextMenu: NavContextMenuPatchCallback = (children, { guild }) => {
+    if (!guild) return;
+
+    children.push(
+        <Menu.MenuItem
+            id="blu-guild-export"
+            label="Export Server"
+            action={() => openModal(props => <ExportModal modalProps={props} guild={guild} onExport={exportGuildData} />)}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "GuildExport",
+    description: "Export guild info, assets, and settings to a ZIP file.",
+    authors: [
+        { name: "Bluscream", id: 331103316650393611n },
+        { name: "Antigravity AI", id: 0n }
+    ],
+    settings,
+    contextMenus: {
+        "guild-context": GuildContextMenu,
+    }
+});

--- a/src/equicordplugins/guildExport/index.tsx
+++ b/src/equicordplugins/guildExport/index.tsx
@@ -300,10 +300,10 @@ const GuildContextMenu: NavContextMenuPatchCallback = (children, { guild }) => {
 };
 
 export default definePlugin({
-    name: "GuildExport",
+    name: "Guild Export",
     description: "Export guild info, assets, and settings to a ZIP file.",
     authors: [
-        { name: "Bluscream", id: 331103316650393611n },
+        { name: "Bluscream", id: 467777925790564352n },
         { name: "Antigravity AI", id: 0n }
     ],
     settings,

--- a/src/equicordplugins/guildExport/native.ts
+++ b/src/equicordplugins/guildExport/native.ts
@@ -1,0 +1,28 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export function bluGuildExportNativeMarker() { }
+
+// Electron IPC handlers always receive the event as the first argument
+export async function saveFile(_: any, baseDir: string, subPath: string, data: Uint8Array | string): Promise<void> {
+    const fullPath = path.join(baseDir, subPath);
+    const dir = path.dirname(fullPath);
+
+    await mkdir(dir, { recursive: true });
+
+    // If it's a Buffer/Uint8Array, write as is. If string, write as utf8.
+    const content = typeof data === "string" ? data : Buffer.from(data);
+    await writeFile(fullPath, content);
+}
+
+export async function fetchAsset(_: any, url: string): Promise<Uint8Array | null> {
+    const resp = await fetch(url);
+    if (!resp.ok) return null;
+    return new Uint8Array(await resp.arrayBuffer());
+}

--- a/src/equicordplugins/guildExport/nativeUtils.ts
+++ b/src/equicordplugins/guildExport/nativeUtils.ts
@@ -1,0 +1,17 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export function getNative() {
+    if (IS_WEB) return null;
+
+    const native = Object.values(VencordNative.pluginHelpers)
+        .find(m => (m as any).bluGuildExportNativeMarker);
+
+    return native as {
+        saveFile: (baseDir: string, subPath: string, data: Uint8Array | string) => Promise<void>;
+        fetchAsset: (url: string) => Promise<Uint8Array | null>;
+    } | null;
+}

--- a/src/equicordplugins/guildExport/schemas/automod.schema.json
+++ b/src/equicordplugins/guildExport/schemas/automod.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "guild_id": {
+        "type": "string"
+      },
+      "creator_id": {
+        "type": "string"
+      },
+      "name": {
+        "type": "string"
+      },
+      "event_type": {
+        "type": "integer"
+      },
+      "actions": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "integer"
+            },
+            "metadata": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "required": [
+            "type"
+          ]
+        }
+      },
+      "trigger_type": {
+        "type": "integer"
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "exempt_roles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "exempt_channels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "trigger_metadata": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    "required": [
+      "id",
+      "guild_id",
+      "creator_id",
+      "name",
+      "event_type",
+      "actions",
+      "trigger_type",
+      "enabled"
+    ]
+  },
+  "title": "Generated Schema",
+  "description": "JSON Schema generated from provided JSON data",
+  "examples": [
+    [
+      {
+        "id": "1216051673399824485",
+        "guild_id": "747967102895390741",
+        "creator_id": "188328025727827968",
+        "name": "Block Suspected Spam Content",
+        "event_type": 1,
+        "actions": [
+          {
+            "type": 1
+          },
+          {
+            "type": 2,
+            "metadata": {
+              "channel_id": "1218575234399993937"
+            }
+          }
+        ],
+        "trigger_type": 3,
+        "enabled": true,
+        "exempt_roles": [
+          "752594831704064202",
+          "748258358624256131",
+          "1196160570907426898",
+          "896309806447611974"
+        ],
+        "exempt_channels": [
+          "1218575234399993937",
+          "896433099100016750"
+        ]
+      }
+    ]
+  ]
+}

--- a/src/equicordplugins/guildExport/schemas/bans.schema.json
+++ b/src/equicordplugins/guildExport/schemas/bans.schema.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "user": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "avatar": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "discriminator": {
+            "type": "string"
+          },
+          "public_flags": {
+            "type": "integer"
+          },
+          "flags": {
+            "type": "integer"
+          },
+          "banner": {
+            "type": "string"
+          },
+          "accent_color": {
+            "type": "integer"
+          },
+          "global_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "avatar_decoration_data": {
+            "type": "object"
+          },
+          "collectibles": {
+            "type": "object"
+          },
+          "display_name_styles": {
+            "type": "object"
+          },
+          "banner_color": {
+            "type": "string"
+          },
+          "clan": {
+            "type": "object"
+          },
+          "primary_guild": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "discriminator",
+          "public_flags",
+          "flags"
+        ]
+      },
+      "reason": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
+    "required": [
+      "user"
+    ]
+  },
+  "title": "Generated Schema",
+  "description": "JSON Schema generated from provided JSON data",
+  "examples": [
+    [
+      {
+        "user": {
+          "id": "113486901326921728",
+          "username": "omatamatic",
+          "avatar": "47685a866bd4b923896e2055c5acb074",
+          "discriminator": "0",
+          "public_flags": 0,
+          "flags": 0,
+          "global_name": "Omata"
+        },
+        "reason": "Suspicious or spam account"
+      }
+    ]
+  ]
+}

--- a/src/equicordplugins/guildExport/schemas/channels.schema.json
+++ b/src/equicordplugins/guildExport/schemas/channels.schema.json
@@ -1,0 +1,455 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "4": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "comparator": {
+            "type": "integer"
+          },
+          "channel": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              },
+              "guild_id": {
+                "type": "null"
+              },
+              "permissionOverwrites_": {
+                "type": "object",
+                "properties": {}
+              }
+            },
+            "required": [
+              "id",
+              "type",
+              "name"
+            ]
+          }
+        },
+        "required": [
+          "comparator",
+          "channel"
+        ]
+      }
+    },
+    "id": {
+      "type": "string"
+    },
+    "SELECTABLE": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "channel": {
+            "type": "object",
+            "properties": {
+              "flags_": {
+                "type": "integer"
+              },
+              "guild_id": {
+                "type": "string"
+              },
+              "iconEmoji": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "null"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "id": {
+                "type": "string"
+              },
+              "lastMessageId": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "lastPinTimestamp": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "nsfw_": {
+                "type": "boolean"
+              },
+              "parent_id": {
+                "type": "string"
+              },
+              "permissionOverwrites_": {
+                "type": "object",
+                "properties": {
+                  "896309806447611974": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "integer"
+                      },
+                      "allow": {
+                        "type": "string"
+                      },
+                      "deny": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "type",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "896440828266967090": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "integer"
+                      },
+                      "allow": {
+                        "type": "string"
+                      },
+                      "deny": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "type",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "985544722300932160": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "integer"
+                      },
+                      "allow": {
+                        "type": "string"
+                      },
+                      "deny": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "type",
+                      "allow",
+                      "deny"
+                    ]
+                  },
+                  "747967102895390741": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "integer"
+                      },
+                      "allow": {
+                        "type": "string"
+                      },
+                      "deny": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "type",
+                      "allow",
+                      "deny"
+                    ]
+                  }
+                },
+                "required": []
+              },
+              "position_": {
+                "type": "integer"
+              },
+              "rateLimitPerUser_": {
+                "type": "integer"
+              },
+              "topic_": {
+                "type": "null"
+              },
+              "type": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "flags_",
+              "guild_id",
+              "id",
+              "name",
+              "nsfw_",
+              "parent_id",
+              "position_",
+              "rateLimitPerUser_",
+              "type"
+            ]
+          },
+          "comparator": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "channel",
+          "comparator"
+        ]
+      }
+    },
+    "VOCAL": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "channel": {
+            "type": "object",
+            "properties": {
+              "bitrate_": {
+                "type": "integer"
+              },
+              "flags_": {
+                "type": "integer"
+              },
+              "guild_id": {
+                "type": "string"
+              },
+              "iconEmoji": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "null"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "id": {
+                "type": "string"
+              },
+              "lastMessageId": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "name": {
+                "type": "string"
+              },
+              "nsfw_": {
+                "type": "boolean"
+              },
+              "parent_id": {
+                "type": "string"
+              },
+              "permissionOverwrites_": {
+                "type": "object",
+                "properties": {
+                  "747967102895390741": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "integer"
+                      },
+                      "allow": {
+                        "type": "string"
+                      },
+                      "deny": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "type",
+                      "allow",
+                      "deny"
+                    ]
+                  }
+                },
+                "required": [
+                  "747967102895390741"
+                ]
+              },
+              "position_": {
+                "type": "integer"
+              },
+              "rateLimitPerUser_": {
+                "type": "integer"
+              },
+              "rtcRegion": {
+                "type": "null"
+              },
+              "type": {
+                "type": "integer"
+              },
+              "userLimit_": {
+                "type": "integer"
+              }
+            },
+            "required": [
+              "bitrate_",
+              "flags_",
+              "guild_id",
+              "id",
+              "name",
+              "nsfw_",
+              "parent_id",
+              "position_",
+              "rateLimitPerUser_",
+              "type",
+              "userLimit_"
+            ]
+          },
+          "comparator": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "channel",
+          "comparator"
+        ]
+      }
+    },
+    "count": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id",
+    "count"
+  ],
+  "title": "Generated Schema",
+  "description": "JSON Schema generated from provided JSON data",
+  "examples": [
+    {
+      "4": [
+        {
+          "comparator": -1,
+          "channel": {
+            "id": "null",
+            "type": 4,
+            "name": "Uncategorized",
+            "guild_id": null
+          }
+        }
+      ],
+      "id": "747967102895390741",
+      "SELECTABLE": [
+        {
+          "channel": {
+            "flags_": 1,
+            "guild_id": "747967102895390741",
+            "iconEmoji": {
+              "name": "🤖"
+            },
+            "id": "896433099100016750",
+            "lastMessageId": "1468073249828114698",
+            "lastPinTimestamp": "2021-10-09T17:18:36+00:00",
+            "name": "bot-logs",
+            "nsfw_": false,
+            "parent_id": "1216821130342699078",
+            "permissionOverwrites_": {
+              "896309806447611974": {
+                "id": "896309806447611974",
+                "type": 0,
+                "allow": "1024",
+                "deny": "0"
+              },
+              "896440828266967090": {
+                "id": "896440828266967090",
+                "type": 0,
+                "allow": "515396455488",
+                "deny": "131072"
+              },
+              "985544722300932160": {
+                "id": "985544722300932160",
+                "type": 0,
+                "allow": "1024",
+                "deny": "0"
+              },
+              "747967102895390741": {
+                "id": "747967102895390741",
+                "type": 0,
+                "allow": "0",
+                "deny": "1024"
+              }
+            },
+            "position_": 0,
+            "rateLimitPerUser_": 0,
+            "type": 0
+          },
+          "comparator": 0
+        }
+      ],
+      "VOCAL": [
+        {
+          "channel": {
+            "bitrate_": 64000,
+            "flags_": 0,
+            "guild_id": "747967102895390741",
+            "iconEmoji": {
+              "name": "🎤"
+            },
+            "id": "838470186067165214",
+            "lastMessageId": "1463483893423411283",
+            "name": "voice",
+            "nsfw_": false,
+            "parent_id": "747967102895390742",
+            "permissionOverwrites_": {
+              "747967102895390741": {
+                "id": "747967102895390741",
+                "type": 0,
+                "allow": "103079332928",
+                "deny": "0"
+              }
+            },
+            "position_": 0,
+            "rateLimitPerUser_": 0,
+            "type": 2,
+            "userLimit_": 0
+          },
+          "comparator": 0
+        }
+      ],
+      "count": 486
+    }
+  ]
+}

--- a/src/equicordplugins/guildExport/schemas/emojis.schema.json
+++ b/src/equicordplugins/guildExport/schemas/emojis.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "guildId": {
+        "type": "string"
+      },
+      "id": {
+        "type": "string"
+      },
+      "animated": {
+        "type": "boolean"
+      },
+      "name": {
+        "type": "string"
+      },
+      "require_colons": {
+        "type": "boolean"
+      },
+      "available": {
+        "type": "boolean"
+      },
+      "roles": {
+        "type": "array",
+        "items": {}
+      },
+      "managed": {
+        "type": "boolean"
+      },
+      "type": {
+        "type": "integer"
+      }
+    },
+    "required": [
+      "guildId",
+      "id",
+      "animated",
+      "name",
+      "require_colons",
+      "available",
+      "managed",
+      "type"
+    ]
+  },
+  "title": "Generated Schema",
+  "description": "JSON Schema generated from provided JSON data",
+  "examples": [
+    [
+      {
+        "guildId": "747967102895390741",
+        "id": "951136945935888446",
+        "animated": true,
+        "name": "Approval",
+        "require_colons": true,
+        "available": true,
+        "managed": false,
+        "type": 1
+      }
+    ]
+  ]
+}

--- a/src/equicordplugins/guildExport/schemas/info.schema.json
+++ b/src/equicordplugins/guildExport/schemas/info.schema.json
@@ -1,0 +1,130 @@
+{
+"$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "icon": {
+      "type": "string"
+    },
+    "description": {
+    "type": "string"
+    },
+    "ownerId": {
+      "type": "string"
+    },
+    "verificationLevel": {
+      "type": "integer"
+    },
+    "rulesChannelId": {
+      "type": "string"
+    },
+    "publicUpdatesChannelId": {
+      "type": "string"
+    },
+    "preferredLocale": {
+      "type": "string"
+    },
+    "features": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "vanityURLCode": {
+      "type": "string"
+    },
+    "nsfwLevel": {
+      "type": "integer"
+    },
+    "premiumTier": {
+      "type": "integer"
+    },
+    "premiumSubscriberCount": {
+      "type": "integer"
+    },
+    "totalMembers": {
+      "type": "integer"
+    },
+    "activeMembers": {
+        "type": "integer"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "ownerId",
+    "verificationLevel",
+    "preferredLocale",
+    "nsfwLevel",
+    "premiumTier",
+    "totalMembers"
+  ],
+  "title": "Generated Schema",
+  "description": "JSON Schema generated from provided JSON data",
+  "examples": [
+    {
+      "id": "747967102895390741",
+      "name": "Flatscreen to VR Modding Community",
+      "icon": "4ed9b9516ae3bb878c8e15f4ca089141",
+      "ownerId": "377193438866833408",
+      "verificationLevel": 2,
+      "rulesChannelId": "976580026751406090",
+      "publicUpdatesChannelId": "752883835368112148",
+      "preferredLocale": "en-US",
+      "features": [
+        "COMMUNITY_EXP_LARGE_GATED",
+        "THREADS_ENABLED",
+        "STAGE_CHANNEL_VIEWERS_150",
+        "CREATOR_MONETIZABLE_PROVISIONAL",
+        "TIERLESS_BOOSTING_SYSTEM_MESSAGE",
+        "VIDEO_BITRATE_ENHANCED",
+        "GUILD_ONBOARDING",
+        "VANITY_URL",
+        "BANNER",
+        "VIP_REGIONS",
+        "PREVIEW_ENABLED",
+        "MEMBER_VERIFICATION_GATE_ENABLED",
+        "AUTO_MODERATION",
+        "NEW_THREAD_PERMISSIONS",
+        "ANIMATED_ICON",
+        "WELCOME_SCREEN_ENABLED",
+        "ANIMATED_BANNER",
+        "PIN_PERMISSION_MIGRATION_COMPLETE",
+        "CHANNEL_ICON_EMOJIS_GENERATED",
+        "AUDIO_BITRATE_256_KBPS",
+        "VIDEO_QUALITY_720_60FPS",
+        "AUDIO_BITRATE_384_KBPS",
+        "CONSIDERED_EXTERNALLY_DISCOVERABLE",
+        "NEWS",
+        "VIDEO_QUALITY_1080_60FPS",
+        "PARTNERED",
+        "MAX_FILE_SIZE_100_MB",
+        "BYPASS_SLOWMODE_PERMISSION_MIGRATION_COMPLETE",
+        "GUILD_ONBOARDING_HAS_PROMPTS",
+        "TIERLESS_BOOSTING",
+        "GUILD_ONBOARDING_EVER_ENABLED",
+        "TEXT_IN_VOICE_ENABLED",
+        "SOUNDBOARD",
+        "AUDIO_BITRATE_128_KBPS",
+        "INVITE_SPLASH",
+        "CREATOR_ACCEPTED_NEW_TERMS",
+        "COMMUNITY",
+        "STAGE_CHANNEL_VIEWERS_300",
+        "ROLE_ICONS",
+        "MAX_FILE_SIZE_50_MB",
+        "STAGE_CHANNEL_VIEWERS_50",
+        "ENABLED_DISCOVERABLE_BEFORE"
+      ],
+      "vanityURLCode": "flat2vr",
+      "nsfwLevel": 0,
+      "premiumTier": 3,
+      "premiumSubscriberCount": 18,
+      "totalMembers": 148542
+    }
+  ]
+}

--- a/src/equicordplugins/guildExport/schemas/members.schema.json
+++ b/src/equicordplugins/guildExport/schemas/members.schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "userId": {
+        "type": "string"
+      },
+      "nick": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "guildId": {
+        "type": "string"
+      },
+      "avatar": {
+        "type": "null"
+      },
+      "avatarDecoration": {
+        "type": "null"
+      },
+      "roles": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "colorString": {
+        "type": "string"
+      },
+      "colorStrings": {
+        "type": "object",
+        "properties": {
+          "primaryColor": {
+            "type": "string"
+          },
+          "secondaryColor": {
+            "type": "null"
+          },
+          "tertiaryColor": {
+            "type": "null"
+          }
+        },
+        "required": [
+          "primaryColor"
+        ]
+      },
+      "colorRoleId": {
+        "type": "string"
+      },
+      "hoistRoleId": {
+        "type": "string"
+      },
+      "highestRoleId": {
+        "type": "string"
+      },
+      "premiumSince": {
+        "type": "null"
+      },
+      "isPending": {
+        "type": "boolean"
+      },
+      "joinedAt": {
+        "type": "string"
+      },
+      "communicationDisabledUntil": {
+        "type": "null"
+      },
+      "flags": {
+        "type": "integer"
+      },
+      "collectibles": {
+        "type": "null"
+      },
+      "displayNameStyles": {
+        "type": "null"
+      }
+    },
+    "required": [
+      "userId",
+      "nick",
+      "guildId",
+      "colorString",
+      "colorRoleId",
+      "hoistRoleId",
+      "highestRoleId",
+      "isPending",
+      "joinedAt",
+      "flags"
+    ]
+  },
+  "title": "Generated Schema",
+  "description": "JSON Schema generated from provided JSON data",
+  "examples": [
+    [
+      {
+        "userId": "467777925790564352",
+        "nick": "Bluscream",
+        "guildId": "747967102895390741",
+        "roles": [
+          "748258358624256131",
+          "1084614743806980228",
+          "896309806447611974",
+          "752594831704064202",
+          "1230622672250077204",
+          "976131416511381534"
+        ],
+        "colorString": "#3498db",
+        "colorStrings": {
+          "primaryColor": "#3498db"
+        },
+        "colorRoleId": "748258358624256131",
+        "hoistRoleId": "748258358624256131",
+        "highestRoleId": "748258358624256131",
+        "isPending": false,
+        "joinedAt": "2020-08-27T09:44:54.086000+00:00",
+        "flags": 0
+      }
+    ]
+  ]
+}

--- a/src/equicordplugins/guildExport/schemas/roles.schema.json
+++ b/src/equicordplugins/guildExport/schemas/roles.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Guild Roles Schema",
+  "description": "Schema for Discord guild roles export",
+  "patternProperties": {
+    "^[0-9]+$": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "guildId": {
+          "type": "string"
+        },
+        "permissions": {
+          "type": "string"
+        },
+        "mentionable": {
+          "type": "boolean"
+        },
+        "position": {
+          "type": "integer"
+        },
+        "color": {
+          "type": "integer"
+        },
+        "colorString": {
+          "type": "string"
+        },
+        "colors": {
+          "type": "object",
+          "properties": {
+            "primary_color": {
+              "type": "integer"
+            },
+            "secondary_color": {
+              "type": "integer"
+            },
+            "tertiary_color": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "primary_color"
+          ]
+        },
+        "colorStrings": {
+          "type": "object",
+          "properties": {
+            "primaryColor": {
+              "type": "string"
+            },
+            "secondaryColor": {
+              "type": "string"
+            },
+            "tertiaryColor": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primaryColor"
+          ]
+        },
+        "hoist": {
+          "type": "boolean"
+        },
+        "managed": {
+          "type": "boolean"
+        },
+        "tags": {
+          "type": "object"
+        },
+        "icon": {
+          "type": "string"
+        },
+        "unicodeEmoji": {
+          "type": "string"
+        },
+        "flags": {
+          "type": "integer"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "guildId",
+        "permissions",
+        "mentionable",
+        "position",
+        "color",
+        "hoist",
+        "managed",
+        "flags"
+      ]
+    }
+  }
+}

--- a/src/equicordplugins/guildExport/schemas/sounds.schema.json
+++ b/src/equicordplugins/guildExport/schemas/sounds.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "sound_id": {
+        "type": "string"
+      },
+      "volume": {
+        "type": "integer"
+      },
+      "emoji_id": {
+        "type": "string"
+      },
+      "emoji_name": {
+        "type": "string"
+      },
+      "guild_id": {
+        "type": "string"
+      },
+      "available": {
+        "type": "boolean"
+      },
+      "user_id": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "name",
+      "sound_id",
+      "volume",
+      "emoji_name",
+      "guild_id",
+      "available"
+    ]
+  },
+  "title": "Generated Schema",
+  "description": "JSON Schema generated from provided JSON data",
+  "examples": [
+    [
+      {
+        "name": "Potato",
+        "sound_id": "1344013167080243262",
+        "volume": 1,
+        "emoji_name": "🥔",
+        "guild_id": "1338957510744215574",
+        "available": true,
+        "user_id": "349973848239767554"
+      }
+    ]
+  ]
+}

--- a/src/equicordplugins/guildExport/schemas/stickers.schema.json
+++ b/src/equicordplugins/guildExport/schemas/stickers.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      },
+      "tags": {
+        "type": "string"
+      },
+      "type": {
+        "type": "integer"
+      },
+      "name": {
+        "type": "string"
+      },
+      "description": {
+        "type": "string"
+      },
+      "format_type": {
+        "type": "integer"
+      },
+      "guild_id": {
+        "type": "string"
+      },
+      "available": {
+        "type": "boolean"
+      }
+    },
+    "required": [
+      "id",
+      "tags",
+      "type",
+      "name",
+      "format_type",
+      "guild_id",
+      "available"
+    ]
+  },
+  "title": "Generated Schema",
+  "description": "JSON Schema generated from provided JSON data",
+  "examples": [
+    [
+      {
+        "id": "1338988679401701386",
+        "tags": "1338965885645361332",
+        "type": 2,
+        "name": "Quarkbällchen",
+        "format_type": 1,
+        "guild_id": "1338957510744215574",
+        "available": true
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Ports the 'blu-guild-export' plugin to 'src/equicordplugins/GuildExport'. This plugin allows users to export guild data such as channels, roles, members (cached), emojis, stickers, and more into a ZIP file or local folder.

![](https://files.catbox.moe/sqol9f.png)