### PR TITLE
feat(serverClock): show teammates local time from timezone info in nicknames/roles

### DIFF
--- a/src/equicordplugins/serverClock/components/TimeDisplay.tsx
+++ b/src/equicordplugins/serverClock/components/TimeDisplay.tsx
@@ -1,0 +1,78 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@utils/css";
+import { React, Tooltip } from "@webpack/common";
+
+const cl = classNameFactory("vc-serverclock-");
+
+interface TimeDisplayProps {
+    utcOffset: number;
+    timezoneName: string;
+    use24Hour: boolean;
+    small?: boolean;
+}
+
+function formatTime(utcOffset: number, use24Hour: boolean): string {
+    const now = new Date();
+    const utcMs = now.getTime() + now.getTimezoneOffset() * 60000;
+    const localMs = utcMs + utcOffset * 3600000;
+    const localDate = new Date(localMs);
+
+    const hours = localDate.getHours();
+    const minutes = localDate.getMinutes().toString().padStart(2, "0");
+
+    if (use24Hour) {
+        return `${hours.toString().padStart(2, "0")}:${minutes}`;
+    }
+
+    const period = hours >= 12 ? "PM" : "AM";
+    const h12 = hours % 12 || 12;
+    return `${h12}:${minutes} ${period}`;
+}
+
+export function TimeDisplay({ utcOffset, timezoneName, use24Hour, small }: TimeDisplayProps) {
+    const [time, setTime] = React.useState(() => formatTime(utcOffset, use24Hour));
+
+    React.useEffect(() => {
+        setTime(formatTime(utcOffset, use24Hour));
+
+        const interval = setInterval(() => {
+            setTime(formatTime(utcOffset, use24Hour));
+        }, 60000);
+
+        return () => clearInterval(interval);
+    }, [utcOffset, use24Hour]);
+
+    let utcLabel: string;
+    if (utcOffset === 0) {
+        utcLabel = "UTC";
+    } else {
+        const sign = utcOffset > 0 ? "+" : "-";
+        const abs = Math.abs(utcOffset);
+        const hours = Math.trunc(abs);
+        const minutes = Math.round((abs - hours) * 60);
+        utcLabel = minutes > 0
+            ? `UTC${sign}${hours}:${minutes.toString().padStart(2, "0")}`
+            : `UTC${sign}${hours}`;
+    }
+
+    const isAbbreviation = !/^(?:GMT|UTC)/i.test(timezoneName);
+    const tooltipText = isAbbreviation ? `${timezoneName} (${utcLabel})` : utcLabel;
+
+    return (
+        <Tooltip text={tooltipText}>
+            {tooltipProps => (
+                <span
+                    {...tooltipProps}
+                    className={cl("time", { small: !!small })}
+                >
+                    {"\uD83D\uDD50"} {time}
+                </span>
+            )}
+        </Tooltip>
+    );
+}

--- a/src/equicordplugins/serverClock/index.tsx
+++ b/src/equicordplugins/serverClock/index.tsx
@@ -1,0 +1,210 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { addMemberListDecorator, removeMemberListDecorator } from "@api/MemberListDecorators";
+import { definePluginSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { GuildMemberStore, GuildRoleStore, SelectedGuildStore, UserStore } from "@webpack/common";
+
+import { TimeDisplay } from "./components/TimeDisplay";
+
+const TIMEZONE_ABBREVIATIONS: Record<string, number> = {
+    est: -5,
+    cst: -6,
+    mst: -7,
+    pst: -8,
+    cet: 1,
+    eet: 2,
+    ist: 5.5,
+    jst: 9,
+    aest: 10,
+    kst: 9,
+    wib: 7,
+    trt: 3,
+};
+
+const OFFSET_REGEX = /\b(?:GMT|UTC)\s*([+-]?\d{1,2}(?:\.\d+)?)\b/i;
+
+interface TimezoneResult {
+    offset: number;
+    name: string;
+}
+
+const timezoneCache = new Map<string, TimezoneResult | null>();
+
+function getCacheKey(guildId: string, userId: string): string {
+    return `${guildId}:${userId}`;
+}
+
+const ABBREVIATION_REGEX = new RegExp(
+    `(?<=^|[^a-zA-Z])(${Object.keys(TIMEZONE_ABBREVIATIONS).join("|")})(?=$|[^a-zA-Z])`,
+    "i"
+);
+
+function matchTimezoneInText(text: string): TimezoneResult | null {
+    const offsetMatch = text.match(OFFSET_REGEX);
+    if (offsetMatch) {
+        const offset = parseFloat(offsetMatch[1]);
+        return { offset, name: offsetMatch[0] };
+    }
+
+    const abbrMatch = text.match(ABBREVIATION_REGEX);
+    if (abbrMatch) {
+        const matched = abbrMatch[1];
+        const key = matched.toLowerCase();
+        return { offset: TIMEZONE_ABBREVIATIONS[key], name: matched.toUpperCase() };
+    }
+
+    return null;
+}
+
+function parseTimezone(guildId: string, userId: string): TimezoneResult | null {
+    const key = getCacheKey(guildId, userId);
+    if (timezoneCache.has(key)) return timezoneCache.get(key)!;
+
+    const member = GuildMemberStore.getMember(guildId, userId);
+    const user = UserStore.getUser(userId);
+
+    // Check nickname first — most servers put timezone info here
+    if (member?.nick) {
+        const result = matchTimezoneInText(member.nick);
+        if (result) {
+            timezoneCache.set(key, result);
+            return result;
+        }
+    }
+
+    // Then global display name
+    if (user?.globalName) {
+        const result = matchTimezoneInText(user.globalName);
+        if (result) {
+            timezoneCache.set(key, result);
+            return result;
+        }
+    }
+
+    // Then username
+    if (user?.username) {
+        const result = matchTimezoneInText(user.username);
+        if (result) {
+            timezoneCache.set(key, result);
+            return result;
+        }
+    }
+
+    // Finally scan role names
+    if (member?.roles) {
+        for (const roleId of member.roles) {
+            const role = GuildRoleStore.getRole(guildId, roleId);
+            if (!role?.name) continue;
+
+            const result = matchTimezoneInText(role.name);
+            if (result) {
+                timezoneCache.set(key, result);
+                return result;
+            }
+        }
+    }
+
+    timezoneCache.set(key, null);
+    return null;
+}
+
+const settings = definePluginSettings({
+    showInMemberList: {
+        type: OptionType.BOOLEAN,
+        description: "Show in member list",
+        default: true,
+        restartNeeded: true,
+    },
+    showInPopouts: {
+        type: OptionType.BOOLEAN,
+        description: "Show in user popouts",
+        default: true,
+        restartNeeded: true,
+    },
+    showInProfiles: {
+        type: OptionType.BOOLEAN,
+        description: "Show in user profiles",
+        default: true,
+        restartNeeded: true,
+    },
+    use24Hour: {
+        type: OptionType.BOOLEAN,
+        description: "Use 24-hour format",
+        default: true,
+    },
+});
+
+function ServerClockIndicator({ userId, isProfile }: { userId?: string; isProfile?: boolean; }) {
+    if (!userId) return null;
+
+    const guildId = SelectedGuildStore.getGuildId();
+    if (!guildId) return null;
+
+    const tz = parseTimezone(guildId, userId);
+    if (!tz) return null;
+
+    if (isProfile) {
+        return (
+            <div className="vc-serverclock-profile">
+                <TimeDisplay
+                    utcOffset={tz.offset}
+                    timezoneName={tz.name}
+                    use24Hour={settings.store.use24Hour}
+                />
+            </div>
+        );
+    }
+
+    return (
+        <TimeDisplay
+            utcOffset={tz.offset}
+            timezoneName={tz.name}
+            use24Hour={settings.store.use24Hour}
+            small
+        />
+    );
+}
+
+export default definePlugin({
+    name: "ServerClock",
+    description: "Shows teammates' local time next to their name based on timezone info in nicknames, display names, or roles (e.g., GMT+3, EST, CET).",
+    authors: [EquicordDevs.UnknownHacker9991],
+    dependencies: ["MemberListDecoratorsAPI"],
+    settings,
+
+    patches: [
+        {
+            find: "#{intl::USER_PROFILE_PRONOUNS}",
+            replacement: {
+                match: /(?<=children:\[\i," ",\i)(?=\])/,
+                replace: ",$self.ServerClockIndicator({userId:arguments[0]?.user?.id,isProfile:true})",
+            },
+            predicate: () => settings.store.showInPopouts || settings.store.showInProfiles,
+        },
+    ],
+
+    start() {
+        timezoneCache.clear();
+        if (settings.store.showInMemberList) {
+            addMemberListDecorator("ServerClock", ({ user }) =>
+                user == null ? null : <ServerClockIndicator userId={user.id} />
+            );
+        }
+    },
+
+    stop() {
+        timezoneCache.clear();
+        removeMemberListDecorator("ServerClock");
+    },
+
+    ServerClockIndicator: ErrorBoundary.wrap(ServerClockIndicator, { noop: true }),
+});

--- a/src/equicordplugins/serverClock/style.css
+++ b/src/equicordplugins/serverClock/style.css
@@ -1,0 +1,24 @@
+.vc-serverclock-time {
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    margin-left: 4px;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+.vc-serverclock-time-small {
+    font-size: 10px;
+}
+
+.vc-serverclock-profile {
+    color: var(--text-muted);
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 4px;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1292,6 +1292,10 @@ export const EquicordDevs = Object.freeze({
         name: "pointy",
         id: 99914384989519872n
     },
+    UnknownHacker9991: {
+        name: "UnknownHacker9991",
+        id: 1245799821173067850n,
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## ServerClock

Shows each member's current local time next to their name, inferred from timezone info in their display name, nickname, or roles.

## Features

- Timezone detection from ``GMT+3`` / ``UTC-5`` offsets, IANA-style abbreviations (``EST``, ``CET``, ``PST``, ``JST``, etc.), and role names with the same patterns.
- Per-surface toggles: member list, user popouts, full user profiles.
- 12-hour / 24-hour format toggle.
- Updates every minute without re-parsing timezones each tick.
- No network calls — pure string parsing of cached user/role data.

## Notes

Split from #988 per reviewer feedback (one PR per plugin).