### PR TITLE
fix(LimitMiddleClickPaste): simplify tab blocking

### DIFF
--- a/src/equicordplugins/limitMiddleClickPaste/index.ts
+++ b/src/equicordplugins/limitMiddleClickPaste/index.ts
@@ -48,21 +48,8 @@ const settings = definePluginSettings({
     },
 });
 
-function shouldBlockLink(e: MouseEvent): boolean {
-    if (e.button !== MIDDLE_CLICK) return false;
-
-    const target = e.target as HTMLElement | null;
-    if (!target?.closest) return false;
-
-    const a = target.closest("a[href]") as HTMLAnchorElement | null;
-    if (!a) return false;
-
-    const href = a.getAttribute("href");
-    return !!href && href !== "#";
-}
-
 function handleAuxClick(e: MouseEvent) {
-    if (!shouldBlockLink(e)) return;
+    if (e.button !== MIDDLE_CLICK) return;
     e.preventDefault();
     e.stopPropagation();
 }


### PR DESCRIPTION
Simply blocking all middle-click tab opens instead of only links. 
This also fixes forum images opening in new tabs. 
Auto-scroll is still working fine.