### PR TITLE
Allow using without a CORS proxy

### DIFF
--- a/src/equicordplugins/fileUpload/constants.ts
+++ b/src/equicordplugins/fileUpload/constants.ts
@@ -11,5 +11,8 @@ export function normalizeCorsProxyUrl(url?: string): string {
 }
 
 export function toProxiedUrl(url: string, corsProxyUrl = CORS_PROXY): string {
+    if (corsProxyUrl == "none") {
+        return url;
+    }
     return `${normalizeCorsProxyUrl(corsProxyUrl)}?url=${encodeURIComponent(url)}`;
 }


### PR DESCRIPTION
CORS can be disabled, or the server can be configured to send CORS headers. So, it would be useful to be able to skip the CORS proxy.