### PR TITLE
quickCss Editor ( Always on Top / Close Confirmation when CSS is minimized. + Reopens properly when minimized. ) 

### DIFF
--- a/src/main/ipcMain.ts
+++ b/src/main/ipcMain.ts
@@ -143,6 +143,7 @@ ipcMain.handle(IpcEvents.OPEN_MONACO_EDITOR, async () => {
     const title = "Equicord QuickCSS Editor";
     const existingWindow = BrowserWindow.getAllWindows().find(w => w.title === title);
     if (existingWindow && !existingWindow.isDestroyed()) {
+        existingWindow.show();
         existingWindow.focus();
         return;
     }
@@ -167,10 +168,10 @@ ipcMain.handle(IpcEvents.OPEN_MONACO_EDITOR, async () => {
 
 app.on("before-quit", async (event) => {
     const monacoWindow = BrowserWindow.getAllWindows().find(w => w.title === "Equicord QuickCSS Editor");
-    
+
     if (monacoWindow && !monacoWindow.isDestroyed() && !monacoWindow.isVisible()) {
         event.preventDefault();
-        
+
         const result = await dialog.showMessageBox({
             type: "question",
             buttons: ["Cancel", "Close Anyway"],
@@ -179,7 +180,7 @@ app.on("before-quit", async (event) => {
             message: "QuickCSS editor is still open in the background.",
             detail: "Do you want to close Discord anyway? This will also close the QuickCSS editor."
         });
-        
+
         if (result.response === 1) {
             app.exit();
         }


### PR DESCRIPTION
Title.
<img width="598" height="648" alt="CleanShot 2026-02-21 at 06 04 59@2x" src="https://github.com/user-attachments/assets/073bf666-068b-4b62-be3e-07d8849f359c" />
for accidental closes lost data alot  of time from forgetting about my css window being open.