### PR TITLE
FavouriteAnything improvements

### DIFF
--- a/packages/discord-types/src/common/messages/Message.d.ts
+++ b/packages/discord-types/src/common/messages/Message.d.ts
@@ -291,6 +291,8 @@ export interface MessageAttachment {
     content_type?: string;
     width?: number;
     height?: number;
+    title?: string;
+    description?: string;
 }
 
 export interface ReactionEmoji {

--- a/src/equicordplugins/favouriteAnything/index.tsx
+++ b/src/equicordplugins/favouriteAnything/index.tsx
@@ -30,7 +30,7 @@ export default definePlugin({
     patches: [
         // EMBEDS
         {
-            find: "#{intl::SUPPRESS_ALL_EMBEDS}",
+            find: "this.renderInlineMediaEmbed",
             replacement: [
                 {
                     // Wrap the embed component's render method in a custom context to avoid having to drill props

--- a/src/equicordplugins/favouriteAnything/index.tsx
+++ b/src/equicordplugins/favouriteAnything/index.tsx
@@ -26,6 +26,7 @@ export default definePlugin({
     name: "FavouriteAnything",
     description: "Favourite any image, video, or file attachment",
     authors: [Devs.nin0dev, EquicordDevs.davri],
+    tags: ["favorite"],
     managedStyle,
     patches: [
         // EMBEDS

--- a/src/equicordplugins/favouriteAnything/utils.ts
+++ b/src/equicordplugins/favouriteAnything/utils.ts
@@ -90,7 +90,7 @@ export const defs = defineItems({
             title: title ?? undefined,
             description: description ?? undefined
         }),
-        stringify: ({ filename }) => filename
+        stringify: ({ title, filename }) => title?.trim() || filename
     })
     // This could be expanded in the future with other item types (e.g. voice messages)
 });
@@ -153,23 +153,15 @@ async function fetchAttachment(attachment: MessageAttachment): Promise<File> {
 }
 
 export async function sendAttachment(attachment: MessageAttachment, channel: Channel) {
-    const file = await fetchAttachment(attachment)
-        .catch(() =>
-            Toasts.show({
-                message: `Couldn't fetch ${attachment.filename}`,
-                id: Toasts.genId(),
-                type: Toasts.Type.FAILURE
-            })
-        );
+    const { filename, title, description } = attachment;
+    const file = await fetchAttachment(attachment).catch(() =>
+        Toasts.show({ message: `Couldn't fetch ${filename}`, id: Toasts.genId(), type: Toasts.Type.FAILURE })
+    );
     if (!file) return;
 
     // Using promptToUpload instead of addFiles directly since it has file size checks with error popups
     await UploadHandler.promptToUpload([file], channel, DraftType.ChannelMessage).catch(() =>
-        Toasts.show({
-            message: `Couldn't upload ${attachment.filename}`,
-            id: Toasts.genId(),
-            type: Toasts.Type.FAILURE
-        })
+        Toasts.show({ message: `Couldn't upload ${filename}`, id: Toasts.genId(), type: Toasts.Type.FAILURE })
     );
 
     const uploads = [...UploadAttachmentStore.getUploads(channel.id, DraftType.ChannelMessage)];
@@ -177,8 +169,13 @@ export async function sendAttachment(attachment: MessageAttachment, channel: Cha
     if (uploadIdx === -1) return;
 
     const reply = PendingReplyStore.getPendingReply(channel.id);
+
     const [upload] = uploads.splice(uploadIdx);
     UploadManager.setUploads({ uploads, channelId: channel.id, draftType: DraftType.ChannelMessage });
+    // Empty titles and descriptions are allowed
+    if (title != null) upload.filename = title;
+    if (description != null) upload.description = description;
+
     FluxDispatcher.dispatch({ type: "DELETE_PENDING_REPLY", channelId: channel.id });
 
     void sendMessage(channel.id, {}, false, {

--- a/src/equicordplugins/favouriteAnything/utils.ts
+++ b/src/equicordplugins/favouriteAnything/utils.ts
@@ -70,21 +70,25 @@ function defineItems<T extends Record<CustomItemFormat, CustomItemDef>>(def: Ite
 // Stringify returns a simple string representation used for thumbnail text and expression picker search.
 export const defs = defineItems({
     [CustomItemFormat.ATTACHMENT]: defineItem({
-        encode: ({ id, filename, size, url, content_type = "" }: MessageAttachment) => [
+        encode: ({ id, filename, size, url, content_type = "", title, description }: MessageAttachment) => [
             id,
             filename,
             size,
             new URL(url).pathname,
-            content_type
+            content_type,
+            title ?? null,
+            description ?? null
         ],
-        decode: ([id, filename, size, path, content_type]) => ({
+        decode: ([id, filename, size, path, content_type, title, description]) => ({
             id: id ?? "0",
             filename: filename ?? "UNKNOWN",
             size: +size! || 0,
             url: `${new URL(path!, `https://${window.GLOBAL_ENV.CDN_HOST}`)}`,
             proxy_url: `${new URL(path!, `https://${window.GLOBAL_ENV.MEDIA_PROXY_ENDPOINT}`)}`,
             content_type: content_type ?? "application/octet-stream",
-            spoiler: filename?.startsWith("SPOILER_") ?? false
+            spoiler: filename?.startsWith("SPOILER_") ?? false,
+            title: title ?? undefined,
+            description: description ?? undefined
         }),
         stringify: ({ filename }) => filename
     })


### PR DESCRIPTION
This PR addresses the following issues:
1. the embeds module patch find wasn't unique and matched a second module
2. it was impossible to find this plugin by searching for "favorite" with an american spelling
3. custom titles and descriptions given to attachments weren't getting saved

Here's an example of custom titles being used - these would otherwise be converted into regular filenames with a limited ascii character set
<img width="485" height="182" alt="image" src="https://github.com/user-attachments/assets/4ad5172e-61d6-4500-94af-c12826f711ae" />
