### PR TITLE
fix: handle emoji only channels

### DIFF
--- a/src/equicordplugins/cleanChannelName/index.ts
+++ b/src/equicordplugins/cleanChannelName/index.ts
@@ -20,13 +20,14 @@ const ORIGINAL_NAME = Symbol("cleanChannelName.original");
 let editingChannelId: string | null = null;
 
 function computeClean(name: string, type: number): string {
-    return name
+    const cleaned = name
         .normalize("NFKC")
         .replace(/[ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘǫʀꜱᴛᴜᴠᴡxʏᴢ]/g, m => SMALL_CAPS[m])
         .replace(/[^ -~]?\p{Extended_Pictographic}[^ -~]?/ug, "")
         .replace(/-?[^\p{Letter} -~]-?/ug, [2, 4].includes(type) ? " " : "-")
         .replace(/(^-|-$)/g, "")
         .replace(/-+/g, "-");
+    return cleaned || name;
 }
 
 export default definePlugin({


### PR DESCRIPTION
Previously if a name ended up blank at the end of this sequence it ended up blank in the UI. This'll now fallback to the original name if it ends up blank. 

One of the servers I'm in has like 10 channels that are just emojis (I hate it) and I was tired of being confused tbh. 