### PR TITLE
Questify: Fixes.

### DIFF
--- a/src/equicordplugins/questify/index.tsx
+++ b/src/equicordplugins/questify/index.tsx
@@ -1388,8 +1388,8 @@ export default definePlugin({
                 },
                 {
                     // Prevent SearchableSelect from force-scrolling into view, causing the dropdown to close.
-                    match: /(?<=\.scrollIntoView\()/,
-                    replace: "{block:\"nearest\",inline:\"nearest\"}"
+                    match: /(&&\i.current\?\.scrollIntoView\(\))/,
+                    replace: ""
                 },
                 {
                     // Passes a popoutClassName and optionClassName to the popout handler.
@@ -1418,6 +1418,14 @@ export default definePlugin({
                     replace: ",...arguments[0]"
                 }
             ]
+        },
+        {
+            // Prevent the new version of SearchableSelect from force-scrolling into view.
+            find: '"data-mana-component":"combobox",',
+            replacement: {
+                match: /\i.current\?\.scrollIntoView\({.{0,50}?}\)/,
+                replace: ""
+            }
         },
         {
             // Formats the Orbs balance on the Quests page with locale string formatting.

--- a/src/equicordplugins/questify/utils/misc.tsx
+++ b/src/equicordplugins/questify/utils/misc.tsx
@@ -77,7 +77,7 @@ export function getQuestProgress(quest: Quest, task: QuestTask) {
 export function getQuestTarget(task: QuestTask) {
     const isWatch = task.type === QuestTaskType.WATCH_VIDEO || task.type === QuestTaskType.WATCH_VIDEO_ON_MOBILE;
     const raw = task.target;
-    const adjusted = raw - (isWatch ? videoQuestLeeway : 0);
+    const adjusted = Math.max(0, raw - (isWatch ? videoQuestLeeway : 0));
     return { raw, adjusted };
 }
 


### PR DESCRIPTION
Fixes some math in a function and prevents scroll-into-view for the new version of the selects. Technically the patch might be preventing more than just selects from auto scrolling. Hard to tell if it's a shared utility or not and I can't really be arsed to figure that out right now so :)