### PR TITLE
fix: BetterFolders, CallTimer, Cloud tab, ChannelTabs

### DIFF
--- a/src/components/settings/tabs/sync/CloudTab.tsx
+++ b/src/components/settings/tabs/sync/CloudTab.tsx
@@ -30,6 +30,7 @@ import { Link } from "@components/Link";
 import { Notice } from "@components/Notice";
 import { Paragraph } from "@components/Paragraph";
 import { SettingsTab, wrapTab } from "@components/settings/tabs/BaseTab";
+import { localStorage } from "@utils/localStorage";
 import { Margins } from "@utils/margins";
 import { useForceUpdater } from "@utils/react";
 import { findComponentByCodeLazy } from "@webpack";

--- a/src/equicordplugins/channelTabs/util/constants.tsx
+++ b/src/equicordplugins/channelTabs/util/constants.tsx
@@ -39,11 +39,9 @@ function AnimationSettings(): JSX.Element {
         { label: "Active Quests Gradient", value: "quests-active", selected: settings.store.animationQuestsActive }
     ];
 
-    const [currentValue, setCurrentValue] = useState(animationOptions.filter(option => option.selected));
+    const [currentValue, setCurrentValue] = useState(animationOptions.filter(option => option.selected).map(option => option.value));
 
-    function updateSettingsTruthy(enabled: DynamicDropdownSettingOption[]) {
-        const enabledValues = enabled.map(option => option.value);
-
+    function updateSettingsTruthy(enabledValues: string[]) {
         animationOptions.forEach(option => {
             option.selected = enabledValues.includes(option.value);
         });
@@ -64,23 +62,24 @@ function AnimationSettings(): JSX.Element {
         settings.store.animationResizeHandle = enabledValues.includes("resize-handle");
         settings.store.animationQuestsActive = enabledValues.includes("quests-active");
 
-        setCurrentValue(enabled);
+        setCurrentValue(enabledValues);
     }
 
     function handleChange(values: Array<DynamicDropdownSettingOption | string>) {
-        if (values.length === 0) {
-            updateSettingsTruthy([]);
+        const valueStrings = values.map(v => typeof v === "string" ? v : v.value);
+        const toggled = valueStrings.length > currentValue.length
+            ? valueStrings.find(v => !currentValue.includes(v))
+            : currentValue.find(v => !valueStrings.includes(v));
+
+        if (toggled == null) {
+            updateSettingsTruthy(valueStrings);
             return;
         }
 
-        const stringlessValues = values.filter(v => typeof v !== "string") as DynamicDropdownSettingOption[];
-        const selectedOption = values.find(v => typeof v === "string") as string;
-        const option = animationOptions.find(option => option.value === selectedOption) as DynamicDropdownSettingOption;
-
-        if (option.selected) {
-            updateSettingsTruthy(stringlessValues.filter(v => v.value !== selectedOption));
+        if (currentValue.includes(toggled)) {
+            updateSettingsTruthy(currentValue.filter(v => v !== toggled));
         } else {
-            updateSettingsTruthy([...stringlessValues, option]);
+            updateSettingsTruthy([...currentValue, toggled]);
         }
     }
 

--- a/src/plugins/betterFolders/index.tsx
+++ b/src/plugins/betterFolders/index.tsx
@@ -148,40 +148,21 @@ function closeFolders() {
 }
 
 // Nuckyz: Unsure if this should be a general utility or not
-function filterTreeWithTargetNode(children: any, predicate: (node: any) => boolean, visited = new WeakSet<object>(), depth = 0) {
-    if (children == null) {
-        return false;
-    }
-
-    if (depth > MAX_TREE_FILTER_DEPTH) {
-        return false;
-    }
+function containsTargetNode(children: any, predicate: (node: any) => boolean, visited = new WeakSet<object>(), depth = 0): boolean {
+    if (children == null) return false;
+    if (depth > MAX_TREE_FILTER_DEPTH) return false;
 
     if (typeof children === "object") {
         if (visited.has(children)) return false;
         visited.add(children);
     }
 
-    if (!Array.isArray(children)) {
-        if (predicate(children)) {
-            return true;
-        }
-
-        return filterTreeWithTargetNode(children.props?.children, predicate, visited, depth + 1);
+    if (Array.isArray(children)) {
+        return children.some(child => containsTargetNode(child, predicate, visited, depth + 1));
     }
 
-    let childIsTargetChild = false;
-    for (let i = 0; i < children.length; i++) {
-        const shouldKeep = filterTreeWithTargetNode(children[i], predicate, visited, depth + 1);
-        if (shouldKeep) {
-            childIsTargetChild = true;
-            continue;
-        }
-
-        children.splice(i--, 1);
-    }
-
-    return childIsTargetChild;
+    if (predicate(children)) return true;
+    return containsTargetNode(children.props?.children, predicate, visited, depth + 1);
 }
 
 function getNestedFolderMap(): Record<string, string> {
@@ -853,7 +834,7 @@ export default definePlugin({
             }
 
             try {
-                return filterTreeWithTargetNode(child, child => child?.props?.renderTreeNode != null);
+                return containsTargetNode(child, c => c?.props?.renderTreeNode != null);
             } catch {
                 return true;
             }

--- a/src/plugins/callTimer/index.tsx
+++ b/src/plugins/callTimer/index.tsx
@@ -139,7 +139,7 @@ export default definePlugin({
             find: "renderConnectionStatus(){",
             replacement: {
                 match: /(renderConnectionStatus\(\).{0,1000}?lineClamp:1,children:)(\i)(?=,|}\))/,
-                replace: "$1[$2,$self.renderConnectionTimer(this?.props?.channel?.id)]"
+                replace: "$1[$2,$self.renderConnectionTimer({ channelId: this?.props?.channel?.id })]"
             }
         }
     ],

--- a/src/plugins/callTimer/index.tsx
+++ b/src/plugins/callTimer/index.tsx
@@ -139,7 +139,7 @@ export default definePlugin({
             find: "renderConnectionStatus(){",
             replacement: {
                 match: /(renderConnectionStatus\(\).{0,1000}?lineClamp:1,children:)(\i)(?=,|}\))/,
-                replace: "$1[$2,$self.renderTimer({ channelId: this?.props?.channel?.id })]"
+                replace: "$1[$2,$self.renderConnectionTimer(this?.props?.channel?.id)]"
             }
         }
     ],


### PR DESCRIPTION
CallTimer: connection-status patch passed an object to the wrong renderer
Cloud tab: import localStorage from @utils/localStorage so it works on web
ChannelTabs: animation dropdown handler now diffs against current state instead of relying on the old mixed string object onChange shape
BetterFolders: no idea if i fixed it couldnt reproduce