### PR TITLE
fix/Quoter

### DIFF
--- a/src/equicordplugins/quoter/utils.tsx
+++ b/src/equicordplugins/quoter/utils.tsx
@@ -47,7 +47,7 @@ export function fixUpQuote(quote: string): string {
 export function generateFileNamePreview(message: string): string {
     const words = message.split(" ");
     const preview = words.length > 6 ? words.slice(0, 6).join(" ") : words.join(" ");
-    return preview.slice(0, 50);
+    return preview.slice(0, 10);
 }
 
 export function getFileExtension(saveAsGif: boolean): string {

--- a/src/equicordplugins/quoter/utils.tsx
+++ b/src/equicordplugins/quoter/utils.tsx
@@ -46,7 +46,8 @@ export function fixUpQuote(quote: string): string {
 
 export function generateFileNamePreview(message: string): string {
     const words = message.split(" ");
-    return words.length > 6 ? words.slice(0, 6).join(" ") : words.join(" ");
+    const preview = words.length > 6 ? words.slice(0, 6).join(" ") : words.join(" ");
+    return preview.slice(0, 50);
 }
 
 export function getFileExtension(saveAsGif: boolean): string {
@@ -153,12 +154,31 @@ function calculateTextLines(
     let currentLine: string[] = [];
 
     words.forEach(word => {
-        const testLine = [...currentLine, word].join(" ");
-        if (ctx.measureText(testLine).width > maxWidth && currentLine.length) {
-            lines.push(currentLine.join(" "));
-            currentLine = [word];
+        if (ctx.measureText(word).width > maxWidth) {
+            if (currentLine.length) {
+                lines.push(currentLine.join(" "));
+                currentLine = [];
+            }
+
+            let chunk = "";
+            for (const char of word) {
+                const testChunk = chunk + char;
+                if (ctx.measureText(testChunk).width > maxWidth) {
+                    if (chunk) lines.push(chunk);
+                    chunk = char;
+                } else {
+                    chunk = testChunk;
+                }
+            }
+            if (chunk) lines.push(chunk);
         } else {
-            currentLine.push(word);
+            const testLine = [...currentLine, word].join(" ");
+            if (ctx.measureText(testLine).width > maxWidth && currentLine.length) {
+                lines.push(currentLine.join(" "));
+                currentLine = [word];
+            } else {
+                currentLine.push(word);
+            }
         }
     });
 


### PR DESCRIPTION
if the quote is too many lines long, it linebreaks.
also if the first "word" was like over discord's 100 character limit it lowk just failed to send when trying to send it directly from the modal.

before:
<img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/c2d2e764-b468-4170-bc06-356fe8e9a1f6" />

after:
<img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/0abcfe1a-3aca-4910-8126-d2b2e65f3745" />


woaho