### PR TITLE
Questify: fix quest auto-complete not resuming on restart

### DIFF
--- a/src/equicordplugins/questify/index.tsx
+++ b/src/equicordplugins/questify/index.tsx
@@ -1960,15 +1960,22 @@ export default definePlugin({
             startAutoFetchingQuests();
         }
 
-        const wasReload = window?.navigation?.activation?.navigationType === "reload";
         const maybeResumable = !(settings.store.disableQuestsEverything || settings.store.disableQuestsFetchingQuests);
 
-        if (!wasReload || !maybeResumable) {
+        if (!maybeResumable) {
             resetQuestsToResume();
             return;
         }
 
         onceReady.then(() => {
+            const hasQuestsToResume = settings.store.resumeQuestIDs.play.length
+                || settings.store.resumeQuestIDs.watch.length
+                || settings.store.resumeQuestIDs.achievement.length;
+
+            if (hasQuestsToResume) {
+                void fetchAndDispatchQuests("Questify-Resume", QuestifyLogger);
+            }
+
             const interval = setInterval(() => {
                 if (initialQuestDataFetched) {
                     clearInterval(interval);
@@ -2017,7 +2024,8 @@ export default definePlugin({
 
             clearInterval(intervalData.progressTimeout);
             clearTimeout(intervalData.rerenderTimeout);
-            activeQuestIntervals.delete(questId);
         });
+
+        activeQuestIntervals.clear();
     }
 });

--- a/src/equicordplugins/questify/index.tsx
+++ b/src/equicordplugins/questify/index.tsx
@@ -1973,7 +1973,7 @@ export default definePlugin({
                 || settings.store.resumeQuestIDs.achievement.length;
 
             if (hasQuestsToResume) {
-                void fetchAndDispatchQuests("Questify-Resume", QuestifyLogger);
+                void fetchAndDispatchQuests("Questify", QuestifyLogger);
             }
 
             const interval = setInterval(() => {


### PR DESCRIPTION
## Summary

Fixes three bugs that prevented quest auto-completion from resuming after restarting Discord/Ctrl+R:

1. **`stop()` wiped `resumeQuestIDs`** — Calling `activeQuestIntervals.delete()` per quest triggered the custom `delete()` method which removed quest IDs from `resumeQuestIDs`. By the time `start()` ran, there was nothing left to resume. Now uses `.clear()` which empties the in-memory map without touching persisted settings.

2. **`wasReload` guard blocked resume on non-reload starts** — The check `window.navigation.activation.navigationType === "reload"` rarely works in Discord's Electron client. Removed this guard so quests resume on any Discord start, not just page reloads.

3. **No explicit quest fetch on resume** — The resume loop waited indefinitely for `initialQuestDataFetched`, but no fetch was triggered. Now proactively calls `fetchAndDispatchQuests()` when there are quests to resume, ensuring the store is populated.

## Testing

- Started a "play 15 minutes" quest and a video quest
- Let progress reach ~80%, then Ctrl+R
- Both quests resumed from their saved progress automatically
- Also tested full Discord close/reopen — quests resumed correctly
- Restored original asar and confirmed old behavior (quests stuck, no resume)