### PR TITLE
feat(quickNotes): save messages as personal notes with tags

### DIFF
--- a/src/equicordplugins/quickNotes/components/NotesModal.tsx
+++ b/src/equicordplugins/quickNotes/components/NotesModal.tsx
@@ -1,0 +1,238 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { DataStore } from "@api/index";
+import { classNameFactory } from "@utils/css";
+import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import { Alerts, Button, NavigationRouter, Select, Text, useEffect, useMemo, useState } from "@webpack/common";
+
+import { Note, STORAGE_KEY } from "..";
+
+const cl = classNameFactory("vc-quicknotes-");
+
+const TAG_COLORS: Record<string, string> = {
+    Important: "#ed4245",
+    TODO: "#faa61a",
+    CUSA: "#5865f2",
+    Reference: "#3ba55c",
+};
+
+function getTagColor(tag: string): string {
+    return TAG_COLORS[tag] ?? "#9b59b6";
+}
+
+function formatSavedAt(timestamp: number): string {
+    const diff = Date.now() - timestamp;
+    const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return "Just now";
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    if (days === 1) return "Yesterday";
+    if (days < 30) return `${days} days ago`;
+    const months = Math.floor(days / 30);
+    return `${months} month${months > 1 ? "s" : ""} ago`;
+}
+
+export function NotesModal({ modalProps }: { modalProps: ModalProps; }) {
+    const [notes, setNotes] = useState<Note[]>([]);
+    const [search, setSearch] = useState("");
+    const [filterTag, setFilterTag] = useState("");
+    const [filterGuild, setFilterGuild] = useState("");
+    const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
+
+    useEffect(() => {
+        DataStore.get(STORAGE_KEY).then((data: Note[] | undefined) => {
+            setNotes(data ?? []);
+        });
+    }, []);
+
+    const allTags = useMemo(() => [...new Set(notes.map(n => n.tag).filter(Boolean))], [notes]);
+    const allGuilds = useMemo(() => {
+        const map = new Map<string, string>();
+        for (const n of notes) {
+            if (n.guildId && n.guildName) map.set(n.guildId, n.guildName);
+        }
+        return [...map.entries()];
+    }, [notes]);
+
+    const filtered = useMemo(() => {
+        let result = [...notes];
+
+        if (search.trim()) {
+            const q = search.toLowerCase();
+            result = result.filter(n =>
+                n.content.toLowerCase().includes(q) ||
+                n.authorName.toLowerCase().includes(q) ||
+                n.channelName.toLowerCase().includes(q)
+            );
+        }
+
+        if (filterTag) {
+            result = result.filter(n => n.tag === filterTag);
+        }
+
+        if (filterGuild) {
+            result = result.filter(n => n.guildId === filterGuild);
+        }
+
+        result.sort((a, b) =>
+            sortOrder === "newest" ? b.savedAt - a.savedAt : a.savedAt - b.savedAt
+        );
+
+        return result;
+    }, [notes, search, filterTag, filterGuild, sortOrder]);
+
+    async function deleteNote(id: string) {
+        const updated = notes.filter(n => n.id !== id);
+        setNotes(updated);
+        await DataStore.set(STORAGE_KEY, updated);
+    }
+
+    function jumpToMessage(note: Note) {
+        const guildPart = note.guildId || "@me";
+        NavigationRouter.transitionTo(`/channels/${guildPart}/${note.channelId}/${note.messageId}`);
+        modalProps.onClose();
+    }
+
+    const tagOptions = [
+        { label: "All Tags", value: "" },
+        ...allTags.map(t => ({ label: t, value: t })),
+    ];
+
+    const guildOptions = [
+        { label: "All Servers", value: "" },
+        ...allGuilds.map(([id, name]) => ({ label: name, value: id })),
+    ];
+
+    const sortOptions = [
+        { label: "Newest First", value: "newest" as const },
+        { label: "Oldest First", value: "oldest" as const },
+    ];
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.LARGE}>
+            <ModalHeader separator={false}>
+                <Text variant="heading-lg/semibold" className={cl("header")}>
+                    Quick Notes
+                </Text>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+
+            <div className={cl("filters")}>
+                <input
+                    type="text"
+                    placeholder="Search notes..."
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    className={cl("search")}
+                />
+
+                <div className={cl("filter-row")}>
+                    <Select
+                        options={tagOptions}
+                        isSelected={v => v === filterTag}
+                        select={v => setFilterTag(v)}
+                        serialize={v => v}
+                        closeOnSelect={true}
+                    />
+
+                    <Select
+                        options={guildOptions}
+                        isSelected={v => v === filterGuild}
+                        select={v => setFilterGuild(v)}
+                        serialize={v => v}
+                        closeOnSelect={true}
+                    />
+
+                    <Select
+                        options={sortOptions}
+                        isSelected={v => v === sortOrder}
+                        select={v => setSortOrder(v)}
+                        serialize={v => v}
+                        closeOnSelect={true}
+                    />
+
+                    <Text variant="text-sm/normal" className={cl("count")}>
+                        {filtered.length} note{filtered.length !== 1 ? "s" : ""}
+                    </Text>
+                </div>
+            </div>
+
+            <ModalContent>
+                {filtered.length === 0 ? (
+                    <div className={cl("empty")}>
+                        {notes.length === 0 ? "No notes yet. Right-click a message to save one!" : "No notes match your filters."}
+                    </div>
+                ) : (
+                    filtered.map(note => (
+                        <div key={note.id} className={cl("card")}>
+                            <div className={cl("card-header")}>
+                                <img
+                                    src={note.authorAvatar}
+                                    alt=""
+                                    className={cl("avatar")}
+                                />
+                                <Text variant="text-md/semibold" className={cl("author")}>
+                                    {note.authorName}
+                                </Text>
+                                <Text variant="text-xs/normal" className={cl("channel")}>
+                                    {note.guildName ? `${note.guildName} / #${note.channelName}` : `#${note.channelName}`}
+                                </Text>
+                                {note.tag && (
+                                    <span
+                                        className={cl("tag")}
+                                        style={{ background: getTagColor(note.tag) }}
+                                    >
+                                        {note.tag}
+                                    </span>
+                                )}
+                                <Text variant="text-xs/normal" className={cl("saved-at")}>
+                                    Saved {formatSavedAt(note.savedAt)}
+                                </Text>
+                            </div>
+
+                            <div className={cl("content")}>
+                                {note.content || <span className={cl("no-content")}>(no text content)</span>}
+                            </div>
+
+                            <div className={cl("actions")}>
+                                <button
+                                    className={cl("jump-btn")}
+                                    onClick={() => jumpToMessage(note)}
+                                >
+                                    Jump to Message
+                                </button>
+                                <button
+                                    className={cl("delete-btn")}
+                                    onClick={() => {
+                                        Alerts.show({
+                                            title: "Delete Note",
+                                            body: "Are you sure you want to delete this note?",
+                                            confirmText: "Delete",
+                                            confirmColor: "vc-notification-log-danger-btn",
+                                            cancelText: "Cancel",
+                                            onConfirm: () => deleteNote(note.id),
+                                        });
+                                    }}
+                                >
+                                    Delete Note
+                                </button>
+                            </div>
+                        </div>
+                    ))
+                )}
+            </ModalContent>
+
+            <ModalFooter>
+                <Button look={Button.Looks.LINK} color={Button.Colors.PRIMARY} onClick={modalProps.onClose}>
+                    Close
+                </Button>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/equicordplugins/quickNotes/components/SaveNoteModal.tsx
+++ b/src/equicordplugins/quickNotes/components/SaveNoteModal.tsx
@@ -1,0 +1,80 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@utils/css";
+import { ModalCloseButton, ModalContent, ModalFooter, ModalHeader, ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import { Button, Text, useState } from "@webpack/common";
+
+const cl = classNameFactory("vc-quicknotes-");
+
+const PRESET_TAGS = ["Important", "TODO", "CUSA", "Reference"];
+
+interface SaveNoteModalProps {
+    modalProps: ModalProps;
+    onSave: (tag: string) => void;
+}
+
+export function SaveNoteModal({ modalProps, onSave }: SaveNoteModalProps) {
+    const [tag, setTag] = useState("");
+
+    return (
+        <ModalRoot {...modalProps} size={ModalSize.SMALL}>
+            <ModalHeader separator={false}>
+                <Text variant="heading-lg/semibold" className={cl("header")}>
+                    Save as Note
+                </Text>
+                <ModalCloseButton onClick={modalProps.onClose} />
+            </ModalHeader>
+
+            <ModalContent>
+                <div className={cl("save-content")}>
+                    <Text variant="text-md/medium" className={cl("save-label")}>
+                        Tag / Category (optional)
+                    </Text>
+
+                    <input
+                        type="text"
+                        placeholder="Enter a tag..."
+                        value={tag}
+                        onChange={e => setTag(e.target.value)}
+                        className={cl("tag-input")}
+                    />
+
+                    <div className={cl("preset-tags")}>
+                        {PRESET_TAGS.map(preset => (
+                            <button
+                                key={preset}
+                                onClick={() => setTag(preset)}
+                                className={cl("preset-tag")}
+                                data-selected={tag === preset}
+                            >
+                                {preset}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+            </ModalContent>
+
+            <ModalFooter>
+                <Button
+                    onClick={() => {
+                        onSave(tag.trim());
+                        modalProps.onClose();
+                    }}
+                >
+                    Save Note
+                </Button>
+                <Button
+                    look={Button.Looks.LINK}
+                    color={Button.Colors.PRIMARY}
+                    onClick={modalProps.onClose}
+                >
+                    Cancel
+                </Button>
+            </ModalFooter>
+        </ModalRoot>
+    );
+}

--- a/src/equicordplugins/quickNotes/index.tsx
+++ b/src/equicordplugins/quickNotes/index.tsx
@@ -1,0 +1,150 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { ChatBarButton, ChatBarButtonFactory } from "@api/ChatButtons";
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { DataStore } from "@api/index";
+import { EquicordDevs } from "@utils/constants";
+import { openModal } from "@utils/modal";
+import definePlugin from "@utils/types";
+import { ChannelStore, GuildStore, IconUtils, Menu, UserStore } from "@webpack/common";
+
+import { NotesModal } from "./components/NotesModal";
+import { SaveNoteModal } from "./components/SaveNoteModal";
+
+export const STORAGE_KEY = "vc-quick-notes";
+
+export interface Note {
+    id: string;
+    messageId: string;
+    channelId: string;
+    guildId: string;
+    guildName: string;
+    channelName: string;
+    authorId: string;
+    authorName: string;
+    authorAvatar: string;
+    content: string;
+    tag: string;
+    savedAt: number;
+}
+
+function generateId(): string {
+    return Date.now().toString(36) + Math.random().toString(36);
+}
+
+async function saveNote(note: Note) {
+    const notes: Note[] = await DataStore.get(STORAGE_KEY) ?? [];
+    notes.push(note);
+    await DataStore.set(STORAGE_KEY, notes);
+}
+
+function openNotesModal() {
+    openModal(modalProps => <NotesModal modalProps={modalProps} />);
+}
+
+function openSaveNoteModal(message: any) {
+    const channel = ChannelStore.getChannel(message.channel_id);
+    const guild = channel?.guild_id ? GuildStore.getGuild(channel.guild_id) : null;
+    const author = UserStore.getUser(message.author.id);
+
+    openModal(modalProps => (
+        <SaveNoteModal
+            modalProps={modalProps}
+            onSave={tag => {
+                saveNote({
+                    id: generateId(),
+                    messageId: message.id,
+                    channelId: message.channel_id,
+                    guildId: guild?.id ?? "",
+                    guildName: guild?.name ?? "Direct Messages",
+                    channelName: channel?.name ?? "Unknown",
+                    authorId: message.author.id,
+                    authorName: author?.globalName ?? message.author.username,
+                    authorAvatar: author ? IconUtils.getUserAvatarURL(author, false, 64) : "",
+                    content: message.content ?? "",
+                    tag,
+                    savedAt: Date.now(),
+                });
+            }}
+        />
+    ));
+}
+
+function NotebookIcon() {
+    return (
+        <svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
+            <path d="M6 2a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H6zm0 2h12v16H6V4zm2 2v2h8V6H8zm0 4v2h8v-2H8zm0 4v2h5v-2H8z" />
+        </svg>
+    );
+}
+
+const QuickNotesButton: ChatBarButtonFactory = ({ isMainChat }) => {
+    if (!isMainChat) return null;
+
+    return (
+        <ChatBarButton
+            tooltip="Quick Notes"
+            onClick={openNotesModal}
+        >
+            <NotebookIcon />
+        </ChatBarButton>
+    );
+};
+
+const messageContextMenuPatch: NavContextMenuPatchCallback = (children, { message }: { message: any; }) => {
+    if (!message) return;
+
+    const group = findGroupChildrenByChildId("copy-text", children);
+    if (!group) {
+        children.push(
+            <Menu.MenuGroup>
+                <Menu.MenuItem
+                    id="vc-save-as-note"
+                    label="Save as Note"
+                    action={() => openSaveNoteModal(message)}
+                />
+                <Menu.MenuItem
+                    id="vc-view-notes"
+                    label="View Notes"
+                    action={openNotesModal}
+                />
+            </Menu.MenuGroup>
+        );
+        return;
+    }
+
+    group.push(
+        <Menu.MenuItem
+            id="vc-save-as-note"
+            label="Save as Note"
+            action={() => openSaveNoteModal(message)}
+        />,
+        <Menu.MenuItem
+            id="vc-view-notes"
+            label="View Notes"
+            action={openNotesModal}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "QuickNotes",
+    description: "Save messages as notes with tags and view them anytime from a notes panel.",
+    authors: [EquicordDevs.UnknownHacker9991],
+    dependencies: ["ChatInputButtonAPI"],
+
+    contextMenus: {
+        "message": messageContextMenuPatch,
+    },
+
+    chatBarButton: {
+        icon: NotebookIcon,
+        render: QuickNotesButton,
+    },
+});

--- a/src/equicordplugins/quickNotes/style.css
+++ b/src/equicordplugins/quickNotes/style.css
@@ -1,0 +1,194 @@
+/* Modal header title */
+.vc-quicknotes-header {
+    flex: 1;
+    color: var(--header-primary);
+    font-size: 20px;
+    font-weight: 600;
+}
+
+/* Filter bar below header */
+.vc-quicknotes-filters {
+    padding: 0 16px 8px;
+}
+
+.vc-quicknotes-search {
+    width: 100%;
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid var(--background-modifier-accent);
+    background: var(--background-secondary);
+    color: var(--text-normal);
+    font-size: 14px;
+    box-sizing: border-box;
+    margin-bottom: 8px;
+}
+
+.vc-quicknotes-filter-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.vc-quicknotes-select {
+    background: transparent;
+    color: var(--text-normal);
+    border: none;
+    outline: none;
+}
+
+.vc-quicknotes-select option {
+    background: var(--background-tertiary);
+    color: var(--text-normal);
+}
+
+.vc-quicknotes-count {
+    color: var(--text-muted);
+    font-size: 13px;
+    margin-left: auto;
+}
+
+/* Empty state */
+.vc-quicknotes-empty {
+    padding: 40px 20px;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 14px;
+}
+
+/* Note card */
+.vc-quicknotes-card {
+    padding: 12px 16px;
+    margin: 0 8px 8px;
+    border-radius: 8px;
+    background: var(--background-secondary);
+    border: 1px solid var(--background-modifier-accent);
+}
+
+.vc-quicknotes-card-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.vc-quicknotes-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.vc-quicknotes-author {
+    color: var(--text-normal);
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.vc-quicknotes-channel {
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.vc-quicknotes-tag {
+    padding: 1px 8px;
+    border-radius: 10px;
+    color: var(--white);
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.vc-quicknotes-saved-at {
+    color: var(--text-muted);
+    font-size: 12px;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+.vc-quicknotes-content {
+    color: var(--text-normal);
+    font-size: 14px;
+    line-height: 1.4;
+    margin-bottom: 8px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.vc-quicknotes-no-content {
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+.vc-quicknotes-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.vc-quicknotes-jump-btn {
+    padding: 4px 12px;
+    border-radius: 4px;
+    border: none;
+    background: var(--brand-500);
+    color: var(--white);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.vc-quicknotes-delete-btn {
+    padding: 4px 12px;
+    border-radius: 4px;
+    border: none;
+    background: var(--red-400);
+    color: var(--white);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+/* Save Note Modal */
+.vc-quicknotes-save-content {
+    padding: 8px 0;
+}
+
+.vc-quicknotes-save-label {
+    margin-bottom: 8px;
+    color: var(--text-normal);
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.vc-quicknotes-tag-input {
+    width: 100%;
+    padding: 8px;
+    border-radius: 4px;
+    border: 1px solid var(--background-modifier-accent);
+    background: var(--background-secondary);
+    color: var(--text-normal);
+    font-size: 14px;
+    box-sizing: border-box;
+    margin-bottom: 8px;
+}
+
+.vc-quicknotes-preset-tags {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.vc-quicknotes-preset-tag {
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    border: 1px solid var(--background-modifier-accent);
+    background: var(--background-modifier-accent);
+    color: var(--text-normal);
+}
+
+.vc-quicknotes-preset-tag[data-selected="true"] {
+    border: 2px solid var(--brand-500);
+    background: var(--brand-500);
+    color: var(--white);
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1292,6 +1292,10 @@ export const EquicordDevs = Object.freeze({
         name: "pointy",
         id: 99914384989519872n
     },
+    UnknownHacker9991: {
+        name: "UnknownHacker9991",
+        id: 1245799821173067850n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## QuickNotes

Right-click any message to save it as a personal note with a tag; browse, filter, and copy saved notes from a chat-bar button.

## Features

- ``Save as Note`` entry on the message context menu opens a small modal to pick or enter a tag before saving.
- ``View Notes`` context-menu entry + a chat-bar button (notebook icon) open the notes panel.
- Notes include: author (name + avatar), channel, guild, original timestamp, save timestamp, tag, and full message content.
- Notes panel supports search-by-tag / content, tag filtering, and delete.
- Storage: persisted via ``@api/DataStore`` (per-user, survives reloads).

## Implementation notes

Chat-bar button is registered declaratively (``chatBarButton: { icon, render }`` on ``definePlugin``), not imperatively in ``start()``/``stop()``. Avatars go through ``IconUtils.getUserAvatarURL``.

## Notes

Split from #988 per reviewer feedback (one PR per plugin).