### PR TITLE
QuickReply: bug in the conflict check for NoBlockedMessages

### DIFF
--- a/src/plugins/quickReply/index.ts
+++ b/src/plugins/quickReply/index.ts
@@ -143,7 +143,7 @@ function getNextMessage(isUp: boolean, isReply: boolean) {
         if (!isReply && m.author.id !== meId) return false; // editing only own messages
         if (!MessageTypeSets.REPLYABLE.has(m.type) || m.hasFlag(MessageFlags.EPHEMERAL)) return false;
         if (settings.store.ignoreBlockedAndIgnored && RelationshipStore.isBlockedOrIgnored(m.author.id)) return false;
-        if (hasNoBlockedMessages && NoBlockedMessagesPlugin.isSuppressed(m)) return false;
+        if (hasNoBlockedMessages && NoBlockedMessagesPlugin.isSuppressed(m).suppressed) return false;
 
         return true;
     });


### PR DESCRIPTION
objects are truthy so when NoBlockedMessages is enabled, QuickReply filters out every message which obviously means QuickReply cant do anything