### PR TITLE
add waitForSlot (optimized)

### DIFF
--- a/src/equicordplugins/waitForSlot/components/ReplaceQueueModal.tsx
+++ b/src/equicordplugins/waitForSlot/components/ReplaceQueueModal.tsx
@@ -1,0 +1,43 @@
+import { BaseText } from "@components/BaseText";
+import { Button } from "@components/Button";
+import { Paragraph } from "@components/Paragraph";
+import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import type { Channel } from "@vencord/discord-types";
+import { React } from "@webpack/common";
+
+export function ReplaceQueueModal({ modalProps, channel, onReplace, }: { modalProps: ModalProps; channel: Channel; onReplace: () => void; }) {
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.SMALL}>
+            <ModalHeader className="vc-wfs-header">
+                <BaseText size="lg" weight="semibold">Replace Wait Queue</BaseText>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+            <ModalContent>
+                <div className="vc-wfs-prompt">
+                    <Paragraph size="md" className="vc-wfs-prompt-text">
+                        You are already waiting for a slot. Replace it with <strong>{channel.name}</strong>?
+                    </Paragraph>
+                </div>
+            </ModalContent>
+            <ModalFooter justify="start" direction="horizontal" className="vc-wfs-footer">
+                <Button
+                    onClick={() => {
+                        onReplace();
+                        modalProps.onClose();
+                    }}
+                    variant="positive"
+                    size="small"
+                >
+                    Replace
+                </Button>
+                <Button
+                    onClick={modalProps.onClose}
+                    variant="dangerPrimary"
+                    size="small"
+                >
+                    Cancel
+                </Button>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/equicordplugins/waitForSlot/components/SlotAvailableModal.tsx
+++ b/src/equicordplugins/waitForSlot/components/SlotAvailableModal.tsx
@@ -3,9 +3,12 @@ import { Button } from "@components/Button";
 import { Paragraph } from "@components/Paragraph";
 import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
 import type { Channel } from "@vencord/discord-types";
-import { React } from "@webpack/common";
+import { GuildStore, IconUtils, React } from "@webpack/common";
 
 export function SlotAvailableModal({ modalProps, channel, onJoin, }: { modalProps: ModalProps; channel: Channel; onJoin: () => void; }) {
+    const guild = GuildStore.getGuild(channel.guild_id);
+    const guildIcon = guild?.icon == null ? undefined : IconUtils.getGuildIconURL({ id: guild.id, icon: guild.icon, size: 32 });
+
     return (
         <ModalRoot {...modalProps} size={ModalSize.SMALL}>
             <ModalHeader className="vc-wfs-header">
@@ -13,8 +16,12 @@ export function SlotAvailableModal({ modalProps, channel, onJoin, }: { modalProp
                 <ModalCloseButton onClick={modalProps.onClose} />
             </ModalHeader>
             <ModalContent>
+                <div className="vc-wfs-vc-row">
+                    {guildIcon && <img className="vc-wfs-guild-icon" src={guildIcon} alt="" />}
+                    <BaseText size="md" weight="semibold">{channel.name}</BaseText>
+                </div>
                 <Paragraph size="md" className="vc-wfs-available-text">
-                    Would you like to join <strong>{channel.name}</strong>?
+                    A slot is available for this voice channel. Would you like to join?
                 </Paragraph>
             </ModalContent>
             <ModalFooter justify="start" direction="horizontal" className="vc-wfs-footer">

--- a/src/equicordplugins/waitForSlot/components/SlotAvailableModal.tsx
+++ b/src/equicordplugins/waitForSlot/components/SlotAvailableModal.tsx
@@ -1,0 +1,41 @@
+import { BaseText } from "@components/BaseText";
+import { Button } from "@components/Button";
+import { Paragraph } from "@components/Paragraph";
+import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import type { Channel } from "@vencord/discord-types";
+import { React } from "@webpack/common";
+
+export function SlotAvailableModal({ modalProps, channel, onJoin, }: { modalProps: ModalProps; channel: Channel; onJoin: () => void; }) {
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.SMALL}>
+            <ModalHeader className="vc-wfs-header">
+                <BaseText size="lg" weight="semibold">Slot Available</BaseText>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+            <ModalContent>
+                <Paragraph size="md" className="vc-wfs-available-text">
+                    Would you like to join <strong>{channel.name}</strong>?
+                </Paragraph>
+            </ModalContent>
+            <ModalFooter justify="start" direction="horizontal" className="vc-wfs-footer">
+                <Button
+                    onClick={() => {
+                        onJoin();
+                        modalProps.onClose();
+                    }}
+                    variant="positive"
+                    size="small"
+                >
+                    Yes
+                </Button>
+                <Button
+                    onClick={modalProps.onClose}
+                    variant="dangerPrimary"
+                    size="small"
+                >
+                    No
+                </Button>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/equicordplugins/waitForSlot/components/SlotAvailableModalSimple.tsx
+++ b/src/equicordplugins/waitForSlot/components/SlotAvailableModalSimple.tsx
@@ -1,0 +1,48 @@
+import { BaseText } from "@components/BaseText";
+import { Button } from "@components/Button";
+import { Paragraph } from "@components/Paragraph";
+import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import type { Channel } from "@vencord/discord-types";
+import { GuildStore, IconUtils, React } from "@webpack/common";
+
+export function SlotAvailableModalSimple({ modalProps, channel, onJoin, }: { modalProps: ModalProps; channel: Channel; onJoin: () => void; }) {
+    const guild = GuildStore.getGuild(channel.guild_id);
+    const guildIcon = guild?.icon == null ? undefined : IconUtils.getGuildIconURL({ id: guild.id, icon: guild.icon, size: 32 });
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.SMALL}>
+            <ModalHeader className="vc-wfs-header">
+                <BaseText size="lg" weight="semibold">Slot Available</BaseText>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+            <ModalContent>
+                <div className="vc-wfs-vc-row">
+                    {guildIcon && <img className="vc-wfs-guild-icon" src={guildIcon} alt="" />}
+                    <BaseText size="md" weight="semibold">{channel.name}</BaseText>
+                </div>
+                <Paragraph size="md" className="vc-wfs-available-text">
+                    A slot is available for this voice channel. Would you like to join?
+                </Paragraph>
+            </ModalContent>
+            <ModalFooter justify="start" direction="horizontal" className="vc-wfs-footer">
+                <Button
+                    onClick={() => {
+                        onJoin();
+                        modalProps.onClose();
+                    }}
+                    variant="positive"
+                    size="small"
+                >
+                    Yes
+                </Button>
+                <Button
+                    onClick={modalProps.onClose}
+                    variant="dangerPrimary"
+                    size="small"
+                >
+                    No
+                </Button>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/equicordplugins/waitForSlot/components/WaitPromptModal.tsx
+++ b/src/equicordplugins/waitForSlot/components/WaitPromptModal.tsx
@@ -1,0 +1,44 @@
+import { BaseText } from "@components/BaseText";
+import { Button } from "@components/Button";
+import { Paragraph } from "@components/Paragraph";
+import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import type { Channel } from "@vencord/discord-types";
+import { React } from "@webpack/common";
+
+export function WaitPromptModal({ modalProps, channel, onWait, onDecline, }: { modalProps: ModalProps; channel: Channel; onWait: () => void; onDecline: () => void; }) {
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.SMALL}>
+            <ModalHeader className="vc-wfs-header">
+                <BaseText size="lg" weight="semibold">Channel Full</BaseText>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+            <ModalContent>
+                <Paragraph size="md">
+                    Would you like to wait for a slot in <strong>{channel.name}</strong>?
+                </Paragraph>
+            </ModalContent>
+            <ModalFooter justify="start" direction="horizontal" className="vc-wfs-footer">
+                <Button
+                    onClick={() => {
+                        onWait();
+                        modalProps.onClose();
+                    }}
+                    variant="positive"
+                    size="small"
+                >
+                    Yes
+                </Button>
+                <Button
+                    onClick={() => {
+                        onDecline();
+                        modalProps.onClose();
+                    }}
+                    variant="dangerPrimary"
+                    size="small"
+                >
+                    No
+                </Button>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/equicordplugins/waitForSlot/index.tsx
+++ b/src/equicordplugins/waitForSlot/index.tsx
@@ -1,0 +1,216 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import type { Channel } from "@vencord/discord-types";
+import { ChannelType } from "@vencord/discord-types/enums";
+import { findByPropsLazy } from "@webpack";
+import { ChannelStore, Menu, SelectedChannelStore } from "@webpack/common";
+import { settings } from "./settings";
+import { isChannelFull } from "./utils/voice";
+import { getWaitingChannels, hasWaitingChannels, isWaiting, joinAvailable, promptToWait, removeWaiting, shouldPromptForChannel, stopWaiting, waitForChannel } from "./utils/waiting";
+import managedStyle from "./styles.css?managed";
+
+interface VoiceStateChangeEvent {
+    channelId?: string;
+    oldChannelId?: string;
+}
+
+const waitingChannels = getWaitingChannels();
+type SelectVoiceChannel = (channelId: string | null, ...args: unknown[]) => unknown;
+type SelectChannel = (channelId: string | null, ...args: unknown[]) => unknown;
+let selectVoiceChannelDescriptor: PropertyDescriptor | null = null;
+let rawSelectVoiceChannel: SelectVoiceChannel | null = null;
+let selectChannelDescriptor: PropertyDescriptor | null = null;
+let rawSelectChannel: SelectChannel | null = null;
+let selectVoiceChannelPatchInterval: number | null = null;
+let isSelectVoiceChannelPatched = false;
+let isSelectChannelPatched = false;
+const ChannelActions = findByPropsLazy("selectChannel", "selectVoiceChannel") as {
+    selectVoiceChannel?: SelectVoiceChannel;
+    selectChannel?: SelectChannel;
+};
+
+const isVoiceChannel = (channel: Channel) =>
+    channel.type === ChannelType.GUILD_VOICE || channel.type === ChannelType.GUILD_STAGE_VOICE;
+
+const shouldInterceptChannel = (channel: Channel) =>
+    isVoiceChannel(channel)
+    && SelectedChannelStore.getVoiceChannelId() !== channel.id
+    && !isWaiting(channel)
+    && shouldPromptForChannel(channel);
+
+function onVoiceStateUpdate(voiceStates: VoiceStateChangeEvent[]) {
+    if (!hasWaitingChannels()) return;
+    for (const state of voiceStates) {
+        if (!state.oldChannelId) continue;
+        let waiting: Channel | undefined;
+        for (const channel of waitingChannels) {
+            if (channel.id === state.oldChannelId) {
+                waiting = channel;
+                break;
+            }
+        }
+        if (waiting && !isChannelFull(waiting.id, waiting.userLimit)) {
+            joinAvailable(waiting);
+            return;
+        }
+    }
+}
+
+function wrapSelectVoiceChannel(fn: SelectVoiceChannel): SelectVoiceChannel {
+    return (channelId: string | null, ...args: unknown[]) => {
+        if (channelId == null) return fn(channelId, ...args);
+        const channel = ChannelStore.getChannel(channelId) as Channel | null;
+        if (!channel || !shouldInterceptChannel(channel)) return fn(channelId, ...args);
+        promptToWait(channel);
+    };
+}
+
+function wrapSelectChannel(fn: SelectChannel): SelectChannel {
+    return (channelId: string | null, ...args: unknown[]) => {
+        if (channelId == null) return fn(channelId, ...args);
+        const channel = ChannelStore.getChannel(channelId) as Channel | null;
+        if (!channel || !shouldInterceptChannel(channel)) return fn(channelId, ...args);
+        promptToWait(channel);
+    };
+}
+
+function patchSelectVoiceChannel(): boolean {
+    if (isSelectVoiceChannelPatched) return true;
+    const current = ChannelActions.selectVoiceChannel;
+    if (typeof current !== "function") return false;
+    const descriptor = Object.getOwnPropertyDescriptor(ChannelActions, "selectVoiceChannel");
+    let raw = current;
+    let wrapped = wrapSelectVoiceChannel(current);
+    Object.defineProperty(ChannelActions, "selectVoiceChannel", {
+        configurable: true,
+        enumerable: descriptor?.enumerable ?? true,
+        get: () => wrapped,
+        set: (fn: SelectVoiceChannel) => {
+            raw = fn;
+            wrapped = wrapSelectVoiceChannel(fn);
+        },
+    });
+    selectVoiceChannelDescriptor = descriptor ?? null;
+    rawSelectVoiceChannel = raw;
+    isSelectVoiceChannelPatched = true;
+    return true;
+}
+
+function patchSelectChannel(): boolean {
+    if (isSelectChannelPatched) return true;
+    const current = ChannelActions.selectChannel;
+    if (typeof current !== "function") return false;
+    const descriptor = Object.getOwnPropertyDescriptor(ChannelActions, "selectChannel");
+    let raw = current;
+    let wrapped = wrapSelectChannel(current);
+    Object.defineProperty(ChannelActions, "selectChannel", {
+        configurable: true,
+        enumerable: descriptor?.enumerable ?? true,
+        get: () => wrapped,
+        set: (fn: SelectChannel) => {
+            raw = fn;
+            wrapped = wrapSelectChannel(fn);
+        },
+    });
+    selectChannelDescriptor = descriptor ?? null;
+    rawSelectChannel = raw;
+    isSelectChannelPatched = true;
+    return true;
+}
+
+function installChannelActionPatch(): boolean {
+    patchSelectVoiceChannel();
+    patchSelectChannel();
+
+    const voiceReady = typeof ChannelActions?.selectVoiceChannel === "function";
+    const channelReady = typeof ChannelActions?.selectChannel === "function";
+    return (voiceReady ? isSelectVoiceChannelPatched : false)
+        && (channelReady ? isSelectChannelPatched : false);
+}
+
+const VoiceChannelContext: NavContextMenuPatchCallback = (children, { channel }: { channel: Channel; }) => {
+    if (!channel || (channel.type !== ChannelType.GUILD_VOICE && channel.type !== ChannelType.GUILD_STAGE_VOICE)) return;
+    if (SelectedChannelStore.getVoiceChannelId() === channel.id) return;
+
+    if (isWaiting(channel)) {
+        children.splice(-1, 0, (
+            <Menu.MenuItem
+                key="stop-waiting-for-slot"
+                id="stop-waiting-for-slot"
+                label="Stop waiting for slot"
+                action={() => removeWaiting(channel)}
+            />
+        ));
+        return;
+    }
+
+    if (isChannelFull(channel.id, channel.userLimit)) {
+        children.splice(-1, 0, (
+            <Menu.MenuItem
+                key="wait-for-slot"
+                id="wait-for-slot"
+                label="Wait for Slot"
+                action={() => waitForChannel(channel)}
+            />
+        ));
+    }
+};
+
+export default definePlugin({
+    name: "WaitForSlot",
+    description: "Adds an option to calls to wait for a slot in a full voice channel.",
+    authors: [EquicordDevs.omaw],
+    managedStyle,
+    settings,
+    contextMenus: {
+        "channel-context": VoiceChannelContext,
+    },
+    start() {
+        if (installChannelActionPatch()) return;
+        selectVoiceChannelPatchInterval = window.setInterval(() => {
+            if (installChannelActionPatch() && selectVoiceChannelPatchInterval != null) {
+                clearInterval(selectVoiceChannelPatchInterval);
+                selectVoiceChannelPatchInterval = null;
+            }
+        }, 1000);
+    },
+    flux: {
+        VOICE_STATE_UPDATES({ voiceStates }: { voiceStates: VoiceStateChangeEvent[]; }) {
+            onVoiceStateUpdate(voiceStates);
+        },
+    },
+    stop() {
+        stopWaiting();
+        if (selectVoiceChannelPatchInterval != null) {
+            clearInterval(selectVoiceChannelPatchInterval);
+            selectVoiceChannelPatchInterval = null;
+        }
+        if (isSelectVoiceChannelPatched) {
+            if (selectVoiceChannelDescriptor) {
+                Object.defineProperty(ChannelActions, "selectVoiceChannel", selectVoiceChannelDescriptor);
+            } else if (rawSelectVoiceChannel) {
+                ChannelActions.selectVoiceChannel = rawSelectVoiceChannel;
+            }
+            selectVoiceChannelDescriptor = null;
+            rawSelectVoiceChannel = null;
+            isSelectVoiceChannelPatched = false;
+        }
+        if (isSelectChannelPatched) {
+            if (selectChannelDescriptor) {
+                Object.defineProperty(ChannelActions, "selectChannel", selectChannelDescriptor);
+            } else if (rawSelectChannel) {
+                ChannelActions.selectChannel = rawSelectChannel;
+            }
+            selectChannelDescriptor = null;
+            rawSelectChannel = null;
+            isSelectChannelPatched = false;
+        }
+    },
+});

--- a/src/equicordplugins/waitForSlot/index.tsx
+++ b/src/equicordplugins/waitForSlot/index.tsx
@@ -42,7 +42,7 @@ function onVoiceStateUpdate(voiceStates: VoiceStateChangeEvent[]) {
     for (const state of voiceStates) {
         if (!state.oldChannelId) continue;
         let waiting: Channel | undefined;
-        for (const channel of waitingChannels) {
+        for (const channel of waitingChannels.values()) {
             if (channel.id === state.oldChannelId) {
                 waiting = channel;
                 break;

--- a/src/equicordplugins/waitForSlot/settings.ts
+++ b/src/equicordplugins/waitForSlot/settings.ts
@@ -1,0 +1,29 @@
+import { definePluginSettings } from "@api/Settings";
+import { OptionType } from "@utils/types";
+
+export const settings = definePluginSettings({
+    promptOnFull: {
+        type: OptionType.BOOLEAN,
+        description: "Prompt to wait when selecting a full voice channel",
+        default: true,
+        restartNeeded: false,
+    },
+    showConfirmation: {
+        type: OptionType.BOOLEAN,
+        description: "Show confirmation modal when a slot becomes available",
+        default: true,
+        restartNeeded: false,
+    },
+    playSound: {
+        type: OptionType.BOOLEAN,
+        description: "Play notification sound when a slot becomes available",
+        default: true,
+        restartNeeded: false,
+    },
+    promptOnReplace: {
+        type: OptionType.BOOLEAN,
+        description: "Prompt to replace the current wait queue when selecting another full voice channel",
+        default: true,
+        restartNeeded: false,
+    },
+});

--- a/src/equicordplugins/waitForSlot/styles.css
+++ b/src/equicordplugins/waitForSlot/styles.css
@@ -1,0 +1,82 @@
+.vc-wfs-footer {
+    display: flex;
+    justify-content: flex-start !important;
+    flex-direction: row !important;
+    gap: 8px;
+    width: 100%;
+    align-self: stretch;
+    padding-left: 16px !important;
+    padding-right: 0 !important;
+}
+
+.vc-wfs-footer > * {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+}
+
+.vc-wfs-footer button {
+    flex-shrink: 0;
+}
+
+.vc-wfs-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.vc-wfs-header > button {
+    margin-left: auto;
+}
+
+.vc-wfs-danger {
+    color: var(--status-danger);
+    font-weight: 600;
+}
+
+.vc-wfs-vc-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.vc-wfs-guild-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+}
+
+.vc-wfs-available-text {
+    font-size: 1.05rem;
+    line-height: 1.4;
+}
+
+.vc-wfs-notice {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap;
+}
+
+.vc-wfs-notice-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 4px;
+}
+
+.vc-wfs-notice-text {
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.vc-wfs-notice-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.vc-wfs-notice-actions button {
+    height: 24px;
+    padding: 0 8px;
+    min-height: 24px;
+}

--- a/src/equicordplugins/waitForSlot/utils/voice.ts
+++ b/src/equicordplugins/waitForSlot/utils/voice.ts
@@ -1,0 +1,50 @@
+import { Logger } from "@utils/Logger";
+import { findByPropsLazy } from "@webpack";
+import { VoiceStateStore } from "@webpack/common";
+
+const logger = new Logger("WaitForSlot");
+const { selectVoiceChannel } = findByPropsLazy("selectVoiceChannel", "selectChannel");
+
+export function getVoiceChannelUserCount(channelId: string): number {
+    const voiceStates = VoiceStateStore.getVoiceStatesForChannel(channelId);
+    return voiceStates ? Object.keys(voiceStates).length : 0;
+}
+
+export function isChannelFull(channelId: string, userLimit?: number | null): boolean {
+    if (!userLimit) return false;
+    return getVoiceChannelUserCount(channelId) >= userLimit;
+}
+
+export function joinVoiceChannel(channelId: string) {
+    try {
+        selectVoiceChannel(channelId);
+    } catch (error) {
+        logger.error("Error calling selectVoiceChannel", error);
+        throw error;
+    }
+}
+
+export function playNotificationSound() {
+    try {
+        const AudioContextCtor = window.AudioContext ?? (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+        if (!AudioContextCtor) return;
+        const audioContext = new AudioContextCtor();
+        const oscillator = audioContext.createOscillator();
+        const gainNode = audioContext.createGain();
+
+        oscillator.connect(gainNode);
+        gainNode.connect(audioContext.destination);
+        oscillator.frequency.setValueAtTime(800, audioContext.currentTime);
+        oscillator.frequency.setValueAtTime(1000, audioContext.currentTime + 0.1);
+        oscillator.frequency.setValueAtTime(800, audioContext.currentTime + 0.2);
+        gainNode.gain.setValueAtTime(0.3, audioContext.currentTime);
+        gainNode.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + 0.3);
+        oscillator.start(audioContext.currentTime);
+        oscillator.stop(audioContext.currentTime + 0.3);
+        oscillator.addEventListener("ended", () => {
+            audioContext.close().catch(() => {});
+        });
+    } catch (error) {
+        logger.warn("Could not play notification sound", error);
+    }
+}

--- a/src/equicordplugins/waitForSlot/utils/waiting.ts
+++ b/src/equicordplugins/waitForSlot/utils/waiting.ts
@@ -1,0 +1,161 @@
+import { sendBotMessage } from "@api/Commands";
+import { currentNotice, noticesQueue, popNotice, showNotice } from "@api/Notices";
+import { Logger } from "@utils/Logger";
+import { openModal } from "@utils/modal";
+import type { Channel } from "@vencord/discord-types";
+import type { ReactNode } from "react";
+import { Button } from "@components/Button";
+import { NavigationRouter, React } from "@webpack/common";
+
+import { ReplaceQueueModal } from "../components/ReplaceQueueModal";
+import { SlotAvailableModalSimple } from "../components/SlotAvailableModalSimple";
+import { WaitPromptModal } from "../components/WaitPromptModal";
+import { settings } from "../settings";
+import { isChannelFull, joinVoiceChannel, playNotificationSound } from "./voice";
+
+const logger = new Logger("WaitForSlot");
+const waitingChannels = new Set<Channel>();
+let bypassPrompt = false;
+let waitingNoticeMessage: ReactNode | null = null;
+let waitingNoticeKey: string | null = null;
+let waitingNoticeOnOk: (() => void) | null = null;
+
+const noop = () => { };
+
+export function isWaiting(channel: Channel) {
+    return waitingChannels.has(channel);
+}
+
+export function hasWaitingChannels() {
+    return waitingChannels.size > 0;
+}
+
+export function getWaitingChannels() {
+    return waitingChannels;
+}
+
+function attemptJoin(channelId: string) {
+    try {
+        bypassPrompt = true;
+        joinVoiceChannel(channelId);
+    } catch (error) {
+        logger.error("Failed to join voice channel", error);
+    } finally {
+        bypassPrompt = false;
+    }
+}
+
+function dismissWaitingNotice() {
+    if (!waitingNoticeMessage || !waitingNoticeOnOk) return;
+    if (currentNotice?.[3] === waitingNoticeOnOk) popNotice();
+    const queuedIndex = noticesQueue.findIndex(([, , , onOkClick]) => onOkClick === waitingNoticeOnOk);
+    if (queuedIndex !== -1) noticesQueue.splice(queuedIndex, 1);
+    waitingNoticeMessage = null;
+    waitingNoticeKey = null;
+    waitingNoticeOnOk = null;
+}
+
+function showWaitingNotice(channel: Channel) {
+    const message = React.createElement(
+        "div",
+        { className: "vc-wfs-notice" },
+        React.createElement(
+            "span",
+            { className: "vc-wfs-notice-text" },
+            `Waiting for a Slot in ${channel.name}`
+        ),
+        React.createElement(
+            "div",
+            { className: "vc-wfs-notice-actions" },
+            React.createElement(
+                Button,
+                {
+                    size: "small",
+                    variant: "secondary",
+                    onClick: () => {
+                        const guildId = channel.guild_id ?? "@me";
+                        NavigationRouter.transitionTo(`/channels/${guildId}/${channel.id}`);
+                    },
+                },
+                "Jump"
+            )
+        )
+    );
+    dismissWaitingNotice();
+    const onStop = () => {
+        if (waitingNoticeKey === channel.id) dismissWaitingNotice();
+        stopWaiting();
+    };
+    waitingNoticeMessage = message;
+    waitingNoticeKey = channel.id;
+    waitingNoticeOnOk = onStop;
+    showNotice(message, "Stop Waiting", onStop);
+}
+
+export function stopWaiting() {
+    waitingChannels.clear();
+    dismissWaitingNotice();
+}
+
+export function removeWaiting(channel: Channel, sendMessage = true) {
+    waitingChannels.delete(channel);
+    if (sendMessage) {
+        sendBotMessage(channel.id, { content: `Stopped waiting for a free slot in <#${channel.id}>` });
+    }
+    if (waitingChannels.size === 0) return stopWaiting();
+    const nextChannel = waitingChannels.values().next().value as Channel | undefined;
+    if (nextChannel) showWaitingNotice(nextChannel);
+}
+
+export function shouldPromptForChannel(channel: Channel): boolean {
+    return settings.store.promptOnFull
+        && !bypassPrompt
+        && isChannelFull(channel.id, channel.userLimit);
+}
+
+export function promptToWait(channel: Channel) {
+    openModal(modalProps => React.createElement(WaitPromptModal, {
+        modalProps,
+        channel,
+        onWait: () => waitForChannel(channel),
+        onDecline: noop,
+    }));
+}
+
+export function waitForChannel(channel: Channel) {
+    if (waitingChannels.has(channel)) return;
+    if (settings.store.promptOnReplace && waitingChannels.size > 0) {
+        openModal(modalProps => React.createElement(ReplaceQueueModal, {
+            modalProps,
+            channel,
+            onReplace: () => {
+                dismissWaitingNotice();
+                waitingChannels.clear();
+                waitingChannels.add(channel);
+                sendBotMessage(channel.id, { content: `Started waiting for a free slot in <#${channel.id}>` });
+                showWaitingNotice(channel);
+            },
+        }));
+        return;
+    }
+    waitingChannels.add(channel);
+    sendBotMessage(channel.id, { content: `Started waiting for a free slot in <#${channel.id}>` });
+    showWaitingNotice(channel);
+    if (!isChannelFull(channel.id, channel.userLimit)) joinAvailable(channel);
+}
+
+export function joinAvailable(channel: Channel) {
+    waitingChannels.clear();
+    dismissWaitingNotice();
+    if (settings.store.playSound) playNotificationSound();
+
+    if (settings.store.showConfirmation) {
+        openModal(modalProps => React.createElement(SlotAvailableModalSimple, {
+            modalProps,
+            channel,
+            onJoin: () => attemptJoin(channel.id),
+        }));
+        return;
+    }
+    attemptJoin(channel.id);
+}


### PR DESCRIPTION
- Adds Prompt which displays you with the server icon gives you options to join or cancel when a call is available .
- Adds another Prompt to show whether you want to override an existing queue for another call.
- Displays Header Notification properly for when you're queued to join a call.
- Adds a Hook so when you make an attempt to join a full VC it'll prompt you to queue for call.

I took existing plugin-structure and edited it from a previous plugin submission there's a ton of components for the different panels, that are prompted to user, and functions exist to queue for the call. 