### PR TITLE
fix: update macOS installer asset name to arch-specific zips

### DIFF
--- a/scripts/runInstaller.mjs
+++ b/scripts/runInstaller.mjs
@@ -38,7 +38,7 @@ function getFilename() {
         case "win32":
             return "EquilotlCli.exe";
         case "darwin":
-            return "Equilotl.MacOS.zip";
+            return process.arch === "arm64" ? "Equilotl-darwin-arm64.zip" : "Equilotl-darwin-x64.zip";
         case "linux":
             return "EquilotlCli-linux";
         default:


### PR DESCRIPTION
The Equilotl releases replaced the `Equilotl.MacOS.zip` asset with
architecture-specific builds (`Equilotl-darwin-arm64.zip` /
`Equilotl-darwin-x64.zip`). The installer script now detects the CPU
architecture at runtime and downloads the correct zip instead of failing.

This broke the injection command for MacOS. 