### PR TITLE
feat(roleMembers): view members of any role via role pills and All Roles modal

### DIFF
--- a/src/equicordplugins/roleMembers/components/AllRolesModal.tsx
+++ b/src/equicordplugins/roleMembers/components/AllRolesModal.tsx
@@ -1,0 +1,362 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import ErrorBoundary from "@components/ErrorBoundary";
+import { ModalCloseButton, ModalContent, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
+import { FluxDispatcher, GuildMemberStore, GuildRoleStore, GuildStore, Text, TextInput, useEffect, useMemo, useRef, UserStore, useState, useStateFromStores } from "@webpack/common";
+
+const SEPARATOR_PATTERN = /^[\u2500-\u257F\u2580-\u259F\u25A0-\u25FF\u2600-\u26FF\u2700-\u27BF\u2190-\u21FF\u2B00-\u2BFF\u25AC^.\-+:=_~\s]+$/;
+
+function isSeparatorRole(name: string): boolean {
+    return SEPARATOR_PATTERN.test(name.trim());
+}
+
+function getRoleColor(role: { colorString: string | null; }): string {
+    if (!role.colorString || role.colorString === "#000000") return "var(--interactive-normal)";
+    return role.colorString;
+}
+
+function getRoleTextColor(role: { colorString: string | null; }): string {
+    if (!role.colorString || role.colorString === "#000000") return "var(--text-normal)";
+    return role.colorString;
+}
+
+function formatJoinDate(iso: string): string {
+    try {
+        const date = new Date(iso);
+        return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    } catch {
+        return "Unknown";
+    }
+}
+
+function MemberRow({ userId, nick, joinedAt, guildId }: { userId: string; nick: string | undefined; joinedAt: string | undefined; guildId: string; }) {
+    const user = UserStore.getUser(userId);
+    if (!user) return null;
+
+    const displayName = nick ?? user.globalName ?? user.username;
+    const formattedDate = joinedAt ? formatJoinDate(joinedAt) : "Unknown";
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                gap: "12px",
+                padding: "10px 14px",
+                borderRadius: "8px",
+            }}
+        >
+            <img
+                src={user.getAvatarURL(guildId, 32, false)}
+                width={32}
+                height={32}
+                style={{
+                    width: "32px",
+                    height: "32px",
+                    minWidth: "32px",
+                    maxWidth: "32px",
+                    borderRadius: "50%",
+                    objectFit: "cover",
+                }}
+            />
+            <div style={{ display: "flex", flexDirection: "column" }}>
+                <span style={{ fontSize: "15px", fontWeight: 700, color: "var(--text-normal)" }}>
+                    {displayName}
+                </span>
+                <span style={{ fontSize: "12px", color: "var(--text-muted)" }}>
+                    {user.username !== displayName ? `${user.username} \u00B7 ` : ""}Joined {formattedDate}
+                </span>
+            </div>
+        </div>
+    );
+}
+
+function AllRolesModalComponent({ guildId, modalProps }: { guildId: string; modalProps: ModalProps; }) {
+    const guild = GuildStore.getGuild(guildId);
+
+    // View switching: selectedRoleId controls which view is visible,
+    // membersRoleId persists so the members div stays in the DOM when going back
+    const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
+    const [membersRoleId, setMembersRoleId] = useState<string | null>(null);
+    const showingMembers = selectedRoleId != null;
+
+    // Scroll preservation
+    const rolesListRef = useRef<HTMLDivElement>(null);
+    const savedScrollTop = useRef(0);
+
+    // Roles view state
+    const [roleSearch, setRoleSearch] = useState("");
+    const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+    // Members view state
+    const [memberSearch, setMemberSearch] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [backHovered, setBackHovered] = useState(false);
+
+    const selectedRole = membersRoleId ? GuildRoleStore.getRole(guildId, membersRoleId) : null;
+
+    // Prefetch guild members on mount
+    const memberIds = useStateFromStores(
+        [GuildMemberStore],
+        () => GuildMemberStore.getMemberIds(guildId),
+        null,
+        (old, current) => old.length === current.length
+    );
+
+    useEffect(() => {
+        FluxDispatcher.dispatch({
+            type: "GUILD_MEMBERS_REQUEST",
+            guildIds: [guildId],
+            query: "",
+            presences: false
+        });
+
+        const timer = setTimeout(() => setLoading(false), 1500);
+        return () => clearTimeout(timer);
+    }, [guildId]);
+
+    useEffect(() => {
+        if (memberIds.length > 0) {
+            setLoading(false);
+        }
+    }, [memberIds.length]);
+
+    // Roles data
+    const roles = useMemo(() => {
+        return GuildRoleStore.getSortedRoles(guildId).filter(r => !isSeparatorRole(r.name));
+    }, [guildId]);
+
+    const filteredRoles = useMemo(() => {
+        if (!roleSearch) return roles;
+        const q = roleSearch.toLowerCase();
+        return roles.filter(r => r.name.toLowerCase().includes(q));
+    }, [roles, roleSearch]);
+
+    // Members data (filtered by membersRoleId so it stays valid even when hidden)
+    const members = useMemo(() => {
+        if (!membersRoleId) return [];
+        const result: Array<{ userId: string; nick: string | undefined; joinedAt: string | undefined; }> = [];
+
+        for (const userId of memberIds) {
+            const member = GuildMemberStore.getMember(guildId, userId);
+            if (!member) continue;
+
+            if (membersRoleId === guildId || member.roles.includes(membersRoleId)) {
+                result.push({ userId, nick: member.nick, joinedAt: member.joinedAt });
+            }
+        }
+
+        return result;
+    }, [memberIds, guildId, membersRoleId]);
+
+    const filteredMembers = useMemo(() => {
+        if (!memberSearch) return members;
+        const q = memberSearch.toLowerCase();
+        return members.filter(m => {
+            const user = UserStore.getUser(m.userId);
+            if (!user) return false;
+            const displayName = m.nick ?? user.globalName ?? user.username;
+            return displayName.toLowerCase().includes(q) || user.username.toLowerCase().includes(q);
+        });
+    }, [members, memberSearch]);
+
+    const selectRole = (roleId: string) => {
+        // Save scroll position of the ModalContent scroll container
+        const scrollContainer = rolesListRef.current?.parentElement;
+        if (scrollContainer) {
+            savedScrollTop.current = scrollContainer.scrollTop;
+        }
+        setSelectedRoleId(roleId);
+        setMembersRoleId(roleId);
+        setMemberSearch("");
+    };
+
+    const goBack = () => {
+        setSelectedRoleId(null);
+    };
+
+    // Restore roles list scroll position when returning from members view
+    useEffect(() => {
+        if (!showingMembers) {
+            requestAnimationFrame(() => {
+                const scrollContainer = rolesListRef.current?.parentElement;
+                if (scrollContainer) {
+                    scrollContainer.scrollTop = savedScrollTop.current;
+                }
+            });
+        }
+    }, [showingMembers]);
+
+    const roleName = selectedRole?.name ?? "Unknown Role";
+    const dotColor = selectedRole ? getRoleColor(selectedRole) : "var(--interactive-normal)";
+    const textColor = selectedRole ? getRoleTextColor(selectedRole) : "var(--text-normal)";
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.LARGE}>
+            {/* Header — swaps based on view */}
+            {showingMembers ? (
+                <ModalHeader separator={false}>
+                    <div style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "12px", flex: 1 }}>
+                        <div
+                            style={{
+                                padding: "8px 16px",
+                                borderRadius: "20px",
+                                backgroundColor: backHovered ? "var(--brand-500)" : "var(--background-secondary)",
+                                border: "1px solid var(--background-modifier-accent)",
+                                fontSize: "14px",
+                                fontWeight: 600,
+                                color: backHovered ? "#fff" : "#ffffff",
+                                cursor: "pointer",
+                            }}
+                            onMouseEnter={() => setBackHovered(true)}
+                            onMouseLeave={() => setBackHovered(false)}
+                            onClick={goBack}
+                        >
+                            {"\u2190"} Back
+                        </div>
+                        <span
+                            style={{
+                                width: "16px",
+                                height: "16px",
+                                minWidth: "16px",
+                                borderRadius: "50%",
+                                backgroundColor: dotColor,
+                            }}
+                        />
+                        <Text variant="heading-lg/semibold" style={{ color: textColor }}>
+                            {roleName}
+                        </Text>
+                        <Text variant="text-sm/normal" style={{ color: "var(--text-muted)", marginLeft: "4px" }}>
+                            {loading ? "Loading..." : `${filteredMembers.length} Member${filteredMembers.length !== 1 ? "s" : ""}`}
+                        </Text>
+                    </div>
+                    <ModalCloseButton onClick={modalProps.onClose} />
+                </ModalHeader>
+            ) : (
+                <ModalHeader separator={false}>
+                    <div style={{ display: "flex", flexDirection: "column", flex: 1 }}>
+                        <Text variant="heading-lg/semibold">
+                            {guild?.name ?? "Server"} {"\u2014"} Roles
+                        </Text>
+                        <Text variant="text-sm/normal" style={{ color: "var(--text-muted)", marginTop: "4px" }}>
+                            {filteredRoles.length} Role{filteredRoles.length !== 1 ? "s" : ""}
+                        </Text>
+                    </div>
+                    <ModalCloseButton onClick={modalProps.onClose} />
+                </ModalHeader>
+            )}
+
+            {/* Search bar — swaps based on view */}
+            <div style={{ padding: "0 16px 12px" }}>
+                {showingMembers ? (
+                    <TextInput
+                        placeholder="Search members..."
+                        value={memberSearch}
+                        onChange={setMemberSearch}
+                    />
+                ) : (
+                    <TextInput
+                        placeholder="Search roles..."
+                        value={roleSearch}
+                        onChange={setRoleSearch}
+                    />
+                )}
+            </div>
+
+            {/* Content — both views always in the DOM, toggled via display */}
+            <ModalContent>
+                {/* Roles list — always mounted, hidden when viewing members */}
+                <div ref={rolesListRef} style={{ display: showingMembers ? "none" : "block", overflowY: "auto", paddingRight: "8px" }}>
+                    {filteredRoles.length === 0 ? (
+                        <div style={{ padding: "40px 0", textAlign: "center" }}>
+                            <Text variant="text-md/normal">
+                                No roles match your search.
+                            </Text>
+                        </div>
+                    ) : (
+                        filteredRoles.map(role => (
+                            <div
+                                key={role.id}
+                                style={{
+                                    display: "flex",
+                                    flexDirection: "row",
+                                    alignItems: "center",
+                                    gap: "14px",
+                                    padding: "12px 16px",
+                                    marginBottom: "3px",
+                                    borderRadius: "8px",
+                                    backgroundColor: hoveredId === role.id ? "var(--background-modifier-hover)" : "var(--background-secondary)",
+                                    cursor: "pointer",
+                                }}
+                                onMouseEnter={() => setHoveredId(role.id)}
+                                onMouseLeave={() => setHoveredId(null)}
+                                onClick={() => selectRole(role.id)}
+                            >
+                                <span
+                                    style={{
+                                        width: "16px",
+                                        height: "16px",
+                                        minWidth: "16px",
+                                        borderRadius: "50%",
+                                        backgroundColor: getRoleColor(role),
+                                    }}
+                                />
+                                <span
+                                    style={{
+                                        fontSize: "16px",
+                                        fontWeight: 600,
+                                        color: getRoleTextColor(role),
+                                    }}
+                                >
+                                    {role.name}
+                                </span>
+                            </div>
+                        ))
+                    )}
+                </div>
+
+                {/* Members list — mounted after first role selection, hidden when viewing roles */}
+                {membersRoleId != null && (
+                    <div style={{ display: showingMembers ? "block" : "none", overflowY: "auto", paddingRight: "8px" }}>
+                        {loading ? (
+                            <div style={{ padding: "40px 0", textAlign: "center" }}>
+                                <Text variant="text-md/normal">
+                                    Loading members...
+                                </Text>
+                            </div>
+                        ) : filteredMembers.length === 0 ? (
+                            <div style={{ padding: "40px 0", textAlign: "center" }}>
+                                <Text variant="text-md/normal">
+                                    {memberSearch ? "No members match your search." : "No cached members with this role."}
+                                </Text>
+                            </div>
+                        ) : (
+                            filteredMembers.map(({ userId, nick, joinedAt }) => (
+                                <MemberRow
+                                    key={userId}
+                                    userId={userId}
+                                    nick={nick}
+                                    joinedAt={joinedAt}
+                                    guildId={guildId}
+                                />
+                            ))
+                        )}
+                    </div>
+                )}
+            </ModalContent>
+        </ModalRoot>
+    );
+}
+
+const AllRolesModal = ErrorBoundary.wrap(AllRolesModalComponent);
+
+export default function openAllRolesModal(guildId: string) {
+    openModal(modalProps => (
+        <AllRolesModal guildId={guildId} modalProps={modalProps} />
+    ));
+}

--- a/src/equicordplugins/roleMembers/components/RoleMembersModal.tsx
+++ b/src/equicordplugins/roleMembers/components/RoleMembersModal.tsx
@@ -1,0 +1,224 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import ErrorBoundary from "@components/ErrorBoundary";
+import { ModalCloseButton, ModalContent, ModalHeader, ModalProps, ModalRoot, ModalSize, openModal } from "@utils/modal";
+import { FluxDispatcher, GuildMemberStore, GuildRoleStore, Text, TextInput, useEffect, useMemo, UserStore, useState, useStateFromStores } from "@webpack/common";
+
+function getRoleDotColor(role: { colorString: string | null; }): string {
+    if (!role?.colorString || role.colorString === "#000000") return "var(--interactive-normal)";
+    return role.colorString;
+}
+
+function getRoleTextColor(role: { colorString: string | null; }): string {
+    if (!role?.colorString || role.colorString === "#000000") return "var(--text-normal)";
+    return role.colorString;
+}
+
+function RoleMembersModalComponent({ guildId, roleId, modalProps, onBack }: { guildId: string; roleId: string; modalProps: ModalProps; onBack?: () => void; }) {
+    const role = GuildRoleStore.getRole(guildId, roleId);
+    const [search, setSearch] = useState("");
+    const [loading, setLoading] = useState(true);
+    const [backHovered, setBackHovered] = useState(false);
+
+    const memberIds = useStateFromStores(
+        [GuildMemberStore],
+        () => GuildMemberStore.getMemberIds(guildId),
+        null,
+        (old, current) => old.length === current.length
+    );
+
+    useEffect(() => {
+        FluxDispatcher.dispatch({
+            type: "GUILD_MEMBERS_REQUEST",
+            guildIds: [guildId],
+            query: "",
+            presences: false
+        });
+
+        const timer = setTimeout(() => setLoading(false), 1500);
+        return () => clearTimeout(timer);
+    }, [guildId]);
+
+    useEffect(() => {
+        if (memberIds.length > 0) {
+            setLoading(false);
+        }
+    }, [memberIds.length]);
+
+    const members = useMemo(() => {
+        const result: Array<{ userId: string; nick: string | undefined; joinedAt: string | undefined; }> = [];
+
+        for (const userId of memberIds) {
+            const member = GuildMemberStore.getMember(guildId, userId);
+            if (!member) continue;
+
+            if (roleId === guildId || member.roles.includes(roleId)) {
+                result.push({ userId, nick: member.nick, joinedAt: member.joinedAt });
+            }
+        }
+
+        return result;
+    }, [memberIds, guildId, roleId]);
+
+    const filtered = useMemo(() => {
+        if (!search) return members;
+        const q = search.toLowerCase();
+        return members.filter(m => {
+            const user = UserStore.getUser(m.userId);
+            if (!user) return false;
+            const displayName = m.nick ?? user.globalName ?? user.username;
+            return displayName.toLowerCase().includes(q) || user.username.toLowerCase().includes(q);
+        });
+    }, [members, search]);
+
+    const roleName = role?.name ?? "Unknown Role";
+    const dotColor = getRoleDotColor(role);
+    const textColor = getRoleTextColor(role);
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.LARGE}>
+            <ModalHeader separator={false}>
+                <div style={{ display: "flex", flexDirection: "row", alignItems: "center", gap: "12px", flex: 1 }}>
+                    {onBack && (
+                        <div
+                            style={{
+                                padding: "8px 16px",
+                                borderRadius: "20px",
+                                backgroundColor: backHovered ? "var(--brand-500)" : "var(--background-secondary)",
+                                border: "1px solid var(--background-modifier-accent)",
+                                fontSize: "14px",
+                                fontWeight: 600,
+                                color: backHovered ? "#fff" : "#ffffff",
+                                cursor: "pointer",
+                            }}
+                            onMouseEnter={() => setBackHovered(true)}
+                            onMouseLeave={() => setBackHovered(false)}
+                            onClick={() => {
+                                modalProps.onClose();
+                                onBack();
+                            }}
+                        >
+                            {"\u2190"} Back
+                        </div>
+                    )}
+                    <span
+                        style={{
+                            width: "16px",
+                            height: "16px",
+                            minWidth: "16px",
+                            borderRadius: "50%",
+                            backgroundColor: dotColor,
+                        }}
+                    />
+                    <Text variant="heading-lg/semibold" style={{ color: textColor }}>
+                        {roleName}
+                    </Text>
+                    <Text variant="text-sm/normal" style={{ color: "var(--text-muted)", marginLeft: "4px" }}>
+                        {loading ? "Loading..." : `${filtered.length} Member${filtered.length !== 1 ? "s" : ""}`}
+                    </Text>
+                </div>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+
+            <div style={{ padding: "0 16px 12px" }}>
+                <TextInput
+                    placeholder="Search members..."
+                    value={search}
+                    onChange={setSearch}
+                />
+            </div>
+
+            <ModalContent>
+                {loading ? (
+                    <div style={{ padding: "40px 0", textAlign: "center" }}>
+                        <Text variant="text-md/normal">
+                            Loading members...
+                        </Text>
+                    </div>
+                ) : filtered.length === 0 ? (
+                    <div style={{ padding: "40px 0", textAlign: "center" }}>
+                        <Text variant="text-md/normal">
+                            {search ? "No members match your search." : "No cached members with this role."}
+                        </Text>
+                    </div>
+                ) : (
+                    <div style={{ overflowY: "auto", paddingRight: "8px" }}>
+                        {filtered.map(({ userId, nick, joinedAt }) => (
+                            <MemberRow
+                                key={userId}
+                                userId={userId}
+                                nick={nick}
+                                joinedAt={joinedAt}
+                                guildId={guildId}
+                            />
+                        ))}
+                    </div>
+                )}
+            </ModalContent>
+        </ModalRoot>
+    );
+}
+
+function MemberRow({ userId, nick, joinedAt, guildId }: { userId: string; nick: string | undefined; joinedAt: string | undefined; guildId: string; }) {
+    const user = UserStore.getUser(userId);
+    if (!user) return null;
+
+    const displayName = nick ?? user.globalName ?? user.username;
+    const formattedDate = joinedAt ? formatJoinDate(joinedAt) : "Unknown";
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                gap: "12px",
+                padding: "10px 14px",
+                borderRadius: "8px",
+            }}
+        >
+            <img
+                src={user.getAvatarURL(guildId, 32, false)}
+                width={32}
+                height={32}
+                style={{
+                    width: "32px",
+                    height: "32px",
+                    minWidth: "32px",
+                    maxWidth: "32px",
+                    borderRadius: "50%",
+                    objectFit: "cover",
+                }}
+            />
+            <div style={{ display: "flex", flexDirection: "column" }}>
+                <span style={{ fontSize: "15px", fontWeight: 700, color: "var(--text-normal)" }}>
+                    {displayName}
+                </span>
+                <span style={{ fontSize: "12px", color: "var(--text-muted)" }}>
+                    {user.username !== displayName ? `${user.username} \u00B7 ` : ""}Joined {formattedDate}
+                </span>
+            </div>
+        </div>
+    );
+}
+
+function formatJoinDate(iso: string): string {
+    try {
+        const date = new Date(iso);
+        return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    } catch {
+        return "Unknown";
+    }
+}
+
+const RoleMembersModal = ErrorBoundary.wrap(RoleMembersModalComponent);
+
+export default function openRoleMembersModal(guildId: string, roleId: string, onBack?: () => void) {
+    openModal(modalProps => (
+        <RoleMembersModal guildId={guildId} roleId={roleId} modalProps={modalProps} onBack={onBack} />
+    ));
+}

--- a/src/equicordplugins/roleMembers/index.tsx
+++ b/src/equicordplugins/roleMembers/index.tsx
@@ -1,0 +1,115 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { EquicordDevs } from "@utils/constants";
+import { getCurrentGuild } from "@utils/discord";
+import definePlugin from "@utils/types";
+import { GuildRoleStore, Menu, SelectedGuildStore, useEffect, useRef } from "@webpack/common";
+
+import openAllRolesModal from "./components/AllRolesModal";
+import openRoleMembersModal from "./components/RoleMembersModal";
+
+const devContextMenuPatch: NavContextMenuPatchCallback = (children, { id }: { id: string; }) => {
+    const guild = getCurrentGuild();
+    if (!guild) return;
+
+    const role = GuildRoleStore.getRole(guild.id, id);
+    if (!role) return;
+
+    children.push(
+        <Menu.MenuGroup>
+            <Menu.MenuItem
+                id="vc-role-members"
+                label="View Role Members"
+                action={() => openRoleMembersModal(guild.id, id)}
+            />
+        </Menu.MenuGroup>
+    );
+};
+
+const guildContextMenuPatch: NavContextMenuPatchCallback = (children, { guild }: { guild: any; }) => {
+    if (!guild?.id) return;
+
+    children.push(
+        <Menu.MenuGroup>
+            <Menu.MenuItem
+                id="vc-view-all-roles"
+                label="View All Roles"
+                action={() => openAllRolesModal(guild.id)}
+            />
+        </Menu.MenuGroup>
+    );
+};
+
+export default definePlugin({
+    name: "RoleMembers",
+    description: "Click role pills on profiles and in server settings to see a list of members with that role. Right click a server to view all roles.",
+    authors: [EquicordDevs.UnknownHacker9991],
+
+    patches: [
+        {
+            find: "#{intl::COLLAPSE_ROLES}",
+            replacement: {
+                match: /(?<=\.id\)\),\i\(\))(?=,\i\?)/,
+                replace: ",$self.RolePillClickWrapper(arguments[0])"
+            }
+        },
+        {
+            find: "#{intl::GUILD_SETTINGS_EDIT_ROLE}",
+            replacement: {
+                match: /onClick:(\i),/,
+                replace: "onClick:(e)=>{if(e.shiftKey){$self.onSettingsRoleClick(arguments[0]);return;}$1(e)},"
+            }
+        }
+    ],
+
+    RolePillClickWrapper: ErrorBoundary.wrap(({ guild }: { guild: { id: string; }; }) => {
+        const anchorRef = useRef<HTMLSpanElement>(null);
+
+        useEffect(() => {
+            const parent = anchorRef.current?.parentElement;
+            if (!guild?.id || !parent) return;
+
+            const onClick = (e: MouseEvent) => {
+                if (e.button !== 0 || e.ctrlKey || e.shiftKey || e.metaKey || e.altKey) return;
+
+                let el = e.target as HTMLElement | null;
+                while (el && el !== parent) {
+                    const itemId = el.getAttribute("data-list-item-id");
+                    if (itemId?.startsWith("roles-")) {
+                        const roleId = itemId.slice("roles-".length);
+                        if (roleId) {
+                            openRoleMembersModal(guild.id, roleId);
+                            return;
+                        }
+                    }
+                    el = el.parentElement;
+                }
+            };
+
+            parent.addEventListener("click", onClick, true);
+            return () => parent.removeEventListener("click", onClick, true);
+        }, [guild?.id]);
+
+        if (!guild?.id) return null;
+        return <span ref={anchorRef} style={{ display: "none" }} />;
+    }, { noop: true }),
+
+    onSettingsRoleClick(props: any) {
+        const roleId = props?.role?.id;
+        const guildId = SelectedGuildStore.getGuildId();
+        if (!roleId || !guildId) return;
+        openRoleMembersModal(guildId, roleId);
+    },
+
+    contextMenus: {
+        "dev-context": devContextMenuPatch,
+        "guild-context": guildContextMenuPatch,
+        "guild-header-popout": guildContextMenuPatch
+    }
+});

--- a/src/equicordplugins/roleMembers/style.css
+++ b/src/equicordplugins/roleMembers/style.css
@@ -1,0 +1,140 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+.vc-rolemembers-header {
+    flex: 1;
+}
+
+.vc-rolemembers-header-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.vc-rolemembers-role-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.vc-rolemembers-subtitle {
+    margin-top: 2px;
+    color: var(--text-muted);
+}
+
+.vc-rolemembers-search {
+    padding: 0 16px 12px;
+    border-bottom: 1px solid var(--background-modifier-accent);
+}
+
+.vc-rolemembers-empty {
+    text-align: center;
+    padding: 60px 0;
+    color: var(--text-muted);
+}
+
+.vc-rolemembers-scroller {
+    padding: 0 8px;
+}
+
+/* ===== ALL ROLES MODAL - Role rows ===== */
+.vc-rolemembers-role-row {
+    display: flex;
+    align-items: center;
+    padding: 10px 14px;
+    border-radius: 6px;
+    cursor: pointer;
+    gap: 12px;
+    background-color: var(--background-secondary);
+    margin-bottom: 2px;
+    transition: background-color 0.15s ease;
+}
+
+.vc-rolemembers-role-row:hover {
+    background-color: var(--background-modifier-hover);
+}
+
+.vc-rolemembers-role-row .vc-rolemembers-role-dot {
+    width: 14px;
+    height: 14px;
+}
+
+.vc-rolemembers-role-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 15px;
+}
+
+/* ===== MEMBERS MODAL - Member rows ===== */
+.vc-rolemembers-member-row {
+    display: flex;
+    align-items: center;
+    padding: 8px 12px;
+    border-radius: 4px;
+    gap: 12px;
+    transition: background-color 0.1s ease;
+}
+
+.vc-rolemembers-member-row:hover {
+    background-color: var(--background-modifier-hover);
+}
+
+.vc-rolemembers-avatar {
+    width: 32px !important;
+    height: 32px !important;
+    border-radius: 50%;
+    flex-shrink: 0;
+    object-fit: cover;
+}
+
+.vc-rolemembers-member-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.vc-rolemembers-member-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-normal);
+}
+
+.vc-rolemembers-member-sub {
+    color: var(--text-muted);
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ===== Back button - pill shaped ===== */
+.vc-rolemembers-back-button {
+    background: var(--background-modifier-accent);
+    border: none;
+    color: var(--white);
+    cursor: pointer;
+    padding: 6px 12px;
+    border-radius: 16px;
+    font-size: 14px;
+    font-weight: 500;
+    margin-right: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+    transition: background-color 0.15s ease;
+}
+
+.vc-rolemembers-back-button:hover {
+    background-color: var(--background-modifier-hover);
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1292,6 +1292,10 @@ export const EquicordDevs = Object.freeze({
         name: "pointy",
         id: 99914384989519872n
     },
+    UnknownHacker9991: {
+        name: "UnknownHacker9991",
+        id: 1245799821173067850n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## RoleMembers

Click a role pill on a user profile or in server settings to see who has that role; right-click a server (or use the server-header popout) to open an All Roles modal with search and per-role drill-down.

## Features

- Role-pill clicks on user profiles open a modal listing every member with that role (fetched via the role-member-IDs endpoint).
- Shift-click a role in server settings opens the same modal without leaving the settings panel.
- ``View Role Members`` entry on the dev-context menu for developers.
- ``View All Roles`` entry on the server context menu / header popout opens a searchable list of all roles in the guild, with the same per-role drill-down.
- Modals include member avatars, display names, and a way to jump back from a role view to the full role list.

## Implementation notes

The profile-pill handler uses ``useRef`` + ``useEffect`` with proper cleanup (no raw ``addEventListener`` on mutable DOM flags). A deeper per-pill Vencord patch is possible but would collide with ``ClickableRoles``' existing patch on the same find/match; the current shape intentionally avoids that conflict.

## Notes

Split from #988 per reviewer feedback (one PR per plugin).