### PR TITLE
fix: channelTabs forum unread status

### DIFF
--- a/src/equicordplugins/channelTabs/components/ChannelTab.tsx
+++ b/src/equicordplugins/channelTabs/components/ChannelTab.tsx
@@ -13,7 +13,7 @@ import { getGuildAcronym, getIntlMessage, getUniqueUsername } from "@utils/disco
 import { classes } from "@utils/misc";
 import { Channel, Guild, User } from "@vencord/discord-types";
 import { findComponentByCodeLazy, findCssClassesLazy } from "@webpack";
-import { Avatar, ChannelStore, ContextMenuApi, GuildStore, PresenceStore, ReadStateStore, ThemeStore, TypingStore, useDrag, useDrop, useEffect, useRef, UserStore, useState, useStateFromStores } from "@webpack/common";
+import { ActiveJoinedThreadsStore, Avatar, ChannelStore, ContextMenuApi, GuildStore, PresenceStore, ReadStateStore, ThemeStore, TypingStore, useDrag, useDrop, useEffect, useRef, UserStore, useState, useStateFromStores } from "@webpack/common";
 import { JSX } from "react";
 
 import { TabContextMenu } from "./ContextMenus";
@@ -75,19 +75,29 @@ function TypingIndicator({ isTyping }: { isTyping: boolean; }) {
         : null;
 }
 
+function getChannelUnreadState(channelId: string) {
+    const channel = ChannelStore.getChannel(channelId);
+    const newForumPostCount = channel?.guild_id && channel.isForumLikeChannel?.()
+        ? ActiveJoinedThreadsStore.getNewThreadCount(channel.guild_id, channel.id)
+        : 0;
+    const unreadCount = ReadStateStore.getUnreadCount(channelId) || newForumPostCount;
+
+    return {
+        channelId,
+        hasUnread: ReadStateStore.hasUnread(channelId) || newForumPostCount > 0,
+        mentionCount: ReadStateStore.getMentionCount(channelId),
+        unreadCount
+    };
+}
+
 export const NotificationDot = ({ channelIds }: { channelIds: string[]; }) => {
     const userId = UserStore.getCurrentUser()?.id;
     const { persistUnreadCountFallback } = settings.use(["persistUnreadCountFallback"]);
     const [, forceUpdate] = useState(0);
     const channelStateKey = channelIds.join(",");
     const channelStates = useStateFromStores(
-        [ReadStateStore],
-        () => channelIds.map(channelId => ({
-            channelId,
-            hasUnread: ReadStateStore.hasUnread(channelId),
-            mentionCount: ReadStateStore.getMentionCount(channelId),
-            unreadCount: ReadStateStore.getUnreadCount(channelId)
-        }))
+        [ActiveJoinedThreadsStore, ReadStateStore],
+        () => channelIds.map(getChannelUnreadState)
     );
     const stateSignature = channelStates.map(state => `${state.channelId}:${Number(state.hasUnread)}:${state.mentionCount}:${state.unreadCount}`).join("|");
     const { badgeText, hasMention, shouldShow } = getNotificationDotState(


### PR DESCRIPTION
i deadass only just found out ActiveJoinedThreadsStore exists, what the fuck kinda store is that.

anyway this fixes new posts in a forum not showing an unread status to signify a new post has been sent.
WORST code you've ever seen