### PR TITLE
feat: add Multibox plugin

### DIFF
--- a/src/equicordplugins/multibox.desktop/components/TabBar.tsx
+++ b/src/equicordplugins/multibox.desktop/components/TabBar.tsx
@@ -1,0 +1,53 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and Equicord contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@utils/css";
+
+import type { AccountTab } from "..";
+
+const cl = classNameFactory("vc-multibox-");
+
+interface TabBarProps {
+    accounts: AccountTab[];
+    activeTab: string;
+    onSwitch: (id: string) => void;
+    onAdd: () => void;
+    onRemove: (id: string) => void;
+}
+
+export default function MultiboxTabBar({ accounts, activeTab, onSwitch, onAdd, onRemove }: TabBarProps) {
+    return (
+        <div className={cl("bar")}>
+            <div
+                className={cl("tab", activeTab === "main" ? "tab-active" : "")}
+                onClick={() => onSwitch("main")}
+            >
+                Main
+            </div>
+            {accounts.map(account => (
+                <div
+                    key={account.id}
+                    className={cl("tab", activeTab === account.id ? "tab-active" : "")}
+                    onClick={() => onSwitch(account.id)}
+                >
+                    <span className={cl("tab-label")}>{account.label}</span>
+                    <span
+                        className={cl("tab-close")}
+                        onClick={e => {
+                            e.stopPropagation();
+                            onRemove(account.id);
+                        }}
+                    >
+                        {"\u00d7"}
+                    </span>
+                </div>
+            ))}
+            <div className={cl("tab-add")} onClick={onAdd}>
+                +
+            </div>
+        </div>
+    );
+}

--- a/src/equicordplugins/multibox.desktop/index.tsx
+++ b/src/equicordplugins/multibox.desktop/index.tsx
@@ -1,0 +1,119 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and Equicord contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import * as DataStore from "@api/DataStore";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin, { PluginNative } from "@utils/types";
+import { useState } from "@webpack/common";
+import { JSX } from "react";
+
+import MultiboxTabBar from "./components/TabBar";
+
+const Native = VencordNative.pluginHelpers.Multibox as PluginNative<typeof import("./native")>;
+
+const STORE_KEY = "multibox-accounts";
+
+export interface AccountTab {
+    id: string;
+    label: string;
+}
+
+let accounts: AccountTab[] = [];
+let activeTab = "main";
+let forceUpdateFn: (() => void) | null = null;
+
+function generateId(): string {
+    return Math.random().toString(36).substring(2, 10);
+}
+
+async function switchTab(id: string) {
+    activeTab = id;
+    await Native.switchTo(id);
+    forceUpdateFn?.();
+}
+
+async function addTab() {
+    const id = generateId();
+    const label = `Account ${accounts.length + 2}`;
+    accounts = [...accounts, { id, label }];
+    await Native.addAccount(id);
+    await DataStore.set(STORE_KEY, accounts);
+    await switchTab(id);
+}
+
+async function removeTab(id: string) {
+    await Native.removeAccount(id);
+    accounts = accounts.filter(a => a.id !== id);
+    await DataStore.set(STORE_KEY, accounts);
+    if (activeTab === id) {
+        await switchTab("main");
+    } else {
+        forceUpdateFn?.();
+    }
+}
+
+function MultiboxContainer({ children }: { children: JSX.Element; }) {
+    const [, setTick] = useState(0);
+    forceUpdateFn = () => setTick(t => t + 1);
+
+    return (
+        <>
+            <ErrorBoundary>
+                <MultiboxTabBar
+                    accounts={accounts}
+                    activeTab={activeTab}
+                    onSwitch={switchTab}
+                    onAdd={addTab}
+                    onRemove={removeTab}
+                />
+            </ErrorBoundary>
+            {children}
+        </>
+    );
+}
+
+export default definePlugin({
+    name: "Multibox",
+    description: "Run multiple Discord accounts in tabs within a single Equibop window",
+    authors: [EquicordDevs.DonutsDelivery],
+
+    patches: [
+        {
+            find: '"AppView"',
+            replacement: {
+                match: /((\i\?.params)\?\.channelId.{0,600})"div",{(?=className:\i\.\i)/,
+                replace: "$1$self.render,{",
+            }
+        }
+    ],
+
+    render({ children }: { children: JSX.Element; }) {
+        return <MultiboxContainer>{children}</MultiboxContainer>;
+    },
+
+    async start() {
+        await Native.initialize();
+
+        const saved: AccountTab[] = await DataStore.get(STORE_KEY) ?? [];
+        accounts = saved;
+        for (const account of accounts) {
+            await Native.addAccount(account.id);
+        }
+
+        activeTab = "main";
+        forceUpdateFn?.();
+    },
+
+    async stop() {
+        await Native.cleanup();
+        accounts = [];
+        activeTab = "main";
+        forceUpdateFn = null;
+    }
+});

--- a/src/equicordplugins/multibox.desktop/native.ts
+++ b/src/equicordplugins/multibox.desktop/native.ts
@@ -1,0 +1,90 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and Equicord contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { BrowserWindow, IpcMainInvokeEvent, session, shell, WebContentsView } from "electron";
+
+const views = new Map<string, WebContentsView>();
+let mainWindow: BrowserWindow | null = null;
+const TAB_BAR_HEIGHT = 36;
+
+function onResize() {
+    if (!mainWindow) return;
+    const [width, height] = mainWindow.getContentSize();
+    for (const view of views.values()) {
+        if (mainWindow.contentView.children.includes(view)) {
+            view.setBounds({ x: 0, y: TAB_BAR_HEIGHT, width, height: height - TAB_BAR_HEIGHT });
+        }
+    }
+}
+
+export async function initialize(event: IpcMainInvokeEvent) {
+    mainWindow = BrowserWindow.fromWebContents(event.sender);
+    if (mainWindow) {
+        mainWindow.on("resize", onResize);
+    }
+}
+
+export async function addAccount(event: IpcMainInvokeEvent, id: string) {
+    if (!mainWindow || views.has(id)) return;
+
+    const ses = session.fromPartition(`persist:multibox-${id}`);
+    const view = new WebContentsView({
+        webPreferences: {
+            session: ses,
+        }
+    });
+
+    const [width, height] = mainWindow.getContentSize();
+    view.setBounds({ x: 0, y: TAB_BAR_HEIGHT, width, height: height - TAB_BAR_HEIGHT });
+
+    view.webContents.setUserAgent(mainWindow.webContents.getUserAgent());
+
+    view.webContents.setWindowOpenHandler(({ url }) => {
+        shell.openExternal(url);
+        return { action: "deny" };
+    });
+
+    views.set(id, view);
+    view.webContents.loadURL("https://discord.com/app");
+}
+
+export async function switchTo(event: IpcMainInvokeEvent, id: string) {
+    if (!mainWindow) return;
+
+    for (const view of views.values()) {
+        try { mainWindow.contentView.removeChildView(view); } catch { }
+    }
+
+    if (id === "main") return;
+
+    const view = views.get(id);
+    if (!view) return;
+
+    const [width, height] = mainWindow.getContentSize();
+    view.setBounds({ x: 0, y: TAB_BAR_HEIGHT, width, height: height - TAB_BAR_HEIGHT });
+    mainWindow.contentView.addChildView(view);
+}
+
+export async function removeAccount(event: IpcMainInvokeEvent, id: string) {
+    const view = views.get(id);
+    if (!view || !mainWindow) return;
+
+    try { mainWindow.contentView.removeChildView(view); } catch { }
+    view.webContents.close();
+    views.delete(id);
+}
+
+export async function cleanup(event: IpcMainInvokeEvent) {
+    if (mainWindow) {
+        mainWindow.removeListener("resize", onResize);
+        for (const view of views.values()) {
+            try { mainWindow.contentView.removeChildView(view); } catch { }
+            view.webContents.close();
+        }
+    }
+    views.clear();
+    mainWindow = null;
+}

--- a/src/equicordplugins/multibox.desktop/style.css
+++ b/src/equicordplugins/multibox.desktop/style.css
@@ -1,0 +1,92 @@
+/* Multibox tab bar — fixed at top so native WebContentsViews can't cover it */
+.vc-multibox-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 36px;
+    background: var(--background-secondary-alt, #1e1f22);
+    display: flex;
+    align-items: center;
+    padding: 0 8px;
+    z-index: 99999;
+    border-bottom: 1px solid var(--background-modifier-accent, #2b2d31);
+    gap: 2px;
+    user-select: none;
+    -webkit-app-region: no-drag;
+}
+
+.vc-multibox-tab {
+    display: flex;
+    align-items: center;
+    height: 28px;
+    padding: 0 12px;
+    border-radius: 4px;
+    color: var(--interactive-normal, #b5bac1);
+    font-size: 13px;
+    font-family: var(--font-primary);
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s;
+    white-space: nowrap;
+}
+
+.vc-multibox-tab:hover {
+    background: var(--background-modifier-hover, #2b2d31);
+    color: var(--interactive-hover, #dbdee1);
+}
+
+.vc-multibox-tab-active {
+    background: var(--background-modifier-selected, #35373c);
+    color: var(--interactive-active, #f2f3f5);
+}
+
+.vc-multibox-tab-active:hover {
+    background: var(--background-modifier-selected, #35373c);
+}
+
+.vc-multibox-tab-label {
+    pointer-events: none;
+}
+
+.vc-multibox-tab-close {
+    margin-left: 6px;
+    font-size: 16px;
+    line-height: 1;
+    opacity: 0;
+    transition: opacity 0.15s;
+    padding: 0 2px;
+    border-radius: 2px;
+}
+
+.vc-multibox-tab:hover .vc-multibox-tab-close {
+    opacity: 0.7;
+}
+
+.vc-multibox-tab-close:hover {
+    opacity: 1 !important;
+    background: var(--background-modifier-accent, #4e5058);
+}
+
+.vc-multibox-tab-add {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    color: var(--interactive-normal, #b5bac1);
+    font-size: 18px;
+    cursor: pointer;
+    transition: background-color 0.15s, color 0.15s;
+}
+
+.vc-multibox-tab-add:hover {
+    background: var(--background-modifier-hover, #2b2d31);
+    color: var(--interactive-hover, #dbdee1);
+}
+
+/* Push Discord content below the fixed tab bar */
+#app-mount {
+    margin-top: 36px !important;
+    height: calc(100vh - 36px) !important;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1260,6 +1260,10 @@ export const EquicordDevs = Object.freeze({
         name: "yash",
         id: 889150838658977874n,
     },
+    DonutsDelivery: {
+        name: "DonutsDelivery",
+        id: 0n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Summary
- Adds **Multibox** plugin — run multiple Discord accounts in tabs within a single Equibop window
- Click "+" to add an account tab with its own isolated session, switch between accounts instantly
- Desktop-only (`.desktop` plugin) using native WebContentsView for session isolation

## Implementation
- React component with AppView webpack patch (no raw DOM manipulation)
- Native `WebContentsView` with `session.fromPartition()` for isolated sessions
- `DataStore` persistence across restarts
- CSS uses `vc-multibox-` prefix convention and theme variables

## Test plan
- [ ] Enable Multibox in plugin settings
- [ ] Tab bar appears at top with "Main" tab and "+" button
- [ ] Click "+" — new tab appears, fresh Discord login page loads
- [ ] Switch between tabs — correct account shows
- [ ] Close tab via "×" — account removed, switches back to Main
- [ ] Restart Equibop — tabs persist and restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)