### PR TITLE
Ghosted: add max inactive time for dms

### DIFF
--- a/src/equicordplugins/ghosted/Boo.tsx
+++ b/src/equicordplugins/ghosted/Boo.tsx
@@ -98,6 +98,9 @@ export function Boo({ channel }: { channel: Channel; }) {
     });
     const [isCleared, setIsCleared] = useState(false);
 
+    const lastMessageTimestampMs = lastMessage ? new Date(lastMessage.timestamp).getTime() : 0;
+    const isInactive = !!lastMessage && settings.store.maxInactiveTimeMs > 0 && Number.isFinite(lastMessageTimestampMs) && Date.now() - lastMessageTimestampMs > settings.store.maxInactiveTimeMs;
+
     useEffect(() => {
         if (!lastMessage || !currentUserId) return;
 
@@ -167,7 +170,7 @@ export function Boo({ channel }: { channel: Channel; }) {
         }
 
         // if exempted or bot (if setting enabled), remove from ghost tracking
-        if (isExempted || (settings.store.ignoreBots && lastMessage.author.bot)) {
+        if (isExempted || (settings.store.ignoreBots && lastMessage.author.bot) || isInactive) {
             if (countedChannels.has(id)) {
                 countedChannels.delete(id);
                 setBooCount(getBooCount() - 1);
@@ -187,9 +190,9 @@ export function Boo({ channel }: { channel: Channel; }) {
                 setBooCount(getBooCount() + 1);
             }
         }
-    }, [state.isCurrentUser, state.isDataProcessed, id, lastMessage?.id]);
+    }, [state.isCurrentUser, state.isDataProcessed, id, lastMessage?.id, isInactive]);
 
-    if (!state.isDataProcessed || !currentUserId || !lastMessage || state.isCurrentUser || isChannelExempted(channel) || isCleared || (settings.store.ignoreBots && lastMessage.author.bot))
+    if (!state.isDataProcessed || !currentUserId || !lastMessage || state.isCurrentUser || isChannelExempted(channel) || isCleared || (settings.store.ignoreBots && lastMessage.author.bot) || isInactive)
         return null;
 
     if (!settings.store.showDmIcons) return null;

--- a/src/equicordplugins/ghosted/index.tsx
+++ b/src/equicordplugins/ghosted/index.tsx
@@ -52,6 +52,18 @@ export const settings = definePluginSettings({
         description: "Ignore DMs from bots",
         default: true,
         restartNeeded: false
+    },
+    maxInactiveTimeMs: {
+        type: OptionType.SELECT,
+        description: "Only ghost DMs active within this timeframe",
+        options: [
+            { label: "No limit", value: 0, default: true },
+            { label: "1 hour", value: 60 * 60 * 1000 },
+            { label: "1 day", value: 24 * 60 * 60 * 1000 },
+            { label: "1 week", value: 7 * 24 * 60 * 60 * 1000 },
+            { label: "1 month", value: 30 * 24 * 60 * 60 * 1000 },
+        ],
+        restartNeeded: false
     }
 });
 


### PR DESCRIPTION
Ignores DMs if they're older than the configured inactive time