### PR TITLE
Feat/Markdown Shortcuts

### DIFF
--- a/src/equicordplugins/markdownShortcuts/components/KeybindRecorder.tsx
+++ b/src/equicordplugins/markdownShortcuts/components/KeybindRecorder.tsx
@@ -1,0 +1,127 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Button } from "@components/Button";
+import { IS_MAC } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
+import { Logger } from "@utils/Logger";
+import { useEffect, useState } from "@webpack/common";
+
+import { MarkdownFormat } from "../types";
+import { DISCORD_BUILTIN_SHORTCUTS, formatKeybindDisplay, MODIFIER_KEYS, normalizeKeybindForComparison } from "../utils";
+
+const cl = classNameFactory("vc-mdshortcuts-");
+const logger = new Logger("MarkdownShortcuts");
+
+export function createKeybindRecorderComponent(
+    format: MarkdownFormat,
+    FORMATS: MarkdownFormat[],
+    getStore: () => Record<string, any>
+) {
+    return function KeybindRecorderForFormat() {
+        const [isListening, setIsListening] = useState(false);
+        const [error, setError] = useState<string | null>(null);
+        const store = getStore();
+        const isShortcutsEnabled = store.enableShortcuts;
+
+        let currentKeybind: string[] = store[format.settingKey];
+        if (!Array.isArray(currentKeybind)) {
+            currentKeybind = format.defaultKeybind || [];
+        }
+
+        useEffect(() => {
+            if (!isListening) return;
+
+            const handleKeyDown = (event: KeyboardEvent) => {
+                event.preventDefault();
+                event.stopPropagation();
+
+                if (MODIFIER_KEYS.has(event.key)) return;
+
+                const keys: string[] = [];
+                if (event.metaKey) keys.push("META");
+                if (event.ctrlKey) keys.push(IS_MAC ? "CONTROL" : "CTRL");
+                if (event.shiftKey) keys.push("SHIFT");
+                if (event.altKey) keys.push("ALT");
+
+                let mainKey = event.key.toUpperCase();
+                if (mainKey === " ") mainKey = "SPACE";
+                if (mainKey === "ESCAPE") mainKey = "ESC";
+                keys.push(mainKey);
+
+                const normalized = normalizeKeybindForComparison(keys);
+                const currentStore = getStore();
+
+                for (const otherFormat of FORMATS) {
+                    if (otherFormat.settingKey === format.settingKey) continue;
+                    const otherKeys: string[] = currentStore[otherFormat.settingKey] ?? [];
+                    if (otherKeys.length && normalizeKeybindForComparison(otherKeys) === normalized) {
+                        setError(`Already used by: ${otherFormat.name}`);
+                        setTimeout(() => setError(null), 3000);
+                        setIsListening(false);
+                        return;
+                    }
+                }
+
+                if (DISCORD_BUILTIN_SHORTCUTS.includes(normalized)) {
+                    logger.warn(`Shortcut for ${format.name} may conflict with a Discord built-in shortcut.`);
+                }
+
+                currentStore[format.settingKey] = keys;
+                setError(null);
+                setIsListening(false);
+            };
+
+            const handleBlur = () => setIsListening(false);
+
+            document.addEventListener("keydown", handleKeyDown, true);
+            window.addEventListener("blur", handleBlur);
+
+            return () => {
+                document.removeEventListener("keydown", handleKeyDown, true);
+                window.removeEventListener("blur", handleBlur);
+            };
+        }, [isListening]);
+
+        const handleClear = () => {
+            getStore()[format.settingKey] = [];
+            setError(null);
+        };
+
+        return (
+            <div
+                className={cl("keybind-row")}
+                style={{
+                    opacity: isShortcutsEnabled ? 1 : 0.4,
+                    pointerEvents: isShortcutsEnabled ? "auto" : "none"
+                }}
+            >
+                <div className={cl("keybind-info")}>
+                    <span className={cl("keybind-label")}>{format.name}</span>
+                    {error && (
+                        <span className={cl("keybind-conflict")}>{error}</span>
+                    )}
+                </div>
+                <div className={cl("keybind-controls")}>
+                    <button
+                        type="button"
+                        className={cl("keybind-button", isListening ? "listening" : "")}
+                        onClick={() => setIsListening(true)}
+                    >
+                        {isListening ? "Press a key..." : formatKeybindDisplay(currentKeybind)}
+                    </button>
+                    <Button
+                        size="small"
+                        variant="secondary"
+                        onClick={handleClear}
+                    >
+                        Clear
+                    </Button>
+                </div>
+            </div>
+        );
+    };
+}

--- a/src/equicordplugins/markdownShortcuts/index.tsx
+++ b/src/equicordplugins/markdownShortcuts/index.tsx
@@ -1,0 +1,192 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { EquicordDevs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
+import { Logger } from "@utils/Logger";
+import definePlugin, { OptionType } from "@utils/types";
+
+import { createKeybindRecorderComponent } from "./components/KeybindRecorder";
+import managedStyle from "./styles.css?managed";
+import { ToolbarManager } from "./toolbar";
+import { MarkdownFormat } from "./types";
+import { applyFormatToSelection, isEditableTarget, matchesKeybind } from "./utils";
+
+const cl = classNameFactory("vc-mdshortcuts-");
+const logger = new Logger("MarkdownShortcuts");
+
+const FORMATS: MarkdownFormat[] = [
+    { name: "Bold", prefix: "**", suffix: "**", settingKey: "boldShortcut", lineLevel: false, toolbarIcon: null, toolbarLabel: "Bold", defaultKeybind: ["ctrl", "b"] },
+    { name: "Italic", prefix: "*", suffix: "*", settingKey: "italicShortcut", lineLevel: false, toolbarIcon: null, toolbarLabel: "Italic", defaultKeybind: ["ctrl", "i"] },
+    {
+        name: "Underline", prefix: "__", suffix: "__", settingKey: "underlineShortcut", lineLevel: false, toolbarLabel: "Underline",
+        toolbarIcon: '<svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M12 17c3.31 0 6-2.69 6-6V3h-2.5v8c0 1.93-1.57 3.5-3.5 3.5S8.5 12.93 8.5 11V3H6v8c0 3.31 2.69 6 6 6zm-7 2v2h14v-2H5z"/></svg>',
+        defaultKeybind: ["ctrl", "u"]
+    },
+    { name: "Strikethrough", prefix: "~~", suffix: "~~", settingKey: "strikethroughShortcut", lineLevel: false, toolbarIcon: null, toolbarLabel: "Strikethrough", defaultKeybind: ["ctrl", "shift", "x"] },
+    { name: "Spoiler", prefix: "||", suffix: "||", settingKey: "spoilerShortcut", lineLevel: false, toolbarIcon: null, toolbarLabel: "Spoiler", defaultKeybind: ["ctrl", "shift", "s"] },
+    { name: "Inline Code", prefix: "`", suffix: "`", settingKey: "inlineCodeShortcut", lineLevel: false, toolbarIcon: null, toolbarLabel: "Inline Code", defaultKeybind: ["ctrl", "e"] },
+    {
+        name: "Code Block", prefix: "```\n", suffix: "\n```", settingKey: "codeBlockShortcut", lineLevel: false, toolbarLabel: "Code Block",
+        toolbarIcon: '<svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><text x="12" y="17" text-anchor="middle" font-size="14" font-weight="bold" font-family="monospace">{/}</text></svg>',
+        defaultKeybind: ["ctrl", "shift", "e"]
+    },
+    {
+        name: "Header 1", prefix: "# ", suffix: "", settingKey: "header1Shortcut", lineLevel: true, toolbarLabel: "Header 1",
+        toolbarIcon: '<svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><text x="12" y="17" text-anchor="middle" font-size="16" font-weight="bold" font-family="sans-serif">H1</text></svg>',
+        defaultKeybind: ["ctrl", "shift", "1"]
+    },
+    {
+        name: "Header 2", prefix: "## ", suffix: "", settingKey: "header2Shortcut", lineLevel: true, toolbarLabel: "Header 2",
+        toolbarIcon: '<svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><text x="12" y="17" text-anchor="middle" font-size="16" font-weight="bold" font-family="sans-serif">H2</text></svg>',
+        defaultKeybind: ["ctrl", "shift", "2"]
+    },
+    {
+        name: "Header 3", prefix: "### ", suffix: "", settingKey: "header3Shortcut", lineLevel: true, toolbarLabel: "Header 3",
+        toolbarIcon: '<svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><text x="12" y="17" text-anchor="middle" font-size="16" font-weight="bold" font-family="sans-serif">H3</text></svg>',
+        defaultKeybind: ["ctrl", "shift", "3"]
+    },
+    {
+        name: "Subtext", prefix: "-# ", suffix: "", settingKey: "subtextShortcut", lineLevel: true, toolbarLabel: "Subtext",
+        toolbarIcon: '<svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><text x="12" y="17" text-anchor="middle" font-size="14" font-weight="bold" font-family="sans-serif">-#</text></svg>',
+        defaultKeybind: ["ctrl", "shift", "t"]
+    },
+    { name: "Block Quote", prefix: "> ", suffix: "", settingKey: "blockQuoteShortcut", lineLevel: true, toolbarIcon: null, toolbarLabel: "Block Quote", defaultKeybind: ["ctrl", "shift", "q"] },
+    {
+        name: "Block Quote Multi", prefix: ">>> ", suffix: "", settingKey: "blockQuoteMultiShortcut", lineLevel: true, toolbarLabel: "Block Quote (Multi-line)",
+        toolbarIcon: '<svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20"><path d="M6 17h3l2-4V7H5v6h3zm8 0h3l2-4V7h-6v6h3z"/></svg>',
+        defaultKeybind: ["ctrl", "alt", "q"]
+    },
+];
+
+const TOOLBAR_ORDER = ["Underline", "Subtext", "Header 1", "Header 2", "Header 3", "Block Quote Multi", "Code Block"];
+const TOOLBAR_FORMATS = TOOLBAR_ORDER.map(name => FORMATS.find(f => f.name === name)!).filter(Boolean);
+
+const settingsDefinition: Record<string, any> = {};
+
+settingsDefinition.enableToolbarButtons = {
+    type: OptionType.BOOLEAN,
+    description: "Add extra formatting buttons to the text selection toolbar.",
+    default: true,
+};
+
+settingsDefinition.enableShortcuts = {
+    type: OptionType.BOOLEAN,
+    description: "Enable custom markdown keyboard shortcuts.",
+    default: true,
+};
+
+settingsDefinition.shortcutControls = {
+    type: OptionType.COMPONENT,
+    description: "Bulk actions for all keyboard shortcuts:",
+    component: () => {
+        const isShortcutsEnabled = settings.store.enableShortcuts;
+
+        const handleDisableAll = () => {
+            const store = settings.store as Record<string, any>;
+            for (const format of FORMATS) {
+                store[format.settingKey] = [];
+            }
+        };
+
+        const handleResetAll = () => {
+            const store = settings.store as Record<string, any>;
+            for (const format of FORMATS) {
+                store[format.settingKey] = format.defaultKeybind || [];
+            }
+        };
+
+        return (
+            <div style={{
+                display: "flex", gap: "10px", marginTop: "4px", marginBottom: "8px",
+                paddingBottom: "12px", borderBottom: "1px solid var(--background-modifier-accent)",
+                opacity: isShortcutsEnabled ? 1 : 0.4,
+                pointerEvents: isShortcutsEnabled ? "auto" : "none"
+            }}>
+                <button
+                    type="button"
+                    className={cl("keybind-button")}
+                    style={{ color: "var(--text-danger)" }}
+                    onClick={handleDisableAll}
+                >
+                    Disable All Shortcuts
+                </button>
+                <button
+                    type="button"
+                    className={cl("keybind-button")}
+                    onClick={handleResetAll}
+                >
+                    Reset to Defaults
+                </button>
+            </div>
+        );
+    }
+};
+
+for (const format of FORMATS) {
+    settingsDefinition[format.settingKey] = {
+        type: OptionType.COMPONENT,
+        description: `Keyboard shortcut for ${format.name}. Click to record, Clear to disable.`,
+        default: format.defaultKeybind || [],
+        component: createKeybindRecorderComponent(format, FORMATS, () => settings.store),
+    };
+}
+
+const settings = definePluginSettings(settingsDefinition);
+
+function handleKeyDown(e: KeyboardEvent) {
+    if (!isEditableTarget(e.target)) return;
+
+    const store = settings.store as Record<string, any>;
+    if (!store.enableShortcuts) return;
+
+    for (const format of FORMATS) {
+        let keybind: string[] = store[format.settingKey];
+        if (!Array.isArray(keybind)) {
+            keybind = format.defaultKeybind || [];
+        }
+
+        if (keybind.length && matchesKeybind(e, keybind)) {
+            e.preventDefault();
+            e.stopPropagation();
+            applyFormatToSelection(format);
+            return;
+        }
+    }
+
+    for (const format of FORMATS) {
+        if (format.defaultKeybind && format.defaultKeybind.length > 0 && matchesKeybind(e, format.defaultKeybind)) {
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+        }
+    }
+}
+
+export default definePlugin({
+    name: "MarkdownShortcuts",
+    description: "Adds customizable keyboard shortcuts and toolbar buttons for Markdown formatting in chat input.",
+    authors: [EquicordDevs.feniks],
+    settings,
+    managedStyle,
+
+    start() {
+        document.addEventListener("keydown", handleKeyDown, true);
+
+        if (settings.store.enableToolbarButtons) {
+            ToolbarManager.start(TOOLBAR_FORMATS);
+        }
+
+        logger.info("Started");
+    },
+
+    stop() {
+        document.removeEventListener("keydown", handleKeyDown, true);
+        ToolbarManager.stop();
+        logger.info("Stopped");
+    },
+});

--- a/src/equicordplugins/markdownShortcuts/styles.css
+++ b/src/equicordplugins/markdownShortcuts/styles.css
@@ -1,0 +1,115 @@
+.vc-mdshortcuts-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    min-height: 28px;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+    color: var(--interactive-normal);
+    transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
+}
+
+.vc-mdshortcuts-btn:hover {
+    color: var(--white-500, #fff);
+    background-color: var(--background-modifier-selected, rgb(255 255 255 / 8%));
+}
+
+.vc-mdshortcuts-btn svg {
+    width: 20px;
+    height: 20px;
+    display: block;
+}
+
+.vc-mdshortcuts-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    gap: 4px;
+}
+
+#slate-toolbar:has(#vc-mdshortcuts-container) {
+    transform: translateY(-36px);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+}
+
+.vc-mdshortcuts-keybind-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--background-modifier-accent);
+}
+
+.vc-mdshortcuts-keybind-row:last-child {
+    border-bottom: none;
+}
+
+.vc-mdshortcuts-keybind-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+
+.vc-mdshortcuts-keybind-label {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--header-primary, #fff) !important;
+}
+
+.vc-mdshortcuts-keybind-conflict {
+    font-size: 12px;
+    color: var(--text-danger, #f04747) !important;
+    font-weight: 500;
+}
+
+.vc-mdshortcuts-keybind-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.vc-mdshortcuts-keybind-button {
+    min-width: 120px;
+    padding: 6px 12px;
+    border: 1px solid var(--background-modifier-accent);
+    border-radius: 4px;
+    background: var(--background-secondary);
+    color: var(--interactive-normal, #b9bbbe) !important;
+    font-size: 14px;
+    font-weight: 500;
+    text-align: center;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.vc-mdshortcuts-keybind-button:hover {
+    border-color: var(--interactive-hover);
+    background: var(--background-secondary-alt);
+    color: var(--interactive-hover, #dcddde) !important;
+}
+
+.vc-mdshortcuts-keybind-button.vc-mdshortcuts-listening {
+    border-color: var(--brand-500, #5865f2) !important;
+    background: var(--background-secondary-alt) !important;
+    color: var(--brand-500, #5865f2) !important;
+    box-shadow: 0 0 0 1px var(--brand-500, #5865f2);
+    animation: vc-mdshortcuts-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes vc-mdshortcuts-pulse {
+    0%, 100% { box-shadow: 0 0 0 1px var(--brand-500, #5865f2); }
+    50% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand-500, #5865f2) 40%, transparent); }
+}

--- a/src/equicordplugins/markdownShortcuts/toolbar.ts
+++ b/src/equicordplugins/markdownShortcuts/toolbar.ts
@@ -1,0 +1,80 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@utils/css";
+
+import { MarkdownFormat } from "./types";
+import { applyFormatToSelection } from "./utils";
+
+const cl = classNameFactory("vc-mdshortcuts-");
+const TOOLBAR_CONTAINER_ID = "vc-mdshortcuts-container";
+
+export function createToolbarButton(format: MarkdownFormat): HTMLButtonElement {
+    const btn = document.createElement("button");
+    btn.className = cl("btn");
+    btn.setAttribute("aria-label", format.toolbarLabel);
+    btn.title = format.toolbarLabel;
+    btn.innerHTML = format.toolbarIcon!;
+    btn.addEventListener("mousedown", e => {
+        e.preventDefault();
+        e.stopPropagation();
+    });
+
+    btn.addEventListener("click", e => {
+        e.preventDefault();
+        e.stopPropagation();
+        applyFormatToSelection(format);
+    });
+
+    return btn;
+}
+
+export function injectToolbarButtons(toolbar: HTMLElement, formats: MarkdownFormat[]) {
+    if (toolbar.querySelector(`#${TOOLBAR_CONTAINER_ID}`)) return;
+
+    const container = document.createElement("span");
+    container.id = TOOLBAR_CONTAINER_ID;
+    container.className = cl("container");
+
+    for (const format of formats) {
+        container.appendChild(createToolbarButton(format));
+    }
+
+    toolbar.appendChild(container);
+}
+
+export class ToolbarManager {
+    static observer: MutationObserver | null = null;
+
+    static start(formats: MarkdownFormat[]) {
+        this.observer = new MutationObserver(mutations => {
+            for (const mutation of mutations) {
+                for (const node of mutation.addedNodes) {
+                    if (!(node instanceof HTMLElement)) continue;
+
+                    const toolbar = node.id === "slate-toolbar" ? node : node.querySelector("#slate-toolbar");
+                    if (toolbar instanceof HTMLElement) {
+                        injectToolbarButtons(toolbar, formats);
+                    }
+                }
+            }
+        });
+
+        this.observer.observe(document.body, { childList: true, subtree: true });
+
+        const existingToolbar = document.getElementById("slate-toolbar");
+        if (existingToolbar) {
+            injectToolbarButtons(existingToolbar, formats);
+        }
+    }
+
+    static stop() {
+        this.observer?.disconnect();
+        this.observer = null;
+
+        document.querySelectorAll(`#${TOOLBAR_CONTAINER_ID}`).forEach(el => el.remove());
+    }
+}

--- a/src/equicordplugins/markdownShortcuts/types.ts
+++ b/src/equicordplugins/markdownShortcuts/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface MarkdownFormat {
+    name: string;
+    prefix: string;
+    suffix: string;
+    settingKey: string;
+    lineLevel: boolean;
+    toolbarIcon: string | null;
+    toolbarLabel: string;
+    defaultKeybind: string[];
+}

--- a/src/equicordplugins/markdownShortcuts/utils.ts
+++ b/src/equicordplugins/markdownShortcuts/utils.ts
@@ -1,0 +1,116 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { IS_MAC } from "@utils/constants";
+import { Logger } from "@utils/Logger";
+
+import { MarkdownFormat } from "./types";
+
+const logger = new Logger("MarkdownShortcuts");
+
+export const MODIFIER_KEYS = new Set(["Control", "Shift", "Alt", "Meta"]);
+export const DISCORD_BUILTIN_SHORTCUTS = ["ctrl+b", "ctrl+i", "ctrl+u", "ctrl+shift+x", "ctrl+e"];
+
+export function normalizeKeybindForComparison(keys: string[]): string {
+    return keys.map(k => k.toLowerCase()).sort().join("+");
+}
+
+export function formatKeybindDisplay(keys: string[]): string {
+    if (!keys.length) return "Not set";
+
+    const isMac = navigator.platform.toUpperCase().includes("MAC");
+
+    return keys.map(k => {
+        const upper = k.toUpperCase();
+        if (isMac) {
+            if (upper === "CTRL" || upper === "MOD") return "⌘";
+            if (upper === "CONTROL") return "⌃";
+            if (upper === "META") return "⌘";
+            if (upper === "ALT") return "⌥";
+            if (upper === "SHIFT") return "⇧";
+        }
+        return upper;
+    }).join(" + ");
+}
+
+export function matchesKeybind(e: KeyboardEvent, keybind: string[]): boolean {
+    if (!keybind.length) return false;
+
+    const pressed = e.key.toLowerCase();
+    const code = e.code.toLowerCase().replace("key", "").replace("digit", "");
+
+    let hasNonModifier = false;
+
+    for (const key of keybind) {
+        const lower = key.toLowerCase();
+        switch (lower) {
+            case "mod":
+            case "ctrl":
+                if (!(IS_MAC ? e.metaKey : e.ctrlKey)) return false;
+                break;
+            case "control":
+                if (!e.ctrlKey) return false;
+                break;
+            case "meta":
+            case "cmd":
+                if (!e.metaKey) return false;
+                break;
+            case "shift":
+                if (!e.shiftKey) return false;
+                break;
+            case "alt":
+            case "option":
+                if (!e.altKey) return false;
+                break;
+            default:
+                hasNonModifier = true;
+                if (pressed !== lower && code !== lower) return false;
+        }
+    }
+
+    return hasNonModifier;
+}
+
+export function applyFormatToSelection(format: MarkdownFormat) {
+    try {
+        const sel = window.getSelection();
+        if (!sel || sel.rangeCount === 0) return;
+
+        const selectedText = sel.toString();
+        const hasSelection = selectedText.length > 0;
+
+        let replacement: string;
+        if (format.lineLevel) {
+            replacement = hasSelection ? format.prefix + selectedText : format.prefix;
+        } else {
+            replacement = hasSelection
+                ? format.prefix + selectedText + format.suffix
+                : format.prefix + format.suffix;
+        }
+
+        const dt = new DataTransfer();
+        dt.setData("text/plain", replacement);
+
+        document.dispatchEvent(
+            new ClipboardEvent("paste", {
+                clipboardData: dt,
+            })
+        );
+    } catch (err) {
+        logger.error("Failed to apply format", format.name, err);
+    }
+}
+
+export function isEditableTarget(el: EventTarget | null): boolean {
+    if (!el || !(el instanceof HTMLElement)) return false;
+    return (
+        el instanceof HTMLTextAreaElement ||
+        el.getAttribute("contenteditable") === "true" ||
+        el.getAttribute("role") === "textbox" ||
+        el.closest('[contenteditable="true"]') != null ||
+        el.closest('[role="textbox"]') != null
+    );
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1263,7 +1263,11 @@ export const EquicordDevs = Object.freeze({
     Leon135: {
         name: "Leon135",
         id: 309275452231385088n,
-    }
+    },
+    feniks: {
+        name: "feniks",
+        id: 327398275898671105n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
I've been working on a new plugin called **MarkdownShortcuts**.

**What it does:** It adds customizable keyboard shortcuts for common markdown formatting (bold, italics, strikethrough, code blocks, etc.) and injects formatting buttons directly into the chat input toolbar.

**Why we need this:** Discord's built-in markdown formatting shortcuts are very limited and can sometimes conflict. This plugin lets users define their own custom keybinds for every markdown style. It also adds a visual toolbar for those who prefer clicking over typing markdown symbols manually, making text formatting much faster and more accessible.