### PR TITLE
FileUpload: add cors proxy to uploads for web

### DIFF
--- a/src/equicordplugins/fileUpload/index.tsx
+++ b/src/equicordplugins/fileUpload/index.tsx
@@ -21,8 +21,8 @@ export const settings = definePluginSettings({
         description: "",
         options: [
             { label: "Zipline", value: ServiceType.ZIPLINE, default: true },
-            ...(IS_DISCORD_DESKTOP ? [{ label: "E-Z Host", value: ServiceType.EZHOST }] : []),
-            ...(IS_DISCORD_DESKTOP ? [{ label: "Nest", value: ServiceType.NEST }] : [])
+            { label: "E-Z Host", value: ServiceType.EZHOST },
+            { label: "Nest", value: ServiceType.NEST }
         ],
         hidden: true
     },
@@ -135,7 +135,7 @@ const imageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => 
 export default definePlugin({
     name: "FileUpload",
     description: "Upload images and videos to file hosting services like Zipline and Nest",
-    authors: [EquicordDevs.creations],
+    authors: [EquicordDevs.creations, EquicordDevs.keircn],
     settings,
     contextMenus: {
         "message": messageContextMenuPatch,

--- a/src/equicordplugins/fileUpload/settings.tsx
+++ b/src/equicordplugins/fileUpload/settings.tsx
@@ -21,8 +21,8 @@ export function SettingsComponent() {
 
     const serviceOptions = [
         { label: "Zipline", value: ServiceType.ZIPLINE },
-        ...(IS_DISCORD_DESKTOP ? [{ label: "E-Z Host", value: ServiceType.EZHOST }] : []),
-        ...(IS_DISCORD_DESKTOP ? [{ label: "Nest", value: ServiceType.NEST }] : [])
+        { label: "E-Z Host", value: ServiceType.EZHOST },
+        { label: "Nest", value: ServiceType.NEST }
     ];
 
     return (


### PR DESCRIPTION
this allows uploads to Nest and E-Z to work on equibop/web, and the proxy is hosted on workers so it should have good uptime and latency.

i can send the code if you or creations want to host it instead if that's preferable, since i know relying on too many external apis is yucky