### PR TITLE
homeTyping: Add CSS class targeting for theme compatibility

### DIFF
--- a/src/equicordplugins/homeTyping/index.tsx
+++ b/src/equicordplugins/homeTyping/index.tsx
@@ -4,44 +4,58 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { Devs } from "@utils/constants";
+import { Devs, EquicordDevs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { findComponentByCodeLazy, findStoreLazy } from "@webpack";
 import { TypingStore, UserStore, useStateFromStores } from "@webpack/common";
 
 const ThreeDots = findComponentByCodeLazy("Math.min(1,Math.max(", "dotRadius:");
 
-const PrivateChannelSortStore = findStoreLazy("PrivateChannelSortStore") as { getPrivateChannelIds: () => string[]; };
+const PrivateChannelSortStore = findStoreLazy("PrivateChannelSortStore") as {
+    getPrivateChannelIds: () => string[];
+};
 
 export default definePlugin({
     name: "HomeTyping",
-    description: "Changes the home button to a typing indicator if someone in your dms is typing",
-    authors: [Devs.Samwich],
+    description: "Changes the home button to a typing indicator if someone in your dms is typing.",
+    authors: [Devs.Samwich, EquicordDevs.playfairs],
+
     TypingIcon() {
         return <ThreeDots dotRadius={3} themed={true} />;
+    },
+    updateHomeButtonClass(isTyping: boolean) {
+        const homeButton = document.querySelector('[data-list-item-id="guildsnav___home"]');
+        if (homeButton) {
+            if (isTyping) {
+                homeButton.classList.add("vc-home-typing");
+            } else {
+                homeButton.classList.remove("vc-home-typing");
+            }
+        }
     },
     isTyping() {
         return useStateFromStores([TypingStore], () =>
             PrivateChannelSortStore.getPrivateChannelIds().some(id =>
-                Object.keys(TypingStore.getTypingUsers(id)).some(userId => userId !== UserStore.getCurrentUser().id)
+                Object.keys(TypingStore.getTypingUsers(id)).some(
+                    userId => userId !== UserStore.getCurrentUser().id
+                )
             )
         );
     },
+
     patches: [
         {
             find: "#{intl::DISCODO_DISABLED}",
-            replacement:
-                [
-                    {
-                        match: /(\(0,\i.jsx\)\(\i.\i,{}\))/,
-                        replace: "arguments[0].user == null ? null : (vcIsTyping ? $self.TypingIcon() : $1)"
-                    },
-                    // define isTyping earlier in the function so i dont bReAk ThE rUlEs Of HoOkS
-                    {
-                        match: /if\(null==\i\)return null;/,
-                        replace: "let vcIsTyping = $self.isTyping();$&"
-                    }
-                ],
+            replacement: [
+                {
+                    match: /(\(0,\i.jsx\)\(\i.\i,{}\))/,
+                    replace: "arguments[0].user == null ? null : ($self.updateHomeButtonClass(vcIsTyping), vcIsTyping ? $self.TypingIcon() : $1)"
+                },
+                {
+                    match: /if\(null==\i\)return null;/,
+                    replace: "let vcIsTyping = $self.isTyping();$&"
+                }
+            ],
             group: true
         }
     ]

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1278,8 +1278,12 @@ export const EquicordDevs = Object.freeze({
     },
     ScattrdBlade: {
         name: "ScattrdBlade",
-        id: 678007540608532491n
+        id: 678007540608532491n,
     },
+    playfairs: {
+        name: "playfairs",
+        id: 1426711359059394662n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Updated the homeTyping plugin because I noticed whenever I have a custom theme enabled that has a custom Home icon, the icon does not change when someone is typing, so I fixed it, there is some flaws with how I did this, for a CSS theme to be able to change with the plugin you need to add 
```css

/* This bit allows for the home button to change even with a custom icon, this is needed for the plugin to work with custom icons*/
.wrapper__6e9f8.vc-home-typing[data-list-item-id="guildsnav___home"] .childWrapper__6e9f8 {
    background-image: none !important;
}
.wrapper__6e9f8.vc-home-typing[data-list-item-id="guildsnav___home"] svg {
    display: block !important;
}
```
in the CSS file (may vary) preferably under the area which changes the Home icon, I'm, sure there is a better way to do this but this will have to do for now unless someone else finds a better way to execute this.

https://github.com/user-attachments/assets/b837d038-3465-4d9d-b684-b5c6a6765525

<img width="1453" height="822" alt="image" src="https://github.com/user-attachments/assets/39829199-f978-48ba-98d6-66b82e943ef1" />

These show the changes, and the bit of CSS needed for it to work.