### PR TITLE
moreStickers : use the proxied corsFetch for sending custom stickers …

### DIFF
--- a/src/equicordplugins/moreStickers/stickers.ts
+++ b/src/equicordplugins/moreStickers/stickers.ts
@@ -9,6 +9,8 @@ import * as DataStore from "@api/DataStore";
 import { removeRecentStickerByPackId } from "./components";
 import { DynamicPackSetMeta, DynamicStickerPackMeta, StickerPack, StickerPackMeta } from "./types";
 import { Mutex } from "./utils";
+import { corsFetch } from "./utils";
+
 const mutex = new Mutex();
 
 const PACKS_KEY = "MoreStickers:Packs";
@@ -117,7 +119,7 @@ export async function deleteStickerPack(id: string, packsKey: string = PACKS_KEY
 // ---------------------------- Dynamic Packs ----------------------------
 
 export async function getDynamicStickerPack(dspm: DynamicStickerPackMeta): Promise<StickerPack | null> {
-    const dsp = await fetch(dspm.dynamic.refreshUrl, {
+    const dsp = await corsFetch(dspm.dynamic.refreshUrl, {
         headers: dspm.dynamic.authHeaders,
     });
     if (!dsp.ok) return null;
@@ -133,7 +135,7 @@ function hasDynamicPackSetMeta(dpsm: DynamicPackSetMeta, metas?: DynamicPackSetM
 }
 
 export async function fetchDynamicPackSetMeta(dpsm: DynamicPackSetMeta): Promise<DynamicPackSetMeta | null> {
-    const dpsm_ = await fetch(dpsm.refreshUrl, {
+    const dpsm_ = await corsFetch(dpsm.refreshUrl, {
         headers: dpsm.authHeaders,
     });
     if (!dpsm_.ok) return null;

--- a/src/equicordplugins/moreStickers/upload.ts
+++ b/src/equicordplugins/moreStickers/upload.ts
@@ -6,7 +6,7 @@
 
 import { getMimeFromExtension } from "@equicordplugins/fileUpload/utils/getMediaUrl";
 import { FFmpeg } from "@ffmpeg/ffmpeg";
-import { fetchFile } from "@ffmpeg/util";
+import { corsFetch } from "./utils";
 import { insertTextIntoChatInputBox, MessageOptions } from "@utils/discord";
 import { CloudUploadPlatform } from "@vencord/discord-types/enums";
 import { ChannelStore, CloudUploader, Constants, DraftStore, FluxDispatcher, MessageActions, PendingReplyStore, RestAPI, showToast, SnowflakeUtils, Toasts, UploadHandler } from "@webpack/common";
@@ -75,7 +75,10 @@ async function resizeImage(url: string) {
 
 async function toGIF(url: string, ffmpeg: FFmpeg): Promise<File> {
     const filename = (new URL(url)).pathname.split("/").pop() ?? "image.png";
-    await ffmpeg.writeFile(filename, await fetchFile(url));
+    const res = await corsFetch(url);
+    if (!res.ok) throw new Error("Failed to fetch image for GIF conversion");
+    const arr = new Uint8Array(await res.arrayBuffer());
+    await ffmpeg.writeFile(filename, arr);
 
     const outputFilename = "output.gif";
     await ffmpeg.exec(["-i", filename,
@@ -127,7 +130,8 @@ export async function sendSticker({ channelId, sticker, ctrlKey, shiftKey, ffmpe
         if (!ffmpegState?.ffmpeg || !ffmpegState.isLoaded) throw new Error("FFmpeg not ready");
         file = await toGIF(sticker.image, ffmpegState.ffmpeg);
     } else {
-        const res = await fetch(sticker.image);
+        const res = await corsFetch(sticker.image);
+        if (!res.ok) throw new Error("Failed to fetch sticker image");
         const blobUrl = URL.createObjectURL(await res.blob());
         const processed = await resizeImage(blobUrl);
         const filename = sticker.filename ?? new URL(sticker.image).pathname.split("/").pop()!;


### PR DESCRIPTION
…and for gifs
Downloading a sticker from a custom pack used to end up in a cors error and this fixes it
I have not tested for gifs