### PR TITLE
45 still too low, 90 gud

### DIFF
--- a/src/plugins/ircColors/index.ts
+++ b/src/plugins/ircColors/index.ts
@@ -133,7 +133,7 @@ export default definePlugin({
                 const currentUserColor = Number(h64(currentUserId) % 360n);
                 const otherUserColor = Number(h64(userId) % 360n);
                 const colorDiff = Math.min(Math.abs(currentUserColor - otherUserColor), 360 - Math.abs(currentUserColor - otherUserColor));
-                if (colorDiff < 45) {
+                if (colorDiff < 90) {
                     const newColor = (otherUserColor + 180) % 360;
                     return `hsl(${newColor}, 100%, ${settings.store.lightness}%)`;
                 }


### PR DESCRIPTION
sry for tiny pr, but yah 45 is still too little of a min difference, it still can be annoying. i wanted 90 at first, but picked 45 so i wouldnt flip over so many of the dms i already know the color for.
also, i would try to pr this to vencord https://github.com/Equicord/Equicord/pull/971#issuecomment-4233045318 but its ignored so far

<img width="215" height="235" alt="image" src="https://github.com/user-attachments/assets/df6ef888-22a5-44f1-becc-82e5cd50460b" />
