### PR TITLE
feat(chatExporter): export messages from channels, DMs, groups, and servers

### DIFF
--- a/src/equicordplugins/chatExporter/components/ExportModal.tsx
+++ b/src/equicordplugins/chatExporter/components/ExportModal.tsx
@@ -1,0 +1,260 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@api/Styles";
+import { ExportOptions } from "@equicordplugins/chatExporter/exporter";
+import { cancelChannelJob, getChannelJob, startChannelExport, subscribe } from "@equicordplugins/chatExporter/exportManager";
+import { ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import { useForceUpdater } from "@utils/react";
+import { Button, Forms, Text, useEffect, useState } from "@webpack/common";
+
+const cl = classNameFactory("vc-chatexporter-");
+
+interface ExportModalProps {
+    modalProps: ModalProps;
+    channelId: string;
+    channelName: string;
+    serverName: string;
+}
+
+export function ExportModal({ modalProps, channelId, channelName, serverName }: ExportModalProps) {
+    const [format, setFormat] = useState<"html" | "json">("html");
+    const [messageLimit, setMessageLimit] = useState<number | null>(100);
+    const [includeImages, setIncludeImages] = useState(true);
+    const [includeEmbeds, setIncludeEmbeds] = useState(true);
+    const [includeReactions, setIncludeReactions] = useState(true);
+    const [includePins, setIncludePins] = useState(true);
+    const [startDate, setStartDate] = useState("");
+    const [endDate, setEndDate] = useState("");
+    const forceUpdate = useForceUpdater();
+
+    useEffect(() => subscribe(forceUpdate), [forceUpdate]);
+
+    const job = getChannelJob(channelId);
+    const progress = job?.progress ?? null;
+    const isExporting = progress !== null && (progress.status === "fetching" || progress.status === "rendering");
+
+    function startExport() {
+        const options: ExportOptions = {
+            channelId,
+            format,
+            messageLimit,
+            includeImages,
+            includeEmbeds,
+            includeReactions,
+            includePins,
+            startDate: startDate || null,
+            endDate: endDate || null,
+        };
+        startChannelExport(options, channelName, serverName);
+    }
+
+    function cancelExport() {
+        cancelChannelJob(channelId);
+    }
+
+    const limitOptions: Array<{ label: string; value: number | null; }> = [
+        { label: "Last 100", value: 100 },
+        { label: "Last 500", value: 500 },
+        { label: "Last 1,000", value: 1000 },
+        { label: "Last 5,000", value: 5000 },
+        { label: "All messages", value: null },
+    ];
+
+    const progressPercent = progress && progress.total
+        ? Math.min(100, (progress.fetched / progress.total) * 100)
+        : 0;
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.MEDIUM}>
+            <ModalHeader>
+                <Text variant="heading-lg/semibold" style={{ flexGrow: 1 }}>
+                    Export Chat - #{channelName}
+                </Text>
+            </ModalHeader>
+
+            <ModalContent>
+                <div style={{ padding: "16px 0" }}>
+                    {/* Format */}
+                    <Forms.FormSection>
+                        <Forms.FormTitle>Format</Forms.FormTitle>
+                        <div style={{ display: "flex", gap: "8px" }}>
+                            <Button
+                                size={Button.Sizes.SMALL}
+                                look={format === "html" ? Button.Looks.FILLED : Button.Looks.OUTLINED}
+                                color={format === "html" ? Button.Colors.BRAND : Button.Colors.PRIMARY}
+                                onClick={() => setFormat("html")}
+                                disabled={isExporting}
+                            >
+                                HTML (Pretty)
+                            </Button>
+                            <Button
+                                size={Button.Sizes.SMALL}
+                                look={format === "json" ? Button.Looks.FILLED : Button.Looks.OUTLINED}
+                                color={format === "json" ? Button.Colors.BRAND : Button.Colors.PRIMARY}
+                                onClick={() => setFormat("json")}
+                                disabled={isExporting}
+                            >
+                                JSON (Raw)
+                            </Button>
+                        </div>
+                    </Forms.FormSection>
+
+                    {/* Message Limit */}
+                    <Forms.FormSection style={{ marginTop: "16px" }}>
+                        <Forms.FormTitle>Message Limit</Forms.FormTitle>
+                        <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                            {limitOptions.map(opt => (
+                                <Button
+                                    key={opt.label}
+                                    size={Button.Sizes.SMALL}
+                                    look={messageLimit === opt.value ? Button.Looks.FILLED : Button.Looks.OUTLINED}
+                                    color={messageLimit === opt.value ? Button.Colors.BRAND : Button.Colors.PRIMARY}
+                                    onClick={() => setMessageLimit(opt.value)}
+                                    disabled={isExporting}
+                                >
+                                    {opt.label}
+                                </Button>
+                            ))}
+                        </div>
+                    </Forms.FormSection>
+
+                    {/* Include Options */}
+                    <Forms.FormSection style={{ marginTop: "16px" }}>
+                        <Forms.FormTitle>Include</Forms.FormTitle>
+                        <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+                            {[
+                                { label: "Images/Attachments (URLs)", checked: includeImages, set: setIncludeImages },
+                                { label: "Embeds", checked: includeEmbeds, set: setIncludeEmbeds },
+                                { label: "Reactions", checked: includeReactions, set: setIncludeReactions },
+                                { label: "Pinned messages", checked: includePins, set: setIncludePins },
+                            ].map(({ label, checked, set }) => (
+                                <label key={label} style={{ display: "flex", alignItems: "center", gap: "8px", cursor: "pointer", color: "#dbdee1" }}>
+                                    <input
+                                        type="checkbox"
+                                        checked={checked}
+                                        onChange={e => set(e.target.checked)}
+                                        disabled={isExporting}
+                                        style={{ width: "18px", height: "18px", accentColor: "#5865f2" }}
+                                    />
+                                    {label}
+                                </label>
+                            ))}
+                        </div>
+                    </Forms.FormSection>
+
+                    {/* Date Range */}
+                    <Forms.FormSection style={{ marginTop: "16px" }}>
+                        <Forms.FormTitle>Date Range (optional)</Forms.FormTitle>
+                        <div style={{ display: "flex", gap: "12px", alignItems: "center" }}>
+                            <div>
+                                <label style={{ fontSize: "12px", color: "#949ba4", display: "block", marginBottom: "4px" }}>Start</label>
+                                <input
+                                    type="date"
+                                    value={startDate}
+                                    onChange={e => setStartDate(e.target.value)}
+                                    disabled={isExporting}
+                                    style={{
+                                        background: "#1e1f22",
+                                        border: "1px solid #3f4147",
+                                        borderRadius: "4px",
+                                        color: "#dbdee1",
+                                        padding: "6px 8px",
+                                        fontSize: "14px",
+                                    }}
+                                />
+                            </div>
+                            <div>
+                                <label style={{ fontSize: "12px", color: "#949ba4", display: "block", marginBottom: "4px" }}>End</label>
+                                <input
+                                    type="date"
+                                    value={endDate}
+                                    onChange={e => setEndDate(e.target.value)}
+                                    disabled={isExporting}
+                                    style={{
+                                        background: "#1e1f22",
+                                        border: "1px solid #3f4147",
+                                        borderRadius: "4px",
+                                        color: "#dbdee1",
+                                        padding: "6px 8px",
+                                        fontSize: "14px",
+                                    }}
+                                />
+                            </div>
+                        </div>
+                    </Forms.FormSection>
+
+                    {/* Progress */}
+                    {progress && (
+                        <div style={{ marginTop: "16px" }}>
+                            <Text variant="text-sm/normal" style={{ color: "#b5bac1" }}>
+                                {progress.status === "fetching" && `Fetching messages... ${progress.fetched}${progress.total ? `/${progress.total}` : ""}`}
+                                {progress.status === "rendering" && "Generating export file..."}
+                                {progress.status === "done" && `Export complete! ${progress.fetched} messages exported.`}
+                                {progress.status === "error" && `Error: ${progress.error}`}
+                            </Text>
+                            {progress.status === "fetching" && progress.total && (
+                                <div className={cl("progress-bar")}>
+                                    <div
+                                        className={cl("progress-fill")}
+                                        style={{ width: `${progressPercent}%` }}
+                                    />
+                                </div>
+                            )}
+                            {progress.status === "fetching" && !progress.total && (
+                                <div className={cl("progress-bar")}>
+                                    <div
+                                        className={cl("progress-fill")}
+                                        style={{ width: "100%", opacity: 0.5 }}
+                                    />
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </ModalContent>
+
+            <ModalFooter>
+                <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end", width: "100%" }}>
+                    {isExporting ? (
+                        <>
+                            <Button
+                                look={Button.Looks.LINK}
+                                color={Button.Colors.PRIMARY}
+                                onClick={modalProps.onClose}
+                            >
+                                Close (export continues)
+                            </Button>
+                            <Button
+                                color={Button.Colors.RED}
+                                onClick={cancelExport}
+                            >
+                                Cancel Export
+                            </Button>
+                        </>
+                    ) : (
+                        <>
+                            <Button
+                                look={Button.Looks.LINK}
+                                color={Button.Colors.PRIMARY}
+                                onClick={modalProps.onClose}
+                            >
+                                Close
+                            </Button>
+                            <Button
+                                color={Button.Colors.BRAND}
+                                onClick={startExport}
+                                disabled={progress?.status === "done"}
+                            >
+                                Start Export
+                            </Button>
+                        </>
+                    )}
+                </div>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/equicordplugins/chatExporter/components/ServerExportModal.tsx
+++ b/src/equicordplugins/chatExporter/components/ServerExportModal.tsx
@@ -1,0 +1,245 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@api/Styles";
+import { cancelServerJob, getServerJob, startServerExport, subscribe } from "@equicordplugins/chatExporter/exportManager";
+import { ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import { useForceUpdater } from "@utils/react";
+import { Button, ChannelStore, Forms, GuildChannelStore, Text, useEffect, useState } from "@webpack/common";
+
+const cl = classNameFactory("vc-chatexporter-");
+
+interface ServerExportModalProps {
+    modalProps: ModalProps;
+    guildId: string;
+    guildName: string;
+}
+
+interface ChannelInfo {
+    id: string;
+    name: string;
+    selected: boolean;
+}
+
+export function ServerExportModal({ modalProps, guildId, guildName }: ServerExportModalProps) {
+    const guildChannels = GuildChannelStore.getChannels(guildId);
+    const textChannels: ChannelInfo[] = (guildChannels.SELECTABLE ?? [])
+        .map((entry: any) => {
+            const ch = entry.channel ?? ChannelStore.getChannel(entry.id);
+            if (!ch) return null;
+            if (ch.type !== 0 && ch.type !== 5) return null;
+            return { id: ch.id, name: ch.name, selected: false };
+        })
+        .filter(Boolean) as ChannelInfo[];
+
+    const [channels, setChannels] = useState<ChannelInfo[]>(textChannels);
+    const [format, setFormat] = useState<"html" | "json">("html");
+    const [messageLimit, setMessageLimit] = useState<number | null>(1000);
+    const [combineFiles, setCombineFiles] = useState(false);
+    const forceUpdate = useForceUpdater();
+
+    useEffect(() => subscribe(forceUpdate), [forceUpdate]);
+
+    const job = getServerJob(guildId);
+    const progress = job?.progress ?? null;
+    const currentChannel = job?.currentChannel ?? "";
+    const channelsDone = job?.channelsDone ?? 0;
+    const selectedCount = channels.filter(c => c.selected).length;
+    const isExporting = progress !== null && (progress.status === "fetching" || progress.status === "rendering");
+
+    function toggleChannel(id: string) {
+        setChannels(prev => prev.map(c => c.id === id ? { ...c, selected: !c.selected } : c));
+    }
+
+    function selectAll() {
+        setChannels(prev => prev.map(c => ({ ...c, selected: true })));
+    }
+
+    function selectNone() {
+        setChannels(prev => prev.map(c => ({ ...c, selected: false })));
+    }
+
+    function startExport() {
+        const selected = channels.filter(c => c.selected);
+        if (!selected.length) return;
+        startServerExport({
+            guildId,
+            guildName,
+            channels: selected.map(c => ({ id: c.id, name: c.name })),
+            format,
+            messageLimit,
+            combineFiles,
+        });
+    }
+
+    function cancelExport() {
+        cancelServerJob(guildId);
+    }
+
+    const totalChannels = job?.totalChannels ?? selectedCount;
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.LARGE}>
+            <ModalHeader>
+                <Text variant="heading-lg/semibold" style={{ flexGrow: 1 }}>
+                    Export Server - {guildName}
+                </Text>
+            </ModalHeader>
+
+            <ModalContent>
+                <div style={{ padding: "16px 0" }}>
+                    {/* Format */}
+                    <Forms.FormSection>
+                        <Forms.FormTitle>Format</Forms.FormTitle>
+                        <div style={{ display: "flex", gap: "8px" }}>
+                            <Button
+                                size={Button.Sizes.SMALL}
+                                look={format === "html" ? Button.Looks.FILLED : Button.Looks.OUTLINED}
+                                color={format === "html" ? Button.Colors.BRAND : Button.Colors.PRIMARY}
+                                onClick={() => setFormat("html")}
+                                disabled={isExporting}
+                            >
+                                HTML
+                            </Button>
+                            <Button
+                                size={Button.Sizes.SMALL}
+                                look={format === "json" ? Button.Looks.FILLED : Button.Looks.OUTLINED}
+                                color={format === "json" ? Button.Colors.BRAND : Button.Colors.PRIMARY}
+                                onClick={() => setFormat("json")}
+                                disabled={isExporting}
+                            >
+                                JSON
+                            </Button>
+                        </div>
+                    </Forms.FormSection>
+
+                    {/* Message limit per channel */}
+                    <Forms.FormSection style={{ marginTop: "16px" }}>
+                        <Forms.FormTitle>Messages Per Channel</Forms.FormTitle>
+                        <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                            {[
+                                { label: "100", value: 100 },
+                                { label: "500", value: 500 },
+                                { label: "1,000", value: 1000 },
+                                { label: "All", value: null as number | null },
+                            ].map(opt => (
+                                <Button
+                                    key={opt.label}
+                                    size={Button.Sizes.SMALL}
+                                    look={messageLimit === opt.value ? Button.Looks.FILLED : Button.Looks.OUTLINED}
+                                    color={messageLimit === opt.value ? Button.Colors.BRAND : Button.Colors.PRIMARY}
+                                    onClick={() => setMessageLimit(opt.value)}
+                                    disabled={isExporting}
+                                >
+                                    {opt.label}
+                                </Button>
+                            ))}
+                        </div>
+                    </Forms.FormSection>
+
+                    {/* Combine option */}
+                    <Forms.FormSection style={{ marginTop: "16px" }}>
+                        <label style={{ display: "flex", alignItems: "center", gap: "8px", cursor: "pointer", color: "#dbdee1" }}>
+                            <input
+                                type="checkbox"
+                                checked={combineFiles}
+                                onChange={e => setCombineFiles(e.target.checked)}
+                                disabled={isExporting}
+                                style={{ width: "18px", height: "18px", accentColor: "#5865f2" }}
+                            />
+                            Combine all channels into one file
+                        </label>
+                    </Forms.FormSection>
+
+                    {/* Channel list */}
+                    <Forms.FormSection style={{ marginTop: "16px" }}>
+                        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                            <Forms.FormTitle>Channels ({selectedCount}/{channels.length} selected)</Forms.FormTitle>
+                            <div style={{ display: "flex", gap: "8px" }}>
+                                <Button size={Button.Sizes.TINY} look={Button.Looks.LINK} onClick={selectAll} disabled={isExporting}>
+                                    Select All
+                                </Button>
+                                <Button size={Button.Sizes.TINY} look={Button.Looks.LINK} onClick={selectNone} disabled={isExporting}>
+                                    Select None
+                                </Button>
+                            </div>
+                        </div>
+                        <div className={cl("channel-list")}>
+                            {channels.map(ch => (
+                                <div
+                                    key={ch.id}
+                                    className={cl("channel-item")}
+                                    onClick={() => !isExporting && toggleChannel(ch.id)}
+                                >
+                                    <input
+                                        type="checkbox"
+                                        checked={ch.selected}
+                                        onChange={() => toggleChannel(ch.id)}
+                                        disabled={isExporting}
+                                        style={{ width: "18px", height: "18px", accentColor: "#5865f2" }}
+                                    />
+                                    <span style={{ color: "#dbdee1" }}># {ch.name}</span>
+                                </div>
+                            ))}
+                        </div>
+                    </Forms.FormSection>
+
+                    {/* Progress */}
+                    {progress && (
+                        <div style={{ marginTop: "16px" }}>
+                            <Text variant="text-sm/normal" style={{ color: "#b5bac1" }}>
+                                {progress.status === "fetching" && `Exporting #${currentChannel}... (${channelsDone}/${totalChannels} channels) - ${progress.fetched} messages`}
+                                {progress.status === "rendering" && "Generating files..."}
+                                {progress.status === "done" && `Export complete! ${totalChannels} channels exported.`}
+                                {progress.status === "error" && `Error: ${progress.error}`}
+                            </Text>
+                            {(progress.status === "fetching" || progress.status === "rendering") && (
+                                <div className={cl("progress-bar")}>
+                                    <div
+                                        className={cl("progress-fill")}
+                                        style={{ width: `${totalChannels ? (channelsDone / totalChannels) * 100 : 0}%` }}
+                                    />
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </ModalContent>
+
+            <ModalFooter>
+                <div style={{ display: "flex", gap: "8px", justifyContent: "flex-end", width: "100%" }}>
+                    {isExporting ? (
+                        <>
+                            <Button
+                                look={Button.Looks.LINK}
+                                color={Button.Colors.PRIMARY}
+                                onClick={modalProps.onClose}
+                            >
+                                Close (export continues)
+                            </Button>
+                            <Button color={Button.Colors.RED} onClick={cancelExport}>
+                                Cancel Export
+                            </Button>
+                        </>
+                    ) : (
+                        <>
+                            <Button look={Button.Looks.LINK} color={Button.Colors.PRIMARY} onClick={modalProps.onClose}>
+                                Close
+                            </Button>
+                            <Button
+                                color={Button.Colors.BRAND}
+                                onClick={startExport}
+                                disabled={selectedCount === 0 || progress?.status === "done"}
+                            >
+                                Export {selectedCount} Channel{selectedCount !== 1 ? "s" : ""}
+                            </Button>
+                        </>
+                    )}
+                </div>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/equicordplugins/chatExporter/exportManager.ts
+++ b/src/equicordplugins/chatExporter/exportManager.ts
@@ -1,0 +1,255 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { showToast, Toasts } from "@webpack/common";
+
+import { downloadFile, ExportOptions, ExportProgress, fetchMessages } from "./exporter";
+import { renderHtml } from "./htmlRenderer";
+
+export interface ExportJob {
+    id: string;
+    label: string;
+    progress: ExportProgress;
+    abortController: AbortController;
+}
+
+export interface ServerExportJob {
+    id: string;
+    label: string;
+    progress: ExportProgress;
+    currentChannel: string;
+    channelsDone: number;
+    totalChannels: number;
+    abortController: AbortController;
+}
+
+type Listener = () => void;
+
+const channelJobs = new Map<string, ExportJob>();
+const serverJobs = new Map<string, ServerExportJob>();
+const listeners = new Set<Listener>();
+
+function notify() {
+    for (const fn of listeners) fn();
+}
+
+export function subscribe(fn: Listener): () => void {
+    listeners.add(fn);
+    return () => { listeners.delete(fn); };
+}
+
+export function getChannelJob(channelId: string): ExportJob | undefined {
+    return channelJobs.get(channelId);
+}
+
+export function getServerJob(guildId: string): ServerExportJob | undefined {
+    return serverJobs.get(guildId);
+}
+
+export function cancelChannelJob(channelId: string) {
+    const job = channelJobs.get(channelId);
+    if (job) {
+        job.abortController.abort();
+        channelJobs.delete(channelId);
+        notify();
+    }
+}
+
+export function cancelServerJob(guildId: string) {
+    const job = serverJobs.get(guildId);
+    if (job) {
+        job.abortController.abort();
+        serverJobs.delete(guildId);
+        notify();
+    }
+}
+
+export function startChannelExport(
+    options: ExportOptions,
+    channelName: string,
+    serverName: string,
+) {
+    if (channelJobs.has(options.channelId)) return;
+
+    const controller = new AbortController();
+    const job: ExportJob = {
+        id: options.channelId,
+        label: `#${channelName}`,
+        progress: { fetched: 0, total: options.messageLimit, status: "fetching" },
+        abortController: controller,
+    };
+    channelJobs.set(options.channelId, job);
+    notify();
+
+    const onProgress = (p: ExportProgress) => {
+        job.progress = p;
+        notify();
+    };
+
+    (async () => {
+        try {
+            const messages = await fetchMessages(options, onProgress, controller.signal);
+            if (controller.signal.aborted) return;
+
+            job.progress = { fetched: messages.length, total: options.messageLimit, status: "rendering" };
+            notify();
+
+            const safeName = (serverName + "-" + channelName).replace(/[^a-zA-Z0-9-_]/g, "_");
+            const date = new Date().toISOString().split("T")[0];
+            const filename = `${safeName}-${date}`;
+
+            if (options.format === "json") {
+                downloadFile(JSON.stringify(messages, null, 2), filename + ".json", "application/json");
+            } else {
+                const html = renderHtml(messages, channelName, serverName);
+                downloadFile(html, filename + ".html", "text/html");
+            }
+
+            job.progress = { fetched: messages.length, total: options.messageLimit, status: "done" };
+            notify();
+            showToast(`Export of #${channelName} complete (${messages.length} messages)`, Toasts.Type.SUCCESS);
+        } catch (e: any) {
+            if (!controller.signal.aborted) {
+                job.progress = {
+                    fetched: job.progress.fetched,
+                    total: job.progress.total,
+                    status: "error",
+                    error: e?.message ?? "Unknown error"
+                };
+                notify();
+                showToast(`Export of #${channelName} failed`, Toasts.Type.FAILURE);
+            }
+        } finally {
+            // Clean up finished jobs after a short delay so the modal can still read final state
+            setTimeout(() => {
+                if (job.progress.status === "done" || job.progress.status === "error") {
+                    channelJobs.delete(options.channelId);
+                    notify();
+                }
+            }, 5000);
+        }
+    })();
+}
+
+interface ServerExportParams {
+    guildId: string;
+    guildName: string;
+    channels: Array<{ id: string; name: string; }>;
+    format: "html" | "json";
+    messageLimit: number | null;
+    combineFiles: boolean;
+}
+
+export function startServerExport(params: ServerExportParams) {
+    const { guildId, guildName, channels, format, messageLimit, combineFiles } = params;
+    if (serverJobs.has(guildId)) return;
+
+    const controller = new AbortController();
+    const job: ServerExportJob = {
+        id: guildId,
+        label: guildName,
+        progress: { fetched: 0, total: null, status: "fetching" },
+        currentChannel: "",
+        channelsDone: 0,
+        totalChannels: channels.length,
+        abortController: controller,
+    };
+    serverJobs.set(guildId, job);
+    notify();
+
+    (async () => {
+        const allExports: Array<{ channelName: string; messages: any[]; }> = [];
+        const CONCURRENCY = 3;
+
+        // Process channels in parallel batches of CONCURRENCY
+        for (let i = 0; i < channels.length; i += CONCURRENCY) {
+            if (controller.signal.aborted) break;
+
+            const batch = channels.slice(i, i + CONCURRENCY);
+            const activeNames = batch.map(c => c.name).join(", ");
+            job.currentChannel = activeNames;
+            notify();
+
+            const results = await Promise.allSettled(
+                batch.map(ch => {
+                    const options: ExportOptions = {
+                        channelId: ch.id,
+                        format,
+                        messageLimit,
+                        includeImages: true,
+                        includeEmbeds: true,
+                        includeReactions: true,
+                        includePins: true,
+                        startDate: null,
+                        endDate: null,
+                    };
+                    return fetchMessages(
+                        options,
+                        p => { job.progress = p; notify(); },
+                        controller.signal,
+                    ).then(messages => ({ channelName: ch.name, messages }));
+                })
+            );
+
+            for (const result of results) {
+                if (result.status === "fulfilled") {
+                    allExports.push(result.value);
+                }
+            }
+
+            job.channelsDone = Math.min(i + CONCURRENCY, channels.length);
+            notify();
+        }
+
+        if (controller.signal.aborted) {
+            serverJobs.delete(guildId);
+            notify();
+            return;
+        }
+
+        job.progress = { fetched: 0, total: null, status: "rendering" };
+        notify();
+
+        const date = new Date().toISOString().split("T")[0];
+        const safeName = guildName.replace(/[^a-zA-Z0-9-_]/g, "_");
+
+        if (combineFiles) {
+            if (format === "json") {
+                const combined: Record<string, any[]> = {};
+                for (const exp of allExports) combined[exp.channelName] = exp.messages;
+                downloadFile(JSON.stringify(combined, null, 2), `${safeName}-${date}.json`, "application/json");
+            } else {
+                let combinedHtml = "";
+                for (const exp of allExports) {
+                    combinedHtml += renderHtml(exp.messages, exp.channelName, guildName);
+                    combinedHtml += "\n\n";
+                }
+                downloadFile(combinedHtml, `${safeName}-${date}.html`, "text/html");
+            }
+        } else {
+            for (const exp of allExports) {
+                const chSafe = exp.channelName.replace(/[^a-zA-Z0-9-_]/g, "_");
+                if (format === "json") {
+                    downloadFile(JSON.stringify(exp.messages, null, 2), `${safeName}-${chSafe}-${date}.json`, "application/json");
+                } else {
+                    const html = renderHtml(exp.messages, exp.channelName, guildName);
+                    downloadFile(html, `${safeName}-${chSafe}-${date}.html`, "text/html");
+                }
+            }
+        }
+
+        job.progress = { fetched: 0, total: null, status: "done" };
+        notify();
+        showToast(`Server export of ${guildName} complete (${channels.length} channels)`, Toasts.Type.SUCCESS);
+
+        setTimeout(() => {
+            if (job.progress.status === "done" || job.progress.status === "error") {
+                serverJobs.delete(guildId);
+                notify();
+            }
+        }, 5000);
+    })();
+}

--- a/src/equicordplugins/chatExporter/exporter.ts
+++ b/src/equicordplugins/chatExporter/exporter.ts
@@ -1,0 +1,177 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { sleep } from "@utils/misc";
+import { saveFile } from "@utils/web";
+import { Embed, MessageAttachment, MessageReaction } from "@vencord/discord-types";
+import { Constants, RestAPI } from "@webpack/common";
+
+export interface ExportedMessage {
+    id: string;
+    content: string;
+    author: {
+        id: string;
+        username: string;
+        globalName: string | null;
+        avatar: string | null;
+        bot: boolean;
+    };
+    timestamp: string;
+    edited_timestamp: string | null;
+    attachments: MessageAttachment[];
+    embeds: Embed[];
+    reactions: MessageReaction[];
+    pinned: boolean;
+    type: number;
+}
+
+export interface ExportOptions {
+    channelId: string;
+    format: "html" | "json";
+    messageLimit: number | null; // null = all
+    includeImages: boolean;
+    includeEmbeds: boolean;
+    includeReactions: boolean;
+    includePins: boolean;
+    startDate: string | null;
+    endDate: string | null;
+}
+
+export interface ExportProgress {
+    fetched: number;
+    total: number | null;
+    status: "fetching" | "rendering" | "done" | "cancelled" | "error";
+    error?: string;
+}
+
+type ProgressCallback = (progress: ExportProgress) => void;
+
+export async function fetchMessages(
+    options: ExportOptions,
+    onProgress: ProgressCallback,
+    signal: AbortSignal
+): Promise<ExportedMessage[]> {
+    const messages: ExportedMessage[] = [];
+    let beforeId: string | undefined;
+    let done = false;
+    const limit = options.messageLimit;
+
+    while (!done) {
+        if (signal.aborted) {
+            onProgress({ fetched: messages.length, total: limit, status: "cancelled" });
+            return messages;
+        }
+
+        const query: Record<string, any> = { limit: 100 };
+        if (beforeId) query.before = beforeId;
+
+        let res: any;
+        try {
+            res = await RestAPI.get({
+                url: Constants.Endpoints.MESSAGES(options.channelId),
+                query,
+                retries: 2
+            });
+        } catch (e: any) {
+            if (e?.status === 429) {
+                const retryAfter = e?.body?.retry_after ?? e?.headers?.get?.("retry-after") ?? 2;
+                await sleep(Number(retryAfter) * 1000);
+                continue;
+            }
+            onProgress({
+                fetched: messages.length,
+                total: limit,
+                status: "error",
+                error: `API error: ${e?.status ?? "unknown"}`
+            });
+            throw e;
+        }
+
+        const batch: any[] = res?.body ?? [];
+        if (batch.length === 0) {
+            done = true;
+            break;
+        }
+
+        for (const msg of batch) {
+            if (signal.aborted) {
+                onProgress({ fetched: messages.length, total: limit, status: "cancelled" });
+                return messages;
+            }
+
+            // Date filtering
+            if (options.startDate) {
+                const msgDate = new Date(msg.timestamp);
+                if (msgDate < new Date(options.startDate)) {
+                    done = true;
+                    break;
+                }
+            }
+            if (options.endDate) {
+                const msgDate = new Date(msg.timestamp);
+                if (msgDate > new Date(options.endDate)) continue;
+            }
+
+            const exported: ExportedMessage = {
+                id: msg.id,
+                content: msg.content,
+                author: {
+                    id: msg.author.id,
+                    username: msg.author.username,
+                    globalName: msg.author.global_name ?? null,
+                    avatar: msg.author.avatar,
+                    bot: msg.author.bot ?? false,
+                },
+                timestamp: msg.timestamp,
+                edited_timestamp: msg.edited_timestamp,
+                attachments: options.includeImages ? (msg.attachments ?? []) : [],
+                embeds: options.includeEmbeds ? (msg.embeds ?? []) : [],
+                reactions: options.includeReactions ? (msg.reactions ?? []) : [],
+                pinned: msg.pinned ?? false,
+                type: msg.type,
+            };
+
+            if (!options.includePins && msg.pinned) {
+                exported.pinned = false;
+            }
+
+            messages.push(exported);
+
+            if (limit && messages.length >= limit) {
+                done = true;
+                break;
+            }
+        }
+
+        beforeId = batch[batch.length - 1].id;
+
+        onProgress({
+            fetched: messages.length,
+            total: limit,
+            status: "fetching"
+        });
+
+        // Only delay if we got a full batch (more messages likely exist)
+        if (!done && batch.length === 100) {
+            await sleep(300);
+        }
+    }
+
+    // Messages are fetched newest-first, reverse to chronological order
+    messages.reverse();
+
+    onProgress({
+        fetched: messages.length,
+        total: limit,
+        status: "rendering"
+    });
+
+    return messages;
+}
+
+export function downloadFile(content: string, filename: string, mimeType: string) {
+    saveFile(new File([content], filename, { type: mimeType }));
+}

--- a/src/equicordplugins/chatExporter/htmlRenderer.ts
+++ b/src/equicordplugins/chatExporter/htmlRenderer.ts
@@ -1,0 +1,237 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { ExportedMessage } from "./exporter";
+
+function escapeHtml(text: string): string {
+    return text
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+}
+
+function renderMarkdown(text: string): string {
+    let html = escapeHtml(text);
+
+    // Code blocks (multi-line)
+    html = html.replace(/```(\w*)\n?([\s\S]*?)```/g, (_match, _lang, code) =>
+        `<div style="background:#2b2d31;border-radius:4px;padding:8px 12px;margin:4px 0;font-family:'Consolas','Courier New',monospace;font-size:0.875rem;white-space:pre-wrap;border:1px solid #1e1f22;">${code}</div>`
+    );
+
+    // Inline code
+    html = html.replace(/`([^`]+)`/g, (_match, code) =>
+        `<code style="background:#2b2d31;padding:2px 4px;border-radius:3px;font-family:'Consolas','Courier New',monospace;font-size:0.875rem;">${code}</code>`
+    );
+
+    // Bold
+    html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+    // Italic
+    html = html.replace(/\*(.+?)\*/g, "<em>$1</em>");
+    html = html.replace(/_(.+?)_/g, "<em>$1</em>");
+    // Strikethrough
+    html = html.replace(/~~(.+?)~~/g, "<s>$1</s>");
+    // Underline
+    html = html.replace(/__(.+?)__/g, "<u>$1</u>");
+
+    // Links
+    html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+        "<a href=\"$2\" style=\"color:#00aff4;text-decoration:none;\" target=\"_blank\">$1</a>"
+    );
+    html = html.replace(/(https?:\/\/[^\s<]+)/g,
+        "<a href=\"$1\" style=\"color:#00aff4;text-decoration:none;\" target=\"_blank\">$1</a>"
+    );
+
+    // Newlines
+    html = html.replace(/\n/g, "<br>");
+
+    return html;
+}
+
+function formatTimestamp(iso: string): string {
+    const d = new Date(iso);
+    return d.toLocaleString("en-US", {
+        month: "2-digit",
+        day: "2-digit",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: true,
+    });
+}
+
+function getAvatarUrl(author: ExportedMessage["author"]): string {
+    if (author.avatar) {
+        return `https://cdn.discordapp.com/avatars/${author.id}/${author.avatar}.png?size=64`;
+    }
+    const index = (BigInt(author.id) >> 22n) % 6n;
+    return `https://cdn.discordapp.com/embed/avatars/${index}.png`;
+}
+
+function renderAttachments(attachments: any[]): string {
+    if (!attachments.length) return "";
+    return attachments.map(att => {
+        const isImage = att.content_type?.startsWith("image/") ||
+            /\.(png|jpg|jpeg|gif|webp)$/i.test(att.filename);
+        if (isImage) {
+            return `<div style="margin:4px 0;">
+                <a href="${escapeHtml(att.url)}" target="_blank">
+                    <img src="${escapeHtml(att.url)}" alt="${escapeHtml(att.filename)}"
+                        style="max-width:400px;max-height:300px;border-radius:8px;">
+                </a>
+            </div>`;
+        }
+        return `<div style="margin:4px 0;padding:8px 12px;background:#2b2d31;border-radius:8px;border:1px solid #1e1f22;">
+            <a href="${escapeHtml(att.url)}" style="color:#00aff4;text-decoration:none;" target="_blank">
+                📎 ${escapeHtml(att.filename)}${att.size ? ` (${(att.size / 1024).toFixed(1)} KB)` : ""}
+            </a>
+        </div>`;
+    }).join("");
+}
+
+function renderEmbeds(embeds: any[]): string {
+    if (!embeds.length) return "";
+    return embeds.map(embed => {
+        const borderColor = embed.color ? `#${embed.color.toString(16).padStart(6, "0")}` : "#4f545c";
+        let html = `<div style="margin:4px 0;padding:8px 16px;background:#2b2d31;border-left:4px solid ${borderColor};border-radius:4px;max-width:520px;">`;
+
+        if (embed.author?.name) {
+            html += `<div style="font-size:0.875rem;font-weight:600;margin-bottom:4px;">${escapeHtml(embed.author.name)}</div>`;
+        }
+        if (embed.title) {
+            const title = embed.url
+                ? `<a href="${escapeHtml(embed.url)}" style="color:#00aff4;text-decoration:none;font-weight:700;">${escapeHtml(embed.title)}</a>`
+                : `<span style="font-weight:700;">${escapeHtml(embed.title)}</span>`;
+            html += `<div style="margin-bottom:4px;">${title}</div>`;
+        }
+        if (embed.description) {
+            html += `<div style="font-size:0.875rem;color:#dcddde;margin-bottom:8px;">${renderMarkdown(embed.description)}</div>`;
+        }
+        if (embed.fields?.length) {
+            html += "<div style=\"display:flex;flex-wrap:wrap;gap:8px;\">";
+            for (const field of embed.fields) {
+                const width = field.inline ? "calc(33% - 8px)" : "100%";
+                html += `<div style="min-width:0;flex:0 0 ${width};">
+                    <div style="font-size:0.75rem;font-weight:700;color:#b9bbbe;margin-bottom:2px;">${escapeHtml(field.name)}</div>
+                    <div style="font-size:0.875rem;color:#dcddde;">${renderMarkdown(field.value)}</div>
+                </div>`;
+            }
+            html += "</div>";
+        }
+        if (embed.image?.url) {
+            html += `<div style="margin-top:8px;"><img src="${escapeHtml(embed.image.url)}" style="max-width:100%;border-radius:4px;"></div>`;
+        }
+        if (embed.thumbnail?.url) {
+            html += `<div style="margin-top:8px;"><img src="${escapeHtml(embed.thumbnail.url)}" style="max-width:80px;border-radius:4px;float:right;"></div>`;
+        }
+        if (embed.footer?.text) {
+            html += `<div style="font-size:0.75rem;color:#72767d;margin-top:8px;">${escapeHtml(embed.footer.text)}</div>`;
+        }
+
+        html += "</div>";
+        return html;
+    }).join("");
+}
+
+function renderReactions(reactions: any[]): string {
+    if (!reactions.length) return "";
+    const items = reactions.map(r => {
+        const emoji = r.emoji.id
+            ? `<img src="https://cdn.discordapp.com/emojis/${r.emoji.id}.${r.emoji.animated ? "gif" : "png"}?size=16" style="width:16px;height:16px;vertical-align:middle;">`
+            : escapeHtml(r.emoji.name);
+        return `<span style="display:inline-flex;align-items:center;gap:4px;background:#2b2d31;border:1px solid #1e1f22;border-radius:8px;padding:2px 8px;font-size:0.875rem;">${emoji} <span style="color:#b5bac1;">${r.count}</span></span>`;
+    }).join(" ");
+    return `<div style="margin-top:4px;display:flex;flex-wrap:wrap;gap:4px;">${items}</div>`;
+}
+
+function shouldGroup(prev: ExportedMessage | null, curr: ExportedMessage): boolean {
+    if (!prev) return false;
+    if (prev.author.id !== curr.author.id) return false;
+    const timeDiff = new Date(curr.timestamp).getTime() - new Date(prev.timestamp).getTime();
+    return timeDiff < 7 * 60 * 1000; // 7 minutes
+}
+
+export function renderHtml(
+    messages: ExportedMessage[],
+    channelName: string,
+    serverName: string
+): string {
+    let messagesHtml = "";
+
+    for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i];
+        const prev = i > 0 ? messages[i - 1] : null;
+        const grouped = shouldGroup(prev, msg);
+
+        if (grouped) {
+            messagesHtml += `<div style="padding:2px 16px 2px 72px;position:relative;" class="vc-ce-msg">
+                <span style="display:none;position:absolute;left:16px;top:4px;font-size:0.6875rem;color:#949ba4;width:40px;text-align:right;" class="vc-ce-ts">${new Date(msg.timestamp).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: true })}</span>`;
+        } else {
+            const displayName = msg.author.globalName || msg.author.username;
+            messagesHtml += `<div style="padding:4px 16px;margin-top:16px;display:flex;gap:16px;position:relative;" class="vc-ce-msg">
+                <img src="${getAvatarUrl(msg.author)}" style="width:40px;height:40px;border-radius:50%;flex-shrink:0;margin-top:2px;">
+                <div style="flex:1;min-width:0;">
+                    <div style="display:flex;align-items:baseline;gap:8px;">
+                        <span style="font-weight:600;color:#f2f3f5;">${escapeHtml(displayName)}</span>
+                        ${msg.author.bot ? "<span style=\"background:#5865f2;color:#fff;font-size:0.625rem;padding:1px 4px;border-radius:3px;font-weight:600;\">BOT</span>" : ""}
+                        <span style="font-size:0.75rem;color:#949ba4;">${formatTimestamp(msg.timestamp)}</span>
+                        ${msg.edited_timestamp ? "<span style=\"font-size:0.625rem;color:#949ba4;\">(edited)</span>" : ""}
+                    </div>`;
+        }
+
+        if (!grouped) {
+            if (msg.content) {
+                messagesHtml += `<div style="color:#dbdee1;line-height:1.375;">${renderMarkdown(msg.content)}</div>`;
+            }
+            messagesHtml += renderAttachments(msg.attachments);
+            messagesHtml += renderEmbeds(msg.embeds);
+            messagesHtml += renderReactions(msg.reactions);
+            messagesHtml += "</div></div>";
+        } else {
+            if (msg.content) {
+                messagesHtml += `<div style="color:#dbdee1;line-height:1.375;">${renderMarkdown(msg.content)}</div>`;
+            }
+            messagesHtml += renderAttachments(msg.attachments);
+            messagesHtml += renderEmbeds(msg.embeds);
+            messagesHtml += renderReactions(msg.reactions);
+            messagesHtml += "</div>";
+        }
+    }
+
+    const exportDate = new Date().toLocaleString();
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(serverName)} - #${escapeHtml(channelName)}</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: #313338; color: #dbdee1; font-family: 'gg sans', 'Noto Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 1rem; }
+a { color: #00aff4; }
+.vc-ce-msg:hover { background: #2e3035; }
+.vc-ce-msg:hover .vc-ce-ts { display: inline !important; }
+::-webkit-scrollbar { width: 8px; }
+::-webkit-scrollbar-track { background: #2b2d31; }
+::-webkit-scrollbar-thumb { background: #1a1b1e; border-radius: 4px; }
+</style>
+</head>
+<body>
+<div style="background:#1e1f22;padding:16px 16px;border-bottom:1px solid #1e1f22;">
+    <h1 style="font-size:1.25rem;font-weight:700;color:#f2f3f5;"># ${escapeHtml(channelName)}</h1>
+    <div style="font-size:0.875rem;color:#949ba4;margin-top:4px;">${escapeHtml(serverName)} &mdash; ${messages.length} messages exported</div>
+</div>
+<div style="padding:8px 0;">
+${messagesHtml}
+</div>
+<div style="text-align:center;padding:24px;color:#949ba4;font-size:0.75rem;border-top:1px solid #1e1f22;margin-top:16px;">
+    Generated by ChatExporter &mdash; ${escapeHtml(exportDate)}
+</div>
+</body>
+</html>`;
+}

--- a/src/equicordplugins/chatExporter/index.tsx
+++ b/src/equicordplugins/chatExporter/index.tsx
@@ -1,0 +1,113 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { EquicordDevs } from "@utils/constants";
+import { openModal } from "@utils/modal";
+import definePlugin from "@utils/types";
+import { ChannelStore, GuildStore, Menu } from "@webpack/common";
+
+import { ExportModal } from "./components/ExportModal";
+import { ServerExportModal } from "./components/ServerExportModal";
+
+function openExportModal(channelId: string) {
+    const channel = ChannelStore.getChannel(channelId);
+    if (!channel) return;
+
+    const guild = channel.guild_id ? GuildStore.getGuild(channel.guild_id) : null;
+    const channelName = channel.name || "DM";
+    const serverName = guild?.name || "Direct Messages";
+
+    openModal(modalProps => (
+        <ExportModal
+            modalProps={modalProps}
+            channelId={channelId}
+            channelName={channelName}
+            serverName={serverName}
+        />
+    ));
+}
+
+function openServerExportModal(guildId: string) {
+    const guild = GuildStore.getGuild(guildId);
+    if (!guild) return;
+
+    openModal(modalProps => (
+        <ServerExportModal
+            modalProps={modalProps}
+            guildId={guildId}
+            guildName={guild.name}
+        />
+    ));
+}
+
+const channelContextPatch: NavContextMenuPatchCallback = (children, { channel }) => {
+    if (!channel) return;
+
+    const group = findGroupChildrenByChildId("mark-channel-read", children) ?? children;
+    group.push(
+        <Menu.MenuItem
+            id="vc-export-chat"
+            label="Export Chat"
+            action={() => openExportModal(channel.id)}
+        />
+    );
+};
+
+const dmContextPatch: NavContextMenuPatchCallback = (children, { channel }) => {
+    if (!channel) return;
+
+    const group = findGroupChildrenByChildId("close-dm", children) ?? children;
+    group.push(
+        <Menu.MenuItem
+            id="vc-export-chat"
+            label="Export Chat"
+            action={() => openExportModal(channel.id)}
+        />
+    );
+};
+
+const gdmContextPatch: NavContextMenuPatchCallback = (children, { channel }) => {
+    if (!channel) return;
+
+    children.push(
+        <Menu.MenuItem
+            id="vc-export-chat"
+            label="Export Chat"
+            action={() => openExportModal(channel.id)}
+        />
+    );
+};
+
+const guildContextPatch: NavContextMenuPatchCallback = (children, { guild }) => {
+    if (!guild) return;
+
+    const group = findGroupChildrenByChildId("privacy", children) ?? children;
+    group.push(
+        <Menu.MenuItem
+            id="vc-export-server"
+            label="Export Server"
+            action={() => openServerExportModal(guild.id)}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "ChatExporter",
+    description: "Export messages from any channel, DM, group chat, or entire server as HTML or JSON files",
+    authors: [EquicordDevs.UnknownHacker9991],
+
+    contextMenus: {
+        "channel-context": channelContextPatch,
+        "thread-context": channelContextPatch,
+        "user-context": dmContextPatch,
+        "gdm-context": gdmContextPatch,
+        "guild-context": guildContextPatch,
+        "guild-header-popout": guildContextPatch,
+    },
+});

--- a/src/equicordplugins/chatExporter/style.css
+++ b/src/equicordplugins/chatExporter/style.css
@@ -1,0 +1,38 @@
+.vc-chatexporter-modal {
+    min-width: 500px;
+}
+
+.vc-chatexporter-progress-bar {
+    width: 100%;
+    height: 8px;
+    background: #1e1f22;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-top: 8px;
+}
+
+.vc-chatexporter-progress-fill {
+    height: 100%;
+    background: #5865f2;
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+.vc-chatexporter-channel-list {
+    max-height: 400px;
+    overflow-y: auto;
+    margin: 8px 0;
+}
+
+.vc-chatexporter-channel-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.vc-chatexporter-channel-item:hover {
+    background: #35373c;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1292,6 +1292,10 @@ export const EquicordDevs = Object.freeze({
         name: "pointy",
         id: 99914384989519872n
     },
+    UnknownHacker9991: {
+        name: "UnknownHacker9991",
+        id: 1245799821173067850n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## ChatExporter

Export messages from any channel, DM, group DM, or entire server as HTML (styled, readable) or JSON (raw).

## Features

- Context-menu entries on channels, DMs, group DMs, and users (for cross-server user-message export).
- Channel, server-wide, and user-scoped export modals.
- HTML output mirrors Discord's look (embeds, reactions, attachments, pinned indicators, author metadata). JSON output is the raw Discord REST response shape.
- Configurable per-export: message limit (100 / 500 / 1000 / 5000 / all), include images, embeds, reactions, pins, date range filter.
- Server export fetches multiple channels in parallel (3 concurrent) with progress.
- Background export manager: close the modal while an export is running and it continues; reopen to see progress or cancel.
- Rate-limit handling: respects 429 ``retry_after`` and paces ``RestAPI`` calls to stay under burst limits.

## Notes

Split from #988 per reviewer feedback (one PR per plugin). The ``UnknownHacker9991`` entry in ``src/utils/constants.ts`` is shared across all five split PRs; whichever lands first will cause a small merge conflict on the rest, which I'll rebase as needed.