### PR TITLE
fix(questify): clear all intervals on plugin stop to prevent memory leak

### DIFF
--- a/src/equicordplugins/questify/index.tsx
+++ b/src/equicordplugins/questify/index.tsx
@@ -1751,10 +1751,13 @@ export default definePlugin({
         removeServerListElement(ServerListRenderPosition.Above, this.renderQuestifyButton);
         stopAutoFetchingQuests();
 
-        activeQuestIntervals.forEach((intervalData, questId) => {
-            clearInterval(intervalData.progressTimeout);
-            clearTimeout(intervalData.rerenderTimeout);
-            activeQuestIntervals.delete(questId);
-        });
+        for (const questId of activeQuestIntervals.keys()) {
+            const intervalData = activeQuestIntervals.get(questId);
+            if (intervalData) {
+                clearInterval(intervalData.progressTimeout);
+                clearTimeout(intervalData.rerenderTimeout);
+            }
+        }
+        activeQuestIntervals.clear();
     }
 });


### PR DESCRIPTION
# Optimize Interval Cleanup in Questify

Improved performance of cleanup process by clearing all intervals at once instead 
of one by one.