### PR TITLE
feat: Greentext plugin

### DIFF
--- a/src/equicordplugins/greenText/index.tsx
+++ b/src/equicordplugins/greenText/index.tsx
@@ -23,7 +23,7 @@ function makeColorRule(char: string, regex: RegExp, color: string) {
 }
 
 export default definePlugin({
-    name: "greenText",
+    name: "Greentext",
     description: "Renders imageboard-style colored text (>, <, ^).",
     authors: [EquicordDevs.NonsensicalOne],
 

--- a/src/equicordplugins/greenText/index.tsx
+++ b/src/equicordplugins/greenText/index.tsx
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import { EquicordDevs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { Parser } from "@webpack/common";
-
-import { equicordDevs } from "../../../scripts/utils";
 
 function makeColorRule(char: string, regex: RegExp, color: string) {
     return {
@@ -26,7 +25,7 @@ function makeColorRule(char: string, regex: RegExp, color: string) {
 export default definePlugin({
     name: "greenText",
     description: "Renders imageboard-style colored text (>, <, ^).",
-    authors: [equicordDevs.NonsensicalOne],
+    authors: [EquicordDevs.NonsensicalOne],
 
     start() {
         Parser.defaultRules.greentext = makeColorRule(">", /^>[^\n]*/, "#789922");

--- a/src/equicordplugins/greenText/index.tsx
+++ b/src/equicordplugins/greenText/index.tsx
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { Parser } from "@webpack/common";
+
+import { equicordDevs } from "../../../scripts/utils";
 
 function makeColorRule(char: string, regex: RegExp, color: string) {
     return {
@@ -23,9 +24,9 @@ function makeColorRule(char: string, regex: RegExp, color: string) {
 }
 
 export default definePlugin({
-    name: "Greentext",
+    name: "greenText",
     description: "Renders imageboard-style colored text (>, <, ^).",
-    authors: [Devs.NonsensicalOne],
+    authors: [equicordDevs.NonsensicalOne],
 
     start() {
         Parser.defaultRules.greentext = makeColorRule(">", /^>[^\n]*/, "#789922");

--- a/src/equicordplugins/greentext/index.tsx
+++ b/src/equicordplugins/greentext/index.tsx
@@ -1,0 +1,45 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { Parser } from "@webpack/common";
+
+function makeColorRule(char: string, regex: RegExp, color: string) {
+    return {
+        order: 9,
+        match: (source: string, state: any) => {
+            if (state.prevCapture?.[0].slice(-1) !== "\n" && state.prevCapture != null)
+                return null;
+            return regex.exec(source);
+        },
+        parse: (capture: string[]) => ({ content: capture[0] }),
+        react: (node: any) => <span style={{ color }}>{node.content}</span>,
+        requiredFirstCharacters: [char],
+    } as any;
+}
+
+export default definePlugin({
+    name: "Greentext",
+    description: "Renders imageboard-style colored text (>, <, ^).",
+    authors: [Devs.NonsensicalOne],
+
+    start() {
+        Parser.defaultRules.greentext = makeColorRule(">", /^>[^\n]*/, "#789922");
+        Parser.defaultRules.orangetext = makeColorRule("<", /^<(?!@)[^\n]*/, "#f6750b");
+        Parser.defaultRules.bluetext = makeColorRule("^", /^\^[^\n]*/, "#6577E6");
+
+        this._oldParse = Parser.parse;
+        Parser.parse = Parser.reactParserFor(Parser.defaultRules);
+    },
+
+    stop() {
+        delete Parser.defaultRules.greentext;
+        delete Parser.defaultRules.orangetext;
+        delete Parser.defaultRules.bluetext;
+        Parser.parse = this._oldParse;
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -143,6 +143,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Nickyux",
         id: 427146305651998721n
     },
+    NonsensicalOne: {
+        name: "nonsensical1",
+        id: 917403205250457641n
+    },
     mantikafasi: {
         name: "mantikafasi",
         id: 287555395151593473n

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -143,10 +143,6 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "Nickyux",
         id: 427146305651998721n
     },
-    NonsensicalOne: {
-        name: "nonsensical1",
-        id: 917403205250457641n
-    },
     mantikafasi: {
         name: "mantikafasi",
         id: 287555395151593473n
@@ -1279,6 +1275,10 @@ export const EquicordDevs = Object.freeze({
     ScattrdBlade: {
         name: "ScattrdBlade",
         id: 678007540608532491n
+    },
+    NonsensicalOne: {
+        name: "nonsensical1",
+        id: 917403205250457641n
     },
 } satisfies Record<string, Dev>);
 


### PR DESCRIPTION
This plugin introduces imageboard-style colored text

Use case: A lot of Discord servers, especially ones with imageboard culture, use these text styles regularly.

^bluetext
>greentext
<orangetext