### PR TITLE
feat(plugin): add FileSplitter

### DIFF
--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -573,7 +573,7 @@ export default definePlugin({
             scanChannel(ch);
             delayedScan = setTimeout(() => scanChannel(ch), 1500);
         }
-        cleanupInterval = setInterval(pruneOldChunks, 60_000);
+        cleanupInterval = setInterval(pruneOldChunks, 60000);
     },
 
     stop() {

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -116,9 +116,7 @@ function getChunkFromMessage(message: Message): ChunkData | null {
 }
 
 function anchorMessageId(key: string): string | null {
-    const entry = chunkStore[key];
-    if (!entry?.chunks.length) return null;
-    return [...entry.chunks].sort((a, b) => a.index - b.index)[0].messageId;
+    return chunkStore[key]?.chunks[0]?.messageId ?? null;
 }
 
 async function fetchBlob(url: string, filename?: string): Promise<Blob> {
@@ -154,7 +152,7 @@ async function downloadBlob(blob: Blob, filename: string) {
             return;
         } catch { }
     }
-    saveFile(new File([blob], filename, { type: blob.type || "application/octet-stream" }));
+    saveFile(new File([blob], filename, { type: blob.type ?? "application/octet-stream" }));
 }
 
 async function handleDownload(key: string) {
@@ -253,10 +251,9 @@ function processMessage(message: Message) {
 }
 
 function scanChannel(channelId: string) {
-    try {
-        const messages = MessageStore.getMessages(channelId).toArray();
-        for (const msg of messages) processMessage(msg);
-    } catch { }
+    const messages = MessageStore.getMessages(channelId);
+    if (!messages) return;
+    for (const msg of messages.toArray()) processMessage(msg);
 }
 
 function clearAll() {

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -1,0 +1,895 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 sioaeko and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./styles.css";
+
+import { ChatBarButton, addChatBarButton, removeChatBarButton } from "@api/ChatButtons";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { EquicordDevs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
+import definePlugin, { PluginNative } from "@utils/types";
+import { chooseFile, saveFile } from "@utils/web";
+import { findLazy } from "@webpack";
+import { Constants, MessageStore, React, RestAPI, SelectedChannelStore, SnowflakeUtils, Toasts } from "@webpack/common";
+
+const cl = classNameFactory("vc-file-splitter-");
+const CloudUpload = findLazy(m => m.prototype?.trackUploadFinished);
+
+const Native = IS_DISCORD_DESKTOP
+    ? VencordNative.pluginHelpers.FileSplitter as PluginNative<typeof import("./native")>
+    : null;
+
+const CHUNK_SIZE = 10 * 1024 * 1024;
+const MAX_FILE_SIZE = 500 * 1024 * 1024;
+const CHUNK_TIMEOUT = 30 * 60 * 1000;
+
+interface ChunkData {
+    index: number;
+    total: number;
+    originalName: string;
+    originalSize: number;
+    timestamp: number;
+    url: string;
+    channelId?: string;
+    messageId?: string;
+}
+
+interface ChunkStorageEntry {
+    ch: ChunkData[];
+    lu: number;
+    mg?: boolean;
+}
+
+interface MergedResult {
+    key: string;
+    originalName: string;
+    isImage: boolean;
+    mimeType: string;
+    status: "pending" | "loading" | "ready" | "error";
+    blob?: Blob;
+    objectUrl?: string;
+    error?: string;
+}
+
+type ChunkMessage = {
+    id?: string;
+    channel_id?: string;
+    channelId?: string;
+    content?: string;
+    attachments?: any[];
+};
+
+const cs: Record<string, ChunkStorageEntry> = {};
+const mergedResults = new Map<string, MergedResult>();
+const storeListeners = new Set<() => void>();
+let storeVersion = 0;
+let delayedChannelScan: ReturnType<typeof setTimeout> | undefined;
+let hideObserver: MutationObserver | undefined;
+let pendingHideSweep: number | undefined;
+
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+    avif: "image/avif",
+    bmp: "image/bmp",
+    gif: "image/gif",
+    jpeg: "image/jpeg",
+    jpg: "image/jpeg",
+    png: "image/png",
+    webp: "image/webp"
+};
+
+function emitStoreChange() {
+    storeVersion++;
+    for (const listener of storeListeners) listener();
+}
+
+function useFileSplitterStore() {
+    const [, setVersion] = React.useState(storeVersion);
+
+    React.useEffect(() => {
+        const listener = () => setVersion(storeVersion);
+        storeListeners.add(listener);
+        return () => {
+            storeListeners.delete(listener);
+        };
+    }, []);
+}
+
+async function downloadBlob(blob: Blob, filename: string) {
+    if (IS_DISCORD_DESKTOP) {
+        try {
+            const buffer = await blob.arrayBuffer();
+            await DiscordNative.fileManager.saveWithDialog(new Uint8Array(buffer), filename);
+            return;
+        } catch (e) {
+            console.warn("[FileSplitter] saveWithDialog failed, using browser fallback:", e);
+        }
+    }
+
+    saveFile(new File([blob], filename, { type: blob.type || "application/octet-stream" }));
+}
+
+function getChunkKey(c: Pick<ChunkData, "originalName" | "timestamp"> & Partial<Pick<ChunkData, "originalSize">>) {
+    return `${c.originalName}_${c.originalSize ?? "unknown"}_${c.timestamp}`;
+}
+
+function normalizeAttachmentUrl(url: string | null | undefined) {
+    if (!url) return null;
+
+    try {
+        const parsed = new URL(url);
+        if (parsed.hostname === "media.discordapp.net") {
+            parsed.hostname = "cdn.discordapp.com";
+        }
+        return parsed.toString();
+    } catch {
+        return url.replace("://media.discordapp.net/", "://cdn.discordapp.com/");
+    }
+}
+
+function getAttachmentUrl(attachment: any) {
+    return attachment?.url
+        ?? attachment?.proxy_url
+        ?? attachment?.download_url
+        ?? attachment?.proxyUrl
+        ?? null;
+}
+
+function getMessageId(message: ChunkMessage) {
+    return message.id ?? "";
+}
+
+function getMessageChannelId(message: ChunkMessage) {
+    return message.channel_id ?? message.channelId ?? "";
+}
+
+function parseChunkMeta(content: string | undefined): Omit<ChunkData, "url" | "channelId" | "messageId"> | null {
+    if (!content) return null;
+
+    try {
+        const c = JSON.parse(content);
+        if (
+            typeof c === "object"
+            && c?.type === "FileSplitterChunk"
+            && Number.isInteger(c.index)
+            && c.index >= 0
+            && Number.isInteger(c.total)
+            && c.total > 0
+            && c.index < c.total
+            && typeof c.originalName === "string"
+            && typeof c.originalSize === "number"
+            && typeof c.timestamp === "number"
+        ) {
+            return c;
+        }
+    } catch { }
+
+    return null;
+}
+
+function getStoredMessages(channelId: string): ChunkMessage[] {
+    const messages = MessageStore.getMessages(channelId);
+    if (!messages) return [];
+
+    if (Array.isArray(messages)) return messages;
+    if (typeof messages.toArray === "function") return messages.toArray();
+    if (typeof messages.values === "function") return Array.from(messages.values());
+    if (Array.isArray((messages as any)._array)) return (messages as any)._array;
+    if (Array.isArray((messages as any).array)) return (messages as any).array;
+    if ((messages as any)._map && typeof (messages as any)._map.values === "function") {
+        return Array.from((messages as any)._map.values());
+    }
+
+    return Object.values(messages).filter((message: any) => typeof message?.content === "string") as ChunkMessage[];
+}
+
+function inferMimeType(filename: string) {
+    const extension = filename.split(".").pop()?.toLowerCase();
+    return extension ? IMAGE_MIME_BY_EXTENSION[extension] ?? null : null;
+}
+
+function isInlinePreviewableImage(filename: string) {
+    const mimeType = inferMimeType(filename);
+    return mimeType?.startsWith("image/") ?? false;
+}
+
+function getFileBadge(filename: string) {
+    const extension = filename.split(".").pop()?.toLowerCase() ?? "";
+    if (["zip", "rar", "7z", "tar", "gz"].includes(extension)) return { kind: "archive", label: extension.toUpperCase() };
+    if (["pdf"].includes(extension)) return { kind: "document", label: "PDF" };
+    if (["txt", "md", "json", "csv", "xml", "yaml", "yml"].includes(extension)) return { kind: "text", label: extension.toUpperCase() };
+    if (["mp3", "wav", "flac", "ogg", "m4a"].includes(extension)) return { kind: "audio", label: extension.toUpperCase() };
+    if (["mp4", "mkv", "avi", "mov", "webm"].includes(extension)) return { kind: "video", label: extension.toUpperCase() };
+    if (["exe", "msi", "apk"].includes(extension)) return { kind: "app", label: extension.toUpperCase() };
+    return { kind: "file", label: (extension || "FILE").slice(0, 4).toUpperCase() };
+}
+
+function getChunkFromMessage(message: ChunkMessage): (ChunkData & { attachmentUrl: string; }) | null {
+    if (!message?.attachments?.length) return null;
+
+    const meta = parseChunkMeta(message.content);
+    if (!meta) return null;
+
+    const attachmentUrl = normalizeAttachmentUrl(getAttachmentUrl(message.attachments[0]));
+    if (!attachmentUrl) return null;
+
+    return {
+        ...meta,
+        url: attachmentUrl,
+        attachmentUrl,
+        channelId: getMessageChannelId(message),
+        messageId: getMessageId(message)
+    };
+}
+
+function getAnchorChunk(key: string) {
+    const entry = cs[key];
+    if (!entry?.ch.length) return null;
+
+    return entry.ch.find(chunk => chunk.channelId && chunk.messageId && getMessageElement(chunk.channelId, chunk.messageId, chunk.url))
+        ?? [...entry.ch].sort((a, b) => a.index - b.index)[0]
+        ?? null;
+}
+
+function getMessageElement(channelId: string, messageId: string, attachmentUrl?: string) {
+    const directId = document.getElementById(`chat-messages-${channelId}-${messageId}`);
+    if (directId instanceof HTMLElement) return directId;
+
+    const fallbackSelectors = [
+        `[data-list-item-id="chat-messages___${channelId}-${messageId}"]`,
+        `[data-message-id="${messageId}"]`,
+        `[id$="-${messageId}"]`
+    ];
+
+    for (const selector of fallbackSelectors) {
+        const element = document.querySelector(selector);
+        if (element instanceof HTMLElement) return element;
+    }
+
+    if (!attachmentUrl) return null;
+
+    let normalizedAttachmentUrl = normalizeAttachmentUrl(attachmentUrl)?.split("?")[0] ?? null;
+    if (!normalizedAttachmentUrl) return null;
+
+    for (const link of Array.from(document.querySelectorAll("a[href]"))) {
+        if (!(link instanceof HTMLAnchorElement)) continue;
+
+        const href = normalizeAttachmentUrl(link.href)?.split("?")[0] ?? null;
+        if (href !== normalizedAttachmentUrl) continue;
+
+        const container = link.closest("[id^='chat-messages-'], [data-list-item-id^='chat-messages___'], li, article, [class*='message']");
+        if (container instanceof HTMLElement) return container;
+    }
+
+    return null;
+}
+
+function isFileSplitterNode(element: HTMLElement) {
+    return Boolean(element.closest(".vc-file-splitter-card") || element.querySelector(".vc-file-splitter-card"));
+}
+
+function markHidden(element: HTMLElement) {
+    if (element.dataset.filesplitterHidden === "true") return;
+
+    element.dataset.filesplitterHidden = "true";
+    element.dataset.filesplitterPrevDisplay = element.style.display || "";
+    element.style.display = "none";
+}
+
+function restoreHiddenChunkMessages() {
+    for (const node of Array.from(document.querySelectorAll("[data-filesplitter-hidden='true']"))) {
+        if (!(node instanceof HTMLElement)) continue;
+
+        node.style.display = node.dataset.filesplitterPrevDisplay ?? "";
+        delete node.dataset.filesplitterHidden;
+        delete node.dataset.filesplitterPrevDisplay;
+    }
+}
+
+function hideAnchorChunkPayload(messageEl: HTMLElement, chunk: ChunkData) {
+    const contentCandidates = messageEl.querySelectorAll("[id^='message-content-'], [class*='messageContent'], [class*='markup']");
+    for (const candidate of Array.from(contentCandidates)) {
+        if (!(candidate instanceof HTMLElement) || isFileSplitterNode(candidate)) continue;
+        if ((candidate.textContent ?? "").includes("FileSplitterChunk")) markHidden(candidate);
+    }
+
+    const attachmentBlocks = messageEl.querySelectorAll([
+        "[class*='attachment']",
+        "[class*='mediaMosaic']",
+        "[class*='visualMediaItemContainer']",
+        "[class*='fileWrapper']",
+        "[class*='file']"
+    ].join(", "));
+
+    for (const block of Array.from(attachmentBlocks)) {
+        if (!(block instanceof HTMLElement) || isFileSplitterNode(block)) continue;
+        markHidden(block);
+    }
+
+    const attachmentHref = normalizeAttachmentUrl(chunk.url)?.split("?")[0] ?? null;
+    if (attachmentHref) {
+        for (const link of Array.from(messageEl.querySelectorAll("a[href]"))) {
+            if (!(link instanceof HTMLAnchorElement) || isFileSplitterNode(link)) continue;
+
+            const href = normalizeAttachmentUrl(link.href)?.split("?")[0] ?? null;
+            if (href !== attachmentHref) continue;
+
+            const target = link.closest("[class*='attachment'], [class*='fileWrapper'], [class*='file'], [class*='embed'], [class*='container'], a[href]");
+            if (target instanceof HTMLElement && target !== messageEl && !isFileSplitterNode(target)) markHidden(target);
+        }
+    }
+
+    for (const node of Array.from(messageEl.querySelectorAll("a, button, div, span"))) {
+        if (!(node instanceof HTMLElement) || isFileSplitterNode(node)) continue;
+
+        const text = node.textContent ?? "";
+        if (!/FileSplitterChunk|\.part\d{3}/i.test(text)) continue;
+
+        const target = node.closest("[id^='message-content-'], [class*='messageContent'], [class*='markup'], [class*='attachment'], [class*='fileWrapper'], [class*='file'], [class*='embed'], [class*='container'], a[href]");
+        if (target instanceof HTMLElement && target !== messageEl && !isFileSplitterNode(target)) {
+            markHidden(target);
+        } else {
+            markHidden(node);
+        }
+    }
+}
+
+function hideChunkMessages(key: string) {
+    const entry = cs[key];
+    const anchorChunk = getAnchorChunk(key);
+    if (!entry?.ch.length || !anchorChunk?.messageId) return;
+
+    for (const chunk of entry.ch) {
+        if (!chunk.channelId || !chunk.messageId) continue;
+
+        const messageEl = getMessageElement(chunk.channelId, chunk.messageId, chunk.url);
+        if (!messageEl) continue;
+
+        if (chunk.messageId !== anchorChunk.messageId) {
+            markHidden(messageEl);
+            continue;
+        }
+
+        hideAnchorChunkPayload(messageEl, chunk);
+    }
+}
+
+function hideKnownChunkMessages() {
+    for (const key of Object.keys(cs)) hideChunkMessages(key);
+}
+
+function scheduleHideSweep() {
+    if (pendingHideSweep !== undefined) return;
+
+    pendingHideSweep = requestAnimationFrame(() => {
+        pendingHideSweep = undefined;
+        hideKnownChunkMessages();
+    });
+}
+
+function getCompleteChunkCount(entry: ChunkStorageEntry) {
+    return new Set(entry.ch.map(chunk => chunk.index)).size;
+}
+
+function hasAllChunks(entry: ChunkStorageEntry) {
+    if (!entry.ch.length) return false;
+
+    const expectedCount = entry.ch[0].total;
+    if (getCompleteChunkCount(entry) !== expectedCount) return false;
+
+    const indexes = new Set(entry.ch.map(chunk => chunk.index));
+    for (let i = 0; i < expectedCount; i++) {
+        if (!indexes.has(i)) return false;
+    }
+
+    return true;
+}
+
+function storeChunk(c: ChunkData) {
+    const key = getChunkKey(c);
+    const entry = cs[key] ?? (cs[key] = { ch: [], lu: Date.now() });
+    const existing = entry.ch.find(chunk => chunk.index === c.index);
+    let changed = false;
+
+    if (!existing) {
+        entry.ch.push(c);
+        changed = true;
+    } else if (existing.url !== c.url || existing.messageId !== c.messageId || existing.channelId !== c.channelId) {
+        Object.assign(existing, c);
+        changed = true;
+    }
+
+    entry.ch.sort((a, b) => a.index - b.index);
+    entry.lu = Date.now();
+
+    if (changed) emitStoreChange();
+    return { key, entry, changed };
+}
+
+async function fetchBlob(url: string, filename?: string): Promise<Blob> {
+    const normalizedUrl = normalizeAttachmentUrl(url) ?? url;
+
+    if (Native) {
+        try {
+            const res = await Native.fetchChunk(normalizedUrl);
+            if (res.success && res.data) {
+                return new Blob([res.data], {
+                    type: res.contentType || (filename ? inferMimeType(filename) : null) || "application/octet-stream"
+                });
+            }
+            console.warn("[FileSplitter] Native fetch failed:", res.error);
+        } catch (e) {
+            console.warn("[FileSplitter] Native fetch errored:", e);
+        }
+    }
+
+    const r = await fetch(normalizedUrl);
+    if (!r.ok) throw new Error(`HTTP ${r.status}`);
+    return await r.blob();
+}
+
+async function assembleBlob(key: string) {
+    const entry = cs[key];
+    if (!entry?.ch.length) throw new Error("No chunks available");
+
+    const filename = entry.ch[0].originalName;
+    const parts: Blob[] = [];
+    for (const chunk of entry.ch) {
+        parts.push(await fetchBlob(chunk.url, filename));
+    }
+
+    const mimeType = inferMimeType(filename) ?? "application/octet-stream";
+    return {
+        blob: new Blob(parts, { type: mimeType }),
+        mimeType
+    };
+}
+
+async function ensureMergedResult(key: string, eagerImagePreview = false) {
+    const entry = cs[key];
+    if (!entry?.ch.length) return;
+
+    const originalName = entry.ch[0].originalName;
+    const isImage = isInlinePreviewableImage(originalName);
+    let result = mergedResults.get(key);
+    let changed = false;
+
+    if (!result) {
+        result = {
+            key,
+            originalName,
+            isImage,
+            mimeType: inferMimeType(originalName) ?? "application/octet-stream",
+            status: "pending"
+        };
+        mergedResults.set(key, result);
+        changed = true;
+    }
+
+    const shouldPreparePreview = isImage && eagerImagePreview && !result.objectUrl && result.status !== "loading";
+    if (changed) emitStoreChange();
+    if (!shouldPreparePreview) return;
+
+    result.status = "loading";
+    result.error = undefined;
+    emitStoreChange();
+
+    try {
+        const { blob, mimeType } = await assembleBlob(key);
+        if (result.objectUrl) URL.revokeObjectURL(result.objectUrl);
+        result.blob = blob;
+        result.mimeType = mimeType;
+        result.objectUrl = URL.createObjectURL(blob);
+        result.status = "ready";
+        result.error = undefined;
+    } catch (e: any) {
+        result.status = "error";
+        result.error = e?.message ?? String(e);
+        console.error("[FileSplitter] Preview preparation failed:", e);
+    }
+
+    emitStoreChange();
+}
+
+async function handleDownload(key: string) {
+    const result = mergedResults.get(key);
+    if (!result) return;
+
+    try {
+        if (!result.blob) {
+            result.status = "loading";
+            result.error = undefined;
+            emitStoreChange();
+
+            const assembled = await assembleBlob(key);
+            result.blob = assembled.blob;
+            result.mimeType = assembled.mimeType;
+            result.status = "ready";
+        }
+
+        await downloadBlob(result.blob, result.originalName);
+    } catch (e: any) {
+        result.status = "error";
+        result.error = e?.message ?? String(e);
+        emitStoreChange();
+        console.error("[FileSplitter] Download failed:", e);
+        Toasts.show({
+            message: `Download failed: ${e?.message ?? e}`,
+            id: Toasts.genId(),
+            type: Toasts.Type.FAILURE
+        });
+        return;
+    }
+
+    emitStoreChange();
+    Toasts.show({
+        message: `Downloaded: ${result.originalName}`,
+        id: Toasts.genId(),
+        type: Toasts.Type.SUCCESS
+    });
+}
+
+function tryMergeChunks(key: string) {
+    const entry = cs[key];
+    if (!entry || entry.mg || !hasAllChunks(entry)) return;
+
+    entry.mg = true;
+    entry.ch.sort((a, b) => a.index - b.index);
+    emitStoreChange();
+    void ensureMergedResult(key, isInlinePreviewableImage(entry.ch[0].originalName));
+}
+
+function processMessage(message: ChunkMessage) {
+    const chunk = getChunkFromMessage(message);
+    if (!chunk) return false;
+
+    const { key } = storeChunk(chunk);
+    tryMergeChunks(key);
+    scheduleHideSweep();
+    return true;
+}
+
+function scanExistingMessages(channelId: string) {
+    try {
+        const messages = getStoredMessages(channelId);
+        for (const msg of messages) {
+            processMessage(msg);
+        }
+    } catch (e) {
+        console.error("[FileSplitter] Scan error:", e);
+    }
+}
+
+function clearAllState() {
+    if (pendingHideSweep !== undefined) {
+        cancelAnimationFrame(pendingHideSweep);
+        pendingHideSweep = undefined;
+    }
+
+    for (const result of mergedResults.values()) {
+        if (result.objectUrl) URL.revokeObjectURL(result.objectUrl);
+    }
+
+    for (const key of Object.keys(cs)) delete cs[key];
+    mergedResults.clear();
+    restoreHiddenChunkMessages();
+    emitStoreChange();
+}
+
+function pruneOldChunks() {
+    const now = Date.now();
+    let changed = false;
+
+    for (const key of Object.keys(cs)) {
+        if (!cs[key].mg && now - cs[key].lu > CHUNK_TIMEOUT) {
+            delete cs[key];
+            changed = true;
+        }
+    }
+
+    if (changed) emitStoreChange();
+}
+
+function uploadChunk(channelId: string, chunkFile: File, metadata: any): Promise<void> {
+    return new Promise((resolve, reject) => {
+        try {
+            const uploader = new (CloudUpload as any)({ file: chunkFile, platform: 1 }, channelId);
+
+            uploader.on("complete", () => {
+                RestAPI.post({
+                    url: Constants.Endpoints.MESSAGES(channelId),
+                    body: {
+                        flags: 0,
+                        channel_id: channelId,
+                        content: JSON.stringify(metadata),
+                        nonce: SnowflakeUtils.fromTimestamp(Date.now()),
+                        sticker_ids: [],
+                        type: 0,
+                        attachments: [{
+                            id: "0",
+                            filename: uploader.filename,
+                            uploaded_filename: uploader.uploadedFilename
+                        }]
+                    }
+                }).then(() => resolve()).catch((e: any) => reject(new Error(`Send failed: ${JSON.stringify(e)}`)));
+            });
+
+            uploader.on("error", (e: any) => reject(new Error(`Upload failed: ${JSON.stringify(e)}`)));
+            uploader.upload();
+        } catch (e: any) {
+            reject(new Error(e?.message ?? JSON.stringify(e)));
+        }
+    });
+}
+
+const SplitIcon = () => (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+        <path d="M14 2H6C4.9 2 4 2.9 4 4v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zM6 20V4h7v5h5v11H6zm8-4h-4v-2h4v-2l3 3-3 3v-2z" />
+    </svg>
+);
+
+const FileTypeIcon = ({ kind, label }: { kind: string; label: string; }) => {
+    const paths = [
+        "M14 2H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7z",
+        "M14 2v5h5"
+    ];
+
+    if (kind === "archive") paths.push("M10 10v8", "M12 10v8", "M10 12h2", "M10 15h2", "M10 18h2");
+    else if (kind === "video") paths.push("M10 10.5v5l4-2.5z");
+    else if (kind === "audio") paths.push("M10 10v6", "M14 9v5", "M10 16a1.5 1.5 0 1 1-1.5 1.5", "M14 14a1.5 1.5 0 1 1-1.5 1.5");
+    else if (kind === "text") paths.push("M9 11h6", "M9 14h6", "M9 17h4");
+    else if (kind === "document") paths.push("M9 11h6", "M9 15h6");
+    else if (kind === "app") paths.push("M9 10h6v6H9z");
+    else paths.push("M9 11h6", "M9 15h6", "M9 19h4");
+
+    return (
+        <div className={cl("file-icon")} title={label}>
+            <svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                {paths.map(path => <path key={path} d={path} />)}
+            </svg>
+        </div>
+    );
+};
+
+const ActionButton = ({ children, disabled, onClick }: { children: any; disabled?: boolean; onClick: () => void; }) => (
+    <button
+        className={cl("action")}
+        type="button"
+        disabled={disabled}
+        onClick={event => {
+            event.preventDefault();
+            event.stopPropagation();
+            onClick();
+        }}
+    >
+        {children}
+    </button>
+);
+
+function ProgressCard({ entry }: { entry: ChunkStorageEntry; }) {
+    const first = entry.ch[0];
+    const count = getCompleteChunkCount(entry);
+    const total = first?.total ?? 0;
+
+    return (
+        <div className={cl("card")} data-status="pending">
+            <div className={cl("body")}>
+                <div className={cl("text")}>
+                    <div className={cl("title")}>{first?.originalName ?? "Split file"}</div>
+                    <div className={cl("subtitle")}>Waiting for chunks: {count}/{total}</div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function MergedResultCard({ result }: { result: MergedResult; }) {
+    const badgeInfo = getFileBadge(result.originalName);
+    const subtitle = result.error
+        ? `Merge failed: ${result.error}`
+        : result.isImage
+            ? result.status === "ready"
+                ? "Merged image preview"
+                : "Preparing image preview..."
+            : result.status === "loading"
+                ? "Preparing download..."
+                : "Merged file ready to download";
+
+    return (
+        <div className={cl("card")} data-status={result.status} data-image={String(result.isImage)}>
+            {result.isImage && result.objectUrl && (
+                <img className={cl("image")} src={result.objectUrl} alt={result.originalName} />
+            )}
+            <div className={cl("body")}>
+                {!result.isImage && <FileTypeIcon kind={badgeInfo.kind} label={badgeInfo.label} />}
+                <div className={cl("text")}>
+                    <div className={cl("title")}>{result.originalName}</div>
+                    <div className={cl("subtitle")}>{subtitle}</div>
+                </div>
+                <div className={cl("actions")}>
+                    {result.status === "error" ? (
+                        <ActionButton onClick={() => {
+                            if (result.isImage) void ensureMergedResult(result.key, true);
+                            else void handleDownload(result.key);
+                        }}>
+                            Retry
+                        </ActionButton>
+                    ) : (
+                        <ActionButton disabled={result.status === "loading" && !result.blob} onClick={() => void handleDownload(result.key)}>
+                            Download
+                        </ActionButton>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function FileSplitterAccessory({ message }: { message: ChunkMessage; }) {
+    useFileSplitterStore();
+
+    React.useEffect(() => {
+        processMessage(message);
+    }, [message?.id, message?.content, message?.attachments?.length]);
+
+    const chunk = getChunkFromMessage(message);
+    const key = chunk ? getChunkKey(chunk) : null;
+    const entry = key ? cs[key] : null;
+    const anchorChunk = key ? getAnchorChunk(key) : null;
+    const isAnchor = Boolean(anchorChunk?.messageId && anchorChunk.messageId === getMessageId(message));
+    const count = entry ? getCompleteChunkCount(entry) : 0;
+    const total = entry?.ch[0]?.total ?? 0;
+    const complete = Boolean(entry && count === total && hasAllChunks(entry));
+    const result = key ? mergedResults.get(key) : null;
+
+    React.useEffect(() => {
+        if (!key || !entry || !complete) return;
+        void ensureMergedResult(key, isInlinePreviewableImage(entry.ch[0].originalName));
+    }, [key, count, total, complete]);
+
+    React.useEffect(() => {
+        if (key) scheduleHideSweep();
+    }, [key, count, total, complete, result?.status]);
+
+    if (!chunk || !key || !entry || !isAnchor) return null;
+    if (!complete) return <ProgressCard entry={entry} />;
+    if (!result) return null;
+
+    return <MergedResultCard result={result} />;
+}
+
+const SafeFileSplitterAccessory = ErrorBoundary.wrap(FileSplitterAccessory, { noop: true });
+
+const SplitButton = () => {
+    const [status, setStatus] = React.useState<string | null>(null);
+
+    async function doUpload() {
+        const file = await chooseFile("*/*");
+        if (!file) return;
+
+        if (file.size > MAX_FILE_SIZE) {
+            Toasts.show({ message: "File exceeds 500MB limit.", id: Toasts.genId(), type: Toasts.Type.FAILURE });
+            return;
+        }
+
+        if (file.size <= CHUNK_SIZE) {
+            Toasts.show({ message: "File is small enough to send directly.", id: Toasts.genId(), type: Toasts.Type.MESSAGE });
+            return;
+        }
+
+        const channelId = SelectedChannelStore.getChannelId();
+        if (!channelId) {
+            Toasts.show({ message: "No channel selected.", id: Toasts.genId(), type: Toasts.Type.FAILURE });
+            return;
+        }
+
+        const totalChunks = Math.ceil(file.size / CHUNK_SIZE);
+        Toasts.show({ message: `Splitting ${file.name} into ${totalChunks} chunks...`, id: Toasts.genId(), type: Toasts.Type.MESSAGE });
+        setStatus("0%");
+
+        try {
+            const uploadTimestamp = Date.now();
+            for (let i = 0; i < totalChunks; i++) {
+                const start = i * CHUNK_SIZE;
+                const end = Math.min(start + CHUNK_SIZE, file.size);
+                const chunkBlob = file.slice(start, end);
+
+                const metadata = {
+                    type: "FileSplitterChunk",
+                    index: i,
+                    total: totalChunks,
+                    originalName: file.name,
+                    originalSize: file.size,
+                    timestamp: uploadTimestamp
+                };
+
+                const chunkFile = new File(
+                    [chunkBlob],
+                    `${file.name}.part${String(i + 1).padStart(3, "0")}`,
+                    { type: "application/octet-stream" }
+                );
+
+                await uploadChunk(channelId, chunkFile, metadata);
+                setStatus(`${Math.round(((i + 1) / totalChunks) * 100)}%`);
+            }
+
+            Toasts.show({ message: `Uploaded ${totalChunks} parts for ${file.name}`, id: Toasts.genId(), type: Toasts.Type.SUCCESS });
+        } catch (e: any) {
+            Toasts.show({ message: `Error: ${e?.message ?? JSON.stringify(e)}`, id: Toasts.genId(), type: Toasts.Type.FAILURE });
+        } finally {
+            setStatus(null);
+        }
+    }
+
+    const label = status ? `Uploading ${status}` : "Split & Upload";
+
+    return (
+        <ChatBarButton tooltip={label} onClick={status ? () => { } : () => void doUpload()}>
+            <SplitIcon />
+        </ChatBarButton>
+    );
+};
+
+export default definePlugin({
+    name: "FileSplitter",
+    description: "Splits large files into Discord-sized chunks and rebuilds them in chat.",
+    tags: ["Chat", "Utility"],
+    authors: [EquicordDevs.sioaeko],
+    dependencies: ["ChatInputButtonAPI", "MessageAccessoriesAPI"],
+    _cleanupInterval: undefined as any,
+
+    renderMessageAccessory(props: { message: ChunkMessage; }) {
+        return <SafeFileSplitterAccessory message={props.message} />;
+    },
+
+    flux: {
+        MESSAGE_CREATE({ message }: { message: ChunkMessage; }) {
+            processMessage(message);
+        },
+        MESSAGE_UPDATE({ message }: { message: ChunkMessage; }) {
+            processMessage(message);
+        },
+        LOAD_MESSAGES_SUCCESS({ channelId }: { channelId?: string; }) {
+            if (channelId) scanExistingMessages(channelId);
+        },
+        CHANNEL_SELECT({ channelId }: { channelId?: string; }) {
+            if (!channelId) return;
+
+            scanExistingMessages(channelId);
+            if (delayedChannelScan) clearTimeout(delayedChannelScan);
+            delayedChannelScan = setTimeout(() => {
+                scanExistingMessages(channelId);
+            }, 1500);
+        }
+    },
+
+    start() {
+        clearAllState();
+        addChatBarButton("FileSplitter", SplitButton, SplitIcon);
+
+        if (typeof MutationObserver !== "undefined" && document.body) {
+            hideObserver = new MutationObserver(() => scheduleHideSweep());
+            hideObserver.observe(document.body, { childList: true, subtree: true });
+        }
+
+        const currentChannel = SelectedChannelStore.getChannelId();
+        if (currentChannel) {
+            scanExistingMessages(currentChannel);
+            delayedChannelScan = setTimeout(() => scanExistingMessages(currentChannel), 1500);
+        }
+
+        scheduleHideSweep();
+        this._cleanupInterval = setInterval(pruneOldChunks, 60000);
+    },
+
+    stop() {
+        removeChatBarButton("FileSplitter");
+        if (delayedChannelScan) clearTimeout(delayedChannelScan);
+        if (this._cleanupInterval) clearInterval(this._cleanupInterval);
+        if (hideObserver) hideObserver.disconnect();
+        hideObserver = undefined;
+        clearAllState();
+    }
+});

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -6,17 +6,18 @@
 
 import "./styles.css";
 
-import { ChatBarButton, addChatBarButton, removeChatBarButton } from "@api/ChatButtons";
+import { ChatBarButton, ChatBarButtonFactory } from "@api/ChatButtons";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { EquicordDevs } from "@utils/constants";
 import { classNameFactory } from "@utils/css";
 import definePlugin, { PluginNative } from "@utils/types";
 import { chooseFile, saveFile } from "@utils/web";
+import type { Message, MessageAttachment } from "@vencord/discord-types";
 import { findLazy } from "@webpack";
 import { Constants, MessageStore, React, RestAPI, SelectedChannelStore, SnowflakeUtils, Toasts } from "@webpack/common";
 
 const cl = classNameFactory("vc-file-splitter-");
-const CloudUpload = findLazy(m => m.prototype?.trackUploadFinished);
+const CloudUpload = findLazy(m => m.prototype?.trackUploadFinished) as CloudUploadConstructor;
 
 const Native = IS_DISCORD_DESKTOP
     ? VencordNative.pluginHelpers.FileSplitter as PluginNative<typeof import("./native")>
@@ -37,6 +38,10 @@ interface ChunkData {
     messageId?: string;
 }
 
+type FileSplitterMetadata = Omit<ChunkData, "url" | "channelId" | "messageId"> & {
+    type: "FileSplitterChunk";
+};
+
 interface ChunkStorageEntry {
     ch: ChunkData[];
     lu: number;
@@ -55,20 +60,47 @@ interface MergedResult {
 }
 
 type ChunkMessage = {
-    id?: string;
     channel_id?: string;
     channelId?: string;
-    content?: string;
-    attachments?: any[];
+} & Partial<Pick<Message, "id" | "content" | "attachments">> & {
+    attachments?: MessageAttachment[];
 };
+
+type AttachmentWithUrls = MessageAttachment & {
+    download_url?: string;
+    proxyUrl?: string;
+};
+
+type StoredMessageCollection = ChunkMessage[] | {
+    toArray?: () => ChunkMessage[];
+    values?: () => Iterable<ChunkMessage>;
+    _array?: ChunkMessage[];
+    array?: ChunkMessage[];
+    _map?: {
+        values?: () => Iterable<ChunkMessage>;
+    };
+    [key: string]: unknown;
+};
+
+interface CloudUploadInstance {
+    filename: string;
+    uploadedFilename: string;
+    on(event: "complete", callback: () => void): void;
+    on(event: "error", callback: (error: unknown) => void): void;
+    upload(): void;
+}
+
+type CloudUploadConstructor = new (
+    data: { file: File; platform: number; },
+    channelId: string
+) => CloudUploadInstance;
 
 const cs: Record<string, ChunkStorageEntry> = {};
 const mergedResults = new Map<string, MergedResult>();
 const storeListeners = new Set<() => void>();
 let storeVersion = 0;
 let delayedChannelScan: ReturnType<typeof setTimeout> | undefined;
-let hideObserver: MutationObserver | undefined;
-let pendingHideSweep: number | undefined;
+let cleanupInterval: ReturnType<typeof setInterval> | undefined;
 
 const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
     avif: "image/avif",
@@ -103,12 +135,10 @@ async function downloadBlob(blob: Blob, filename: string) {
             const buffer = await blob.arrayBuffer();
             await DiscordNative.fileManager.saveWithDialog(new Uint8Array(buffer), filename);
             return;
-        } catch (e) {
-            console.warn("[FileSplitter] saveWithDialog failed, using browser fallback:", e);
-        }
+        } catch { }
     }
 
-    saveFile(new File([blob], filename, { type: blob.type || "application/octet-stream" }));
+    saveFile(new File([blob], filename, { type: blob.type ?? "application/octet-stream" }));
 }
 
 function getChunkKey(c: Pick<ChunkData, "originalName" | "timestamp"> & Partial<Pick<ChunkData, "originalSize">>) {
@@ -129,7 +159,7 @@ function normalizeAttachmentUrl(url: string | null | undefined) {
     }
 }
 
-function getAttachmentUrl(attachment: any) {
+function getAttachmentUrl(attachment: AttachmentWithUrls) {
     return attachment?.url
         ?? attachment?.proxy_url
         ?? attachment?.download_url
@@ -145,24 +175,57 @@ function getMessageChannelId(message: ChunkMessage) {
     return message.channel_id ?? message.channelId ?? "";
 }
 
+function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    if (typeof error === "string") return error;
+
+    try {
+        return JSON.stringify(error) ?? String(error);
+    } catch {
+        return String(error);
+    }
+}
+
+function isChunkMessageLike(message: unknown): message is ChunkMessage {
+    return typeof message === "object"
+        && message !== null
+        && typeof (message as { content?: unknown; }).content === "string";
+}
+
 function parseChunkMeta(content: string | undefined): Omit<ChunkData, "url" | "channelId" | "messageId"> | null {
     if (!content) return null;
 
     try {
-        const c = JSON.parse(content);
+        const c = JSON.parse(content) as Partial<FileSplitterMetadata> & { type?: unknown; };
+        const {
+            index,
+            total,
+            originalName,
+            originalSize,
+            timestamp
+        } = c;
+
         if (
             typeof c === "object"
             && c?.type === "FileSplitterChunk"
-            && Number.isInteger(c.index)
-            && c.index >= 0
-            && Number.isInteger(c.total)
-            && c.total > 0
-            && c.index < c.total
-            && typeof c.originalName === "string"
-            && typeof c.originalSize === "number"
-            && typeof c.timestamp === "number"
+            && Number.isInteger(index)
+            && typeof index === "number"
+            && index >= 0
+            && Number.isInteger(total)
+            && typeof total === "number"
+            && total > 0
+            && index < total
+            && typeof originalName === "string"
+            && typeof originalSize === "number"
+            && typeof timestamp === "number"
         ) {
-            return c;
+            return {
+                index,
+                total,
+                originalName,
+                originalSize,
+                timestamp
+            };
         }
     } catch { }
 
@@ -170,19 +233,19 @@ function parseChunkMeta(content: string | undefined): Omit<ChunkData, "url" | "c
 }
 
 function getStoredMessages(channelId: string): ChunkMessage[] {
-    const messages = MessageStore.getMessages(channelId);
+    const messages = MessageStore.getMessages(channelId) as StoredMessageCollection | null | undefined;
     if (!messages) return [];
 
     if (Array.isArray(messages)) return messages;
     if (typeof messages.toArray === "function") return messages.toArray();
     if (typeof messages.values === "function") return Array.from(messages.values());
-    if (Array.isArray((messages as any)._array)) return (messages as any)._array;
-    if (Array.isArray((messages as any).array)) return (messages as any).array;
-    if ((messages as any)._map && typeof (messages as any)._map.values === "function") {
-        return Array.from((messages as any)._map.values());
+    if (Array.isArray(messages._array)) return messages._array;
+    if (Array.isArray(messages.array)) return messages.array;
+    if (messages._map && typeof messages._map.values === "function") {
+        return Array.from(messages._map.values());
     }
 
-    return Object.values(messages).filter((message: any) => typeof message?.content === "string") as ChunkMessage[];
+    return Object.values(messages).filter(isChunkMessageLike);
 }
 
 function inferMimeType(filename: string) {
@@ -203,7 +266,8 @@ function getFileBadge(filename: string) {
     if (["mp3", "wav", "flac", "ogg", "m4a"].includes(extension)) return { kind: "audio", label: extension.toUpperCase() };
     if (["mp4", "mkv", "avi", "mov", "webm"].includes(extension)) return { kind: "video", label: extension.toUpperCase() };
     if (["exe", "msi", "apk"].includes(extension)) return { kind: "app", label: extension.toUpperCase() };
-    return { kind: "file", label: (extension || "FILE").slice(0, 4).toUpperCase() };
+    const label = extension.toUpperCase();
+    return { kind: "file", label: label ? label.slice(0, 4) : "FILE" };
 }
 
 function getChunkFromMessage(message: ChunkMessage): (ChunkData & { attachmentUrl: string; }) | null {
@@ -228,145 +292,7 @@ function getAnchorChunk(key: string) {
     const entry = cs[key];
     if (!entry?.ch.length) return null;
 
-    return entry.ch.find(chunk => chunk.channelId && chunk.messageId && getMessageElement(chunk.channelId, chunk.messageId, chunk.url))
-        ?? [...entry.ch].sort((a, b) => a.index - b.index)[0]
-        ?? null;
-}
-
-function getMessageElement(channelId: string, messageId: string, attachmentUrl?: string) {
-    const directId = document.getElementById(`chat-messages-${channelId}-${messageId}`);
-    if (directId instanceof HTMLElement) return directId;
-
-    const fallbackSelectors = [
-        `[data-list-item-id="chat-messages___${channelId}-${messageId}"]`,
-        `[data-message-id="${messageId}"]`,
-        `[id$="-${messageId}"]`
-    ];
-
-    for (const selector of fallbackSelectors) {
-        const element = document.querySelector(selector);
-        if (element instanceof HTMLElement) return element;
-    }
-
-    if (!attachmentUrl) return null;
-
-    let normalizedAttachmentUrl = normalizeAttachmentUrl(attachmentUrl)?.split("?")[0] ?? null;
-    if (!normalizedAttachmentUrl) return null;
-
-    for (const link of Array.from(document.querySelectorAll("a[href]"))) {
-        if (!(link instanceof HTMLAnchorElement)) continue;
-
-        const href = normalizeAttachmentUrl(link.href)?.split("?")[0] ?? null;
-        if (href !== normalizedAttachmentUrl) continue;
-
-        const container = link.closest("[id^='chat-messages-'], [data-list-item-id^='chat-messages___'], li, article, [class*='message']");
-        if (container instanceof HTMLElement) return container;
-    }
-
-    return null;
-}
-
-function isFileSplitterNode(element: HTMLElement) {
-    return Boolean(element.closest(".vc-file-splitter-card") || element.querySelector(".vc-file-splitter-card"));
-}
-
-function markHidden(element: HTMLElement) {
-    if (element.dataset.filesplitterHidden === "true") return;
-
-    element.dataset.filesplitterHidden = "true";
-    element.dataset.filesplitterPrevDisplay = element.style.display || "";
-    element.style.display = "none";
-}
-
-function restoreHiddenChunkMessages() {
-    for (const node of Array.from(document.querySelectorAll("[data-filesplitter-hidden='true']"))) {
-        if (!(node instanceof HTMLElement)) continue;
-
-        node.style.display = node.dataset.filesplitterPrevDisplay ?? "";
-        delete node.dataset.filesplitterHidden;
-        delete node.dataset.filesplitterPrevDisplay;
-    }
-}
-
-function hideAnchorChunkPayload(messageEl: HTMLElement, chunk: ChunkData) {
-    const contentCandidates = messageEl.querySelectorAll("[id^='message-content-'], [class*='messageContent'], [class*='markup']");
-    for (const candidate of Array.from(contentCandidates)) {
-        if (!(candidate instanceof HTMLElement) || isFileSplitterNode(candidate)) continue;
-        if ((candidate.textContent ?? "").includes("FileSplitterChunk")) markHidden(candidate);
-    }
-
-    const attachmentBlocks = messageEl.querySelectorAll([
-        "[class*='attachment']",
-        "[class*='mediaMosaic']",
-        "[class*='visualMediaItemContainer']",
-        "[class*='fileWrapper']",
-        "[class*='file']"
-    ].join(", "));
-
-    for (const block of Array.from(attachmentBlocks)) {
-        if (!(block instanceof HTMLElement) || isFileSplitterNode(block)) continue;
-        markHidden(block);
-    }
-
-    const attachmentHref = normalizeAttachmentUrl(chunk.url)?.split("?")[0] ?? null;
-    if (attachmentHref) {
-        for (const link of Array.from(messageEl.querySelectorAll("a[href]"))) {
-            if (!(link instanceof HTMLAnchorElement) || isFileSplitterNode(link)) continue;
-
-            const href = normalizeAttachmentUrl(link.href)?.split("?")[0] ?? null;
-            if (href !== attachmentHref) continue;
-
-            const target = link.closest("[class*='attachment'], [class*='fileWrapper'], [class*='file'], [class*='embed'], [class*='container'], a[href]");
-            if (target instanceof HTMLElement && target !== messageEl && !isFileSplitterNode(target)) markHidden(target);
-        }
-    }
-
-    for (const node of Array.from(messageEl.querySelectorAll("a, button, div, span"))) {
-        if (!(node instanceof HTMLElement) || isFileSplitterNode(node)) continue;
-
-        const text = node.textContent ?? "";
-        if (!/FileSplitterChunk|\.part\d{3}/i.test(text)) continue;
-
-        const target = node.closest("[id^='message-content-'], [class*='messageContent'], [class*='markup'], [class*='attachment'], [class*='fileWrapper'], [class*='file'], [class*='embed'], [class*='container'], a[href]");
-        if (target instanceof HTMLElement && target !== messageEl && !isFileSplitterNode(target)) {
-            markHidden(target);
-        } else {
-            markHidden(node);
-        }
-    }
-}
-
-function hideChunkMessages(key: string) {
-    const entry = cs[key];
-    const anchorChunk = getAnchorChunk(key);
-    if (!entry?.ch.length || !anchorChunk?.messageId) return;
-
-    for (const chunk of entry.ch) {
-        if (!chunk.channelId || !chunk.messageId) continue;
-
-        const messageEl = getMessageElement(chunk.channelId, chunk.messageId, chunk.url);
-        if (!messageEl) continue;
-
-        if (chunk.messageId !== anchorChunk.messageId) {
-            markHidden(messageEl);
-            continue;
-        }
-
-        hideAnchorChunkPayload(messageEl, chunk);
-    }
-}
-
-function hideKnownChunkMessages() {
-    for (const key of Object.keys(cs)) hideChunkMessages(key);
-}
-
-function scheduleHideSweep() {
-    if (pendingHideSweep !== undefined) return;
-
-    pendingHideSweep = requestAnimationFrame(() => {
-        pendingHideSweep = undefined;
-        hideKnownChunkMessages();
-    });
+    return [...entry.ch].sort((a, b) => a.index - b.index)[0] ?? null;
 }
 
 function getCompleteChunkCount(entry: ChunkStorageEntry) {
@@ -416,13 +342,10 @@ async function fetchBlob(url: string, filename?: string): Promise<Blob> {
             const res = await Native.fetchChunk(normalizedUrl);
             if (res.success && res.data) {
                 return new Blob([res.data], {
-                    type: res.contentType || (filename ? inferMimeType(filename) : null) || "application/octet-stream"
+                    type: res.contentType ?? (filename ? inferMimeType(filename) : null) ?? "application/octet-stream"
                 });
             }
-            console.warn("[FileSplitter] Native fetch failed:", res.error);
-        } catch (e) {
-            console.warn("[FileSplitter] Native fetch errored:", e);
-        }
+        } catch { }
     }
 
     const r = await fetch(normalizedUrl);
@@ -451,7 +374,7 @@ async function ensureMergedResult(key: string, eagerImagePreview = false) {
     const entry = cs[key];
     if (!entry?.ch.length) return;
 
-    const originalName = entry.ch[0].originalName;
+    const [{ originalName }] = entry.ch;
     const isImage = isInlinePreviewableImage(originalName);
     let result = mergedResults.get(key);
     let changed = false;
@@ -484,10 +407,9 @@ async function ensureMergedResult(key: string, eagerImagePreview = false) {
         result.objectUrl = URL.createObjectURL(blob);
         result.status = "ready";
         result.error = undefined;
-    } catch (e: any) {
+    } catch (e: unknown) {
         result.status = "error";
-        result.error = e?.message ?? String(e);
-        console.error("[FileSplitter] Preview preparation failed:", e);
+        result.error = getErrorMessage(e);
     }
 
     emitStoreChange();
@@ -510,13 +432,12 @@ async function handleDownload(key: string) {
         }
 
         await downloadBlob(result.blob, result.originalName);
-    } catch (e: any) {
+    } catch (e: unknown) {
         result.status = "error";
-        result.error = e?.message ?? String(e);
+        result.error = getErrorMessage(e);
         emitStoreChange();
-        console.error("[FileSplitter] Download failed:", e);
         Toasts.show({
-            message: `Download failed: ${e?.message ?? e}`,
+            message: `Download failed: ${getErrorMessage(e)}`,
             id: Toasts.genId(),
             type: Toasts.Type.FAILURE
         });
@@ -547,7 +468,6 @@ function processMessage(message: ChunkMessage) {
 
     const { key } = storeChunk(chunk);
     tryMergeChunks(key);
-    scheduleHideSweep();
     return true;
 }
 
@@ -557,24 +477,16 @@ function scanExistingMessages(channelId: string) {
         for (const msg of messages) {
             processMessage(msg);
         }
-    } catch (e) {
-        console.error("[FileSplitter] Scan error:", e);
-    }
+    } catch { }
 }
 
 function clearAllState() {
-    if (pendingHideSweep !== undefined) {
-        cancelAnimationFrame(pendingHideSweep);
-        pendingHideSweep = undefined;
-    }
-
     for (const result of mergedResults.values()) {
         if (result.objectUrl) URL.revokeObjectURL(result.objectUrl);
     }
 
     for (const key of Object.keys(cs)) delete cs[key];
     mergedResults.clear();
-    restoreHiddenChunkMessages();
     emitStoreChange();
 }
 
@@ -592,10 +504,10 @@ function pruneOldChunks() {
     if (changed) emitStoreChange();
 }
 
-function uploadChunk(channelId: string, chunkFile: File, metadata: any): Promise<void> {
+function uploadChunk(channelId: string, chunkFile: File, metadata: FileSplitterMetadata): Promise<void> {
     return new Promise((resolve, reject) => {
         try {
-            const uploader = new (CloudUpload as any)({ file: chunkFile, platform: 1 }, channelId);
+            const uploader = new CloudUpload({ file: chunkFile, platform: 1 }, channelId);
 
             uploader.on("complete", () => {
                 RestAPI.post({
@@ -613,13 +525,13 @@ function uploadChunk(channelId: string, chunkFile: File, metadata: any): Promise
                             uploaded_filename: uploader.uploadedFilename
                         }]
                     }
-                }).then(() => resolve()).catch((e: any) => reject(new Error(`Send failed: ${JSON.stringify(e)}`)));
+                }).then(() => resolve()).catch((e: unknown) => reject(new Error(`Send failed: ${getErrorMessage(e)}`)));
             });
 
-            uploader.on("error", (e: any) => reject(new Error(`Upload failed: ${JSON.stringify(e)}`)));
+            uploader.on("error", (e: unknown) => reject(new Error(`Upload failed: ${getErrorMessage(e)}`)));
             uploader.upload();
-        } catch (e: any) {
-            reject(new Error(e?.message ?? JSON.stringify(e)));
+        } catch (e: unknown) {
+            reject(new Error(getErrorMessage(e)));
         }
     });
 }
@@ -653,7 +565,7 @@ const FileTypeIcon = ({ kind, label }: { kind: string; label: string; }) => {
     );
 };
 
-const ActionButton = ({ children, disabled, onClick }: { children: any; disabled?: boolean; onClick: () => void; }) => (
+const ActionButton = ({ children, disabled, onClick }: { children: React.ReactNode; disabled?: boolean; onClick: () => void; }) => (
     <button
         className={cl("action")}
         type="button"
@@ -749,10 +661,6 @@ function FileSplitterAccessory({ message }: { message: ChunkMessage; }) {
         void ensureMergedResult(key, isInlinePreviewableImage(entry.ch[0].originalName));
     }, [key, count, total, complete]);
 
-    React.useEffect(() => {
-        if (key) scheduleHideSweep();
-    }, [key, count, total, complete, result?.status]);
-
     if (!chunk || !key || !entry || !isAnchor) return null;
     if (!complete) return <ProgressCard entry={entry} />;
     if (!result) return null;
@@ -762,7 +670,24 @@ function FileSplitterAccessory({ message }: { message: ChunkMessage; }) {
 
 const SafeFileSplitterAccessory = ErrorBoundary.wrap(FileSplitterAccessory, { noop: true });
 
-const SplitButton = () => {
+function isFileSplitterChunkMessage(message?: ChunkMessage | null) {
+    return Boolean(message && getChunkFromMessage(message));
+}
+
+function shouldHideFileSplitterChunkMessage(message?: ChunkMessage | null) {
+    if (!message) return false;
+
+    const chunk = getChunkFromMessage(message);
+    if (!chunk) return false;
+
+    const { key } = storeChunk(chunk);
+    tryMergeChunks(key);
+
+    const anchorChunk = getAnchorChunk(key);
+    return Boolean(anchorChunk?.messageId && anchorChunk.messageId !== getMessageId(message));
+}
+
+const SplitButton: ChatBarButtonFactory = ({ isMainChat }) => {
     const [status, setStatus] = React.useState<string | null>(null);
 
     async function doUpload() {
@@ -796,7 +721,7 @@ const SplitButton = () => {
                 const end = Math.min(start + CHUNK_SIZE, file.size);
                 const chunkBlob = file.slice(start, end);
 
-                const metadata = {
+                const metadata: FileSplitterMetadata = {
                     type: "FileSplitterChunk",
                     index: i,
                     total: totalChunks,
@@ -816,12 +741,14 @@ const SplitButton = () => {
             }
 
             Toasts.show({ message: `Uploaded ${totalChunks} parts for ${file.name}`, id: Toasts.genId(), type: Toasts.Type.SUCCESS });
-        } catch (e: any) {
-            Toasts.show({ message: `Error: ${e?.message ?? JSON.stringify(e)}`, id: Toasts.genId(), type: Toasts.Type.FAILURE });
+        } catch (e: unknown) {
+            Toasts.show({ message: `Error: ${getErrorMessage(e)}`, id: Toasts.genId(), type: Toasts.Type.FAILURE });
         } finally {
             setStatus(null);
         }
     }
+
+    if (!isMainChat) return null;
 
     const label = status ? `Uploading ${status}` : "Split & Upload";
 
@@ -838,10 +765,45 @@ export default definePlugin({
     tags: ["Chat", "Utility"],
     authors: [EquicordDevs.sioaeko],
     dependencies: ["ChatInputButtonAPI", "MessageAccessoriesAPI"],
-    _cleanupInterval: undefined as any,
 
-    renderMessageAccessory(props: { message: ChunkMessage; }) {
-        return <SafeFileSplitterAccessory message={props.message} />;
+    chatBarButton: {
+        icon: SplitIcon,
+        render: SplitButton
+    },
+
+    patches: [
+        {
+            find: ".NITRO_NOTIFICATION,[",
+            replacement: [
+                {
+                    match: /renderContentOnly:\i}=\i;/,
+                    replace: "$&if($self.shouldHideChunkMessage(arguments[0].message)) return null;"
+                },
+                {
+                    match: /childrenMessageContent:(\i),/g,
+                    replace: "childrenMessageContent:$self.isChunkMessage(arguments[0].message)?null:$1,"
+                },
+            ]
+        },
+        {
+            find: "this.renderAttachments(",
+            replacement: {
+                match: /(?<=\i=)this\.render(?:Attachments|Embeds|StickersAccessories|ComponentAccessories)\((\i)\)/g,
+                replace: "$self.isChunkMessage($1)?null:$&"
+            }
+        }
+    ],
+
+    renderMessageAccessory({ message }) {
+        return <SafeFileSplitterAccessory message={message as ChunkMessage} />;
+    },
+
+    isChunkMessage(message?: ChunkMessage | null) {
+        return isFileSplitterChunkMessage(message);
+    },
+
+    shouldHideChunkMessage(message?: ChunkMessage | null) {
+        return shouldHideFileSplitterChunkMessage(message);
     },
 
     flux: {
@@ -867,12 +829,6 @@ export default definePlugin({
 
     start() {
         clearAllState();
-        addChatBarButton("FileSplitter", SplitButton, SplitIcon);
-
-        if (typeof MutationObserver !== "undefined" && document.body) {
-            hideObserver = new MutationObserver(() => scheduleHideSweep());
-            hideObserver.observe(document.body, { childList: true, subtree: true });
-        }
 
         const currentChannel = SelectedChannelStore.getChannelId();
         if (currentChannel) {
@@ -880,16 +836,14 @@ export default definePlugin({
             delayedChannelScan = setTimeout(() => scanExistingMessages(currentChannel), 1500);
         }
 
-        scheduleHideSweep();
-        this._cleanupInterval = setInterval(pruneOldChunks, 60000);
+        cleanupInterval = setInterval(pruneOldChunks, 60000);
     },
 
     stop() {
-        removeChatBarButton("FileSplitter");
         if (delayedChannelScan) clearTimeout(delayedChannelScan);
-        if (this._cleanupInterval) clearInterval(this._cleanupInterval);
-        if (hideObserver) hideObserver.disconnect();
-        hideObserver = undefined;
+        if (cleanupInterval) clearInterval(cleanupInterval);
+        delayedChannelScan = undefined;
+        cleanupInterval = undefined;
         clearAllState();
     }
 });

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -30,6 +30,7 @@ const CHUNK_TIMEOUT = 30 * 60 * 1000;
 const SCAN_DELAY = 1500;
 const PRUNE_INTERVAL = 60 * 1000;
 const MAX_PARALLEL_DOWNLOADS = 4;
+const MAX_CHUNKS = Math.ceil(MAX_FILE_SIZE / CHUNK_SIZE);
 
 const IMAGE_MIME: Record<string, string> = {
     avif: "image/avif", bmp: "image/bmp", gif: "image/gif",
@@ -70,6 +71,10 @@ function isImage(filename: string) {
     return mimeType(filename)?.startsWith("image/") ?? false;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
 function normalizeUrl(url: string | null | undefined): string | null {
     if (!url) return null;
     try {
@@ -92,21 +97,25 @@ function isComplete(entry: ChunkEntry) {
 
 function parseChunkMeta(content: string | undefined): Omit<ChunkMeta, "type"> | null {
     if (!content) return null;
+    let c: unknown;
     try {
-        const c = JSON.parse(content);
-        const { type, index, total, originalName, originalSize, timestamp } = c;
-        if (
-            type === "FileSplitterChunk"
-            && Number.isInteger(index) && index >= 0
-            && Number.isInteger(total) && total > 0 && index < total
-            && typeof originalName === "string"
-            && typeof originalSize === "number"
-            && typeof timestamp === "number"
-        ) return { index, total, originalName, originalSize, timestamp };
+        c = JSON.parse(content);
     } catch {
         return null;
     }
-    return null;
+    if (!isRecord(c)) return null;
+
+    const { type, index, total, originalName, originalSize, timestamp } = c;
+    if (
+        type !== "FileSplitterChunk"
+        || typeof index !== "number" || !Number.isSafeInteger(index) || index < 0
+        || typeof total !== "number" || !Number.isSafeInteger(total) || total <= 0 || total > MAX_CHUNKS || index >= total
+        || typeof originalName !== "string" || originalName.length === 0
+        || typeof originalSize !== "number" || !Number.isFinite(originalSize) || originalSize <= 0 || originalSize > MAX_FILE_SIZE
+        || typeof timestamp !== "number" || !Number.isFinite(timestamp) || timestamp <= 0
+    ) return null;
+
+    return { index, total, originalName, originalSize, timestamp };
 }
 
 function getChunkFromMessage(message: Message): ChunkData | null {
@@ -527,11 +536,11 @@ export default definePlugin({
 
     patches: [
         {
-            find: ".NITRO_NOTIFICATION,[",
+            find: '.CUSTOM_GIFT?""',
             replacement: [
                 {
-                    match: /renderContentOnly:\i}=\i;/,
-                    replace: "$&if($self.shouldHideChunkMessage(arguments[0].message)) return null;"
+                    match: /message:(\i),message:\{id:\i\}.{0,200}renderContentOnly:\i\}=\i;/,
+                    replace: "$&if($self.shouldHideChunkMessage($1)) return null;"
                 },
                 {
                     match: /childrenMessageContent:(\i),/g,
@@ -540,7 +549,7 @@ export default definePlugin({
             ]
         },
         {
-            find: "this.renderAttachments(",
+            find: "}renderStickersAccessories(",
             replacement: {
                 match: /(?<=\i=)this\.render(?:Attachments|Embeds|StickersAccessories|ComponentAccessories)\((\i)\)/g,
                 replace: "$self.isChunkMessage($1)?null:$&"

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -14,13 +14,11 @@ import definePlugin, { PluginNative } from "@utils/types";
 import { chooseFile, saveFile } from "@utils/web";
 import { Message } from "@vencord/discord-types";
 import { CloudUploadPlatform } from "@vencord/discord-types/enums";
-import { findLazy } from "@webpack";
-import { Constants, MessageStore, React, RestAPI, SelectedChannelStore, SnowflakeUtils, Toasts } from "@webpack/common";
+import { CloudUploader, Constants, MessageStore, React, RestAPI, SelectedChannelStore, SnowflakeUtils, Toasts } from "@webpack/common";
 
 import { ChunkData, ChunkEntry, ChunkMeta, MergedResult } from "./types";
 
 const cl = classNameFactory("vc-file-splitter-");
-const CloudUpload = findLazy(m => m.prototype?.trackUploadFinished);
 
 const Native = IS_DISCORD_DESKTOP
     ? VencordNative.pluginHelpers.FileSplitter as PluginNative<typeof import("./native")>
@@ -102,7 +100,9 @@ function parseChunkMeta(content: string | undefined): Omit<ChunkMeta, "type"> | 
             && typeof originalSize === "number"
             && typeof timestamp === "number"
         ) return { index, total, originalName, originalSize, timestamp };
-    } catch { }
+    } catch {
+        return null;
+    }
     return null;
 }
 
@@ -127,7 +127,9 @@ async function fetchBlob(url: string, filename?: string): Promise<Blob> {
             const res = await Native.fetchChunk(normalized);
             if (res.success && res.data)
                 return new Blob([res.data], { type: res.contentType ?? (filename ? mimeType(filename) : null) ?? "application/octet-stream" });
-        } catch { }
+        } catch {
+            // Fall through to browser fetch when the native bridge is unavailable.
+        }
     }
 
     const r = await fetch(normalized);
@@ -140,18 +142,13 @@ async function assembleBlob(key: string): Promise<{ blob: Blob; mimeType: string
     if (!entry?.chunks.length) throw new Error("No chunks available");
 
     const name = entry.chunks[0].originalName;
-    const parts = await Promise.all(entry.chunks.map(c => fetchBlob(c.url, name)));
+    const parts: Blob[] = [];
+    for (const chunk of entry.chunks) parts.push(await fetchBlob(chunk.url, name));
     const mime = mimeType(name) ?? "application/octet-stream";
     return { blob: new Blob(parts, { type: mime }), mimeType: mime };
 }
 
-async function downloadBlob(blob: Blob, filename: string) {
-    if (IS_DISCORD_DESKTOP) {
-        try {
-            await DiscordNative.fileManager.saveWithDialog(new Uint8Array(await blob.arrayBuffer()), filename);
-            return;
-        } catch { }
-    }
+function downloadBlob(blob: Blob, filename: string) {
     saveFile(new File([blob], filename, { type: blob.type ?? "application/octet-stream" }));
 }
 
@@ -169,7 +166,7 @@ async function handleDownload(key: string) {
             result.mimeType = assembled.mimeType;
             result.status = "ready";
         }
-        await downloadBlob(result.blob, result.originalName);
+        downloadBlob(result.blob, result.originalName);
     } catch (e) {
         result.status = "error";
         result.error = e instanceof Error ? e.message : String(e);
@@ -267,10 +264,13 @@ function pruneOldChunks() {
     const now = Date.now();
     let changed = false;
     for (const key of Object.keys(chunkStore)) {
-        if (!mergedResults.has(key) && now - chunkStore[key].lastUpdated > CHUNK_TIMEOUT) {
-            delete chunkStore[key];
-            changed = true;
-        }
+        if (now - chunkStore[key].lastUpdated <= CHUNK_TIMEOUT) continue;
+
+        const result = mergedResults.get(key);
+        if (result?.objectUrl) URL.revokeObjectURL(result.objectUrl);
+        mergedResults.delete(key);
+        delete chunkStore[key];
+        changed = true;
     }
     if (changed) emitChange();
 }
@@ -278,7 +278,7 @@ function pruneOldChunks() {
 function uploadChunk(channelId: string, file: File, meta: ChunkMeta): Promise<void> {
     return new Promise((resolve, reject) => {
         try {
-            const uploader = new CloudUpload({ file, platform: CloudUploadPlatform.WEB }, channelId);
+            const uploader = new CloudUploader({ file, platform: CloudUploadPlatform.WEB }, channelId);
             uploader.on("complete", () => {
                 RestAPI.post({
                     url: Constants.Endpoints.MESSAGES(channelId),
@@ -431,7 +431,7 @@ function FileSplitterAccessory({ message }) {
 
 const SafeFileSplitterAccessory = ErrorBoundary.wrap(FileSplitterAccessory, { noop: true });
 
-const SplitButton: ChatBarButtonFactory = ({ isMainChat }) => {
+const SplitButton: ChatBarButtonFactory = ({ isMainChat, channel }) => {
     const [status, setStatus] = React.useState<string | null>(null);
 
     async function doUpload() {
@@ -447,7 +447,7 @@ const SplitButton: ChatBarButtonFactory = ({ isMainChat }) => {
             return;
         }
 
-        const channelId = SelectedChannelStore.getChannelId();
+        const channelId = channel.id;
         if (!channelId) {
             Toasts.show({ message: "No channel selected.", id: Toasts.genId(), type: Toasts.Type.FAILURE });
             return;
@@ -484,8 +484,12 @@ const SplitButton: ChatBarButtonFactory = ({ isMainChat }) => {
 
     if (!isMainChat) return null;
 
+    const handleClick = () => {
+        if (!status) void doUpload();
+    };
+
     return (
-        <ChatBarButton tooltip={status ? `Uploading ${status}` : "Split & Upload"} onClick={status ? () => { } : () => void doUpload()}>
+        <ChatBarButton tooltip={status ? `Uploading ${status}` : "Split & Upload"} onClick={handleClick}>
             <SplitIcon />
         </ChatBarButton>
     );
@@ -578,5 +582,6 @@ export default definePlugin({
         clearInterval(cleanupInterval);
         delayedScan = cleanupInterval = undefined;
         clearAll();
+        storeListeners.clear();
     }
 });

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -27,6 +27,9 @@ const Native = IS_DISCORD_DESKTOP
 const CHUNK_SIZE = 10 * 1024 * 1024;
 const MAX_FILE_SIZE = 500 * 1024 * 1024;
 const CHUNK_TIMEOUT = 30 * 60 * 1000;
+const SCAN_DELAY = 1500;
+const PRUNE_INTERVAL = 60 * 1000;
+const MAX_PARALLEL_DOWNLOADS = 4;
 
 const IMAGE_MIME: Record<string, string> = {
     avif: "image/avif", bmp: "image/bmp", gif: "image/gif",
@@ -128,13 +131,25 @@ async function fetchBlob(url: string, filename?: string): Promise<Blob> {
             if (res.success && res.data)
                 return new Blob([res.data], { type: res.contentType ?? (filename ? mimeType(filename) : null) ?? "application/octet-stream" });
         } catch {
-            // Fall through to browser fetch when the native bridge is unavailable.
+            return fetchBrowserBlob(normalized);
         }
     }
 
-    const r = await fetch(normalized);
+    return fetchBrowserBlob(normalized);
+}
+
+async function fetchBrowserBlob(url: string): Promise<Blob> {
+    const r = await fetch(url);
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
     return r.blob();
+}
+
+async function fetchChunkParts(chunks: ChunkData[], filename: string): Promise<Blob[]> {
+    const parts: Blob[] = [];
+    for (let i = 0; i < chunks.length; i += MAX_PARALLEL_DOWNLOADS) {
+        parts.push(...await Promise.all(chunks.slice(i, i + MAX_PARALLEL_DOWNLOADS).map(chunk => fetchBlob(chunk.url, filename))));
+    }
+    return parts;
 }
 
 async function assembleBlob(key: string): Promise<{ blob: Blob; mimeType: string; }> {
@@ -142,8 +157,7 @@ async function assembleBlob(key: string): Promise<{ blob: Blob; mimeType: string
     if (!entry?.chunks.length) throw new Error("No chunks available");
 
     const name = entry.chunks[0].originalName;
-    const parts: Blob[] = [];
-    for (const chunk of entry.chunks) parts.push(await fetchBlob(chunk.url, name));
+    const parts = await fetchChunkParts(entry.chunks, name);
     const mime = mimeType(name) ?? "application/octet-stream";
     return { blob: new Blob(parts, { type: mime }), mimeType: mime };
 }
@@ -563,7 +577,7 @@ export default definePlugin({
             if (!channelId) return;
             scanChannel(channelId);
             clearTimeout(delayedScan);
-            delayedScan = setTimeout(() => scanChannel(channelId), 1500);
+            delayedScan = setTimeout(() => scanChannel(channelId), SCAN_DELAY);
         }
     },
 
@@ -572,9 +586,9 @@ export default definePlugin({
         const ch = SelectedChannelStore.getChannelId();
         if (ch) {
             scanChannel(ch);
-            delayedScan = setTimeout(() => scanChannel(ch), 1500);
+            delayedScan = setTimeout(() => scanChannel(ch), SCAN_DELAY);
         }
-        cleanupInterval = setInterval(pruneOldChunks, 60000);
+        cleanupInterval = setInterval(pruneOldChunks, PRUNE_INTERVAL);
     },
 
     stop() {

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -10,6 +10,7 @@ import { ChatBarButton, ChatBarButtonFactory } from "@api/ChatButtons";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { EquicordDevs } from "@utils/constants";
 import { classNameFactory } from "@utils/css";
+import { isObject } from "@utils/misc";
 import definePlugin, { PluginNative } from "@utils/types";
 import { chooseFile, saveFile } from "@utils/web";
 import { Message } from "@vencord/discord-types";
@@ -31,6 +32,8 @@ const SCAN_DELAY = 1500;
 const PRUNE_INTERVAL = 60 * 1000;
 const MAX_PARALLEL_DOWNLOADS = 4;
 const MAX_CHUNKS = Math.ceil(MAX_FILE_SIZE / CHUNK_SIZE);
+const CHUNK_UPLOADS_PER_WINDOW = 4;
+const CHUNK_UPLOAD_WINDOW = 5500;
 
 const IMAGE_MIME: Record<string, string> = {
     avif: "image/avif", bmp: "image/bmp", gif: "image/gif",
@@ -40,17 +43,15 @@ const IMAGE_MIME: Record<string, string> = {
 const chunkStore: Record<string, ChunkEntry> = {};
 const mergedResults = new Map<string, MergedResult>();
 const storeListeners = new Set<() => void>();
-let storeVersion = 0;
 
 function emitChange() {
-    storeVersion++;
     for (const listener of storeListeners) listener();
 }
 
 function useStore() {
-    const [, setVersion] = React.useState(storeVersion);
+    const [, setVersion] = React.useState(0);
     React.useEffect(() => {
-        const listener = () => setVersion(storeVersion);
+        const listener = () => setVersion(v => v + 1);
         storeListeners.add(listener);
         return () => {
             storeListeners.delete(listener);
@@ -69,10 +70,6 @@ function mimeType(filename: string) {
 
 function isImage(filename: string) {
     return mimeType(filename)?.startsWith("image/") ?? false;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return value != null && typeof value === "object" && !Array.isArray(value);
 }
 
 function normalizeUrl(url: string | null | undefined): string | null {
@@ -103,9 +100,9 @@ function parseChunkMeta(content: string | undefined): Omit<ChunkMeta, "type"> | 
     } catch {
         return null;
     }
-    if (!isRecord(c)) return null;
+    if (!isObject(c)) return null;
 
-    const { type, index, total, originalName, originalSize, timestamp } = c;
+    const { type, index, total, originalName, originalSize, timestamp } = c as Record<string, unknown>;
     if (
         type !== "FileSplitterChunk"
         || typeof index !== "number" || !Number.isSafeInteger(index) || index < 0
@@ -324,6 +321,14 @@ function uploadChunk(channelId: string, file: File, meta: ChunkMeta): Promise<vo
     });
 }
 
+function wait(ms: number) {
+    return new Promise<void>(resolve => setTimeout(resolve, ms));
+}
+
+function shouldPauseForUploadWindow(index: number, total: number) {
+    return index + 1 < total && (index + 1) % CHUNK_UPLOADS_PER_WINDOW === 0;
+}
+
 const SplitIcon = () => (
     <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
         <path d="M14 2H6C4.9 2 4 2.9 4 4v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zM6 20V4h7v5h5v11H6zm8-4h-4v-2h4v-2l3 3-3 3v-2z" />
@@ -497,6 +502,10 @@ const SplitButton: ChatBarButtonFactory = ({ isMainChat, channel }) => {
                     timestamp
                 });
                 setStatus(`${Math.round(((i + 1) / totalChunks) * 100)}%`);
+                if (shouldPauseForUploadWindow(i, totalChunks)) {
+                    setStatus(`${Math.round(((i + 1) / totalChunks) * 100)}% (rate limit pause)`);
+                    await wait(CHUNK_UPLOAD_WINDOW);
+                }
             }
             Toasts.show({ message: `Uploaded ${totalChunks} parts for ${file.name}`, id: Toasts.genId(), type: Toasts.Type.SUCCESS });
         } catch (e) {

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -333,7 +333,8 @@ const FILE_BADGE_KINDS: Array<[string[], string]> = [
 function getFileBadge(filename: string) {
     const ext = filename.split(".").pop()?.toLowerCase() ?? "";
     const kind = FILE_BADGE_KINDS.find(([exts]) => exts.includes(ext))?.[1] ?? "file";
-    return { kind, label: ext.toUpperCase().slice(0, 4) || "FILE" };
+    const label = ext.toUpperCase().slice(0, 4);
+    return { kind, label: label.length ? label : "FILE" };
 }
 
 const FILE_ICON_PATHS: Record<string, string[]> = {
@@ -424,7 +425,7 @@ function MergedResultCard({ result }: { result: MergedResult; }) {
     );
 }
 
-function FileSplitterAccessory({ message }) {
+function FileSplitterAccessory({ message }: { message: Message; }) {
     useStore();
 
     React.useEffect(() => {

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -12,13 +12,15 @@ import { EquicordDevs } from "@utils/constants";
 import { classNameFactory } from "@utils/css";
 import definePlugin, { PluginNative } from "@utils/types";
 import { chooseFile, saveFile } from "@utils/web";
-import type { Message, MessageAttachment } from "@vencord/discord-types";
+import { Message } from "@vencord/discord-types";
 import { CloudUploadPlatform } from "@vencord/discord-types/enums";
 import { findLazy } from "@webpack";
 import { Constants, MessageStore, React, RestAPI, SelectedChannelStore, SnowflakeUtils, Toasts } from "@webpack/common";
 
+import { ChunkData, ChunkEntry, ChunkMeta, MergedResult } from "./types";
+
 const cl = classNameFactory("vc-file-splitter-");
-const CloudUpload = findLazy(m => m.prototype?.trackUploadFinished) as CloudUploadConstructor;
+const CloudUpload = findLazy(m => m.prototype?.trackUploadFinished);
 
 const Native = IS_DISCORD_DESKTOP
     ? VencordNative.pluginHelpers.FileSplitter as PluginNative<typeof import("./native")>
@@ -28,99 +30,23 @@ const CHUNK_SIZE = 10 * 1024 * 1024;
 const MAX_FILE_SIZE = 500 * 1024 * 1024;
 const CHUNK_TIMEOUT = 30 * 60 * 1000;
 
-interface ChunkData {
-    index: number;
-    total: number;
-    originalName: string;
-    originalSize: number;
-    timestamp: number;
-    url: string;
-    channelId?: string;
-    messageId?: string;
-}
-
-type FileSplitterMetadata = Omit<ChunkData, "url" | "channelId" | "messageId"> & {
-    type: "FileSplitterChunk";
+const IMAGE_MIME: Record<string, string> = {
+    avif: "image/avif", bmp: "image/bmp", gif: "image/gif",
+    jpeg: "image/jpeg", jpg: "image/jpeg", png: "image/png", webp: "image/webp"
 };
 
-interface ChunkStorageEntry {
-    ch: ChunkData[];
-    lu: number;
-    mg?: boolean;
-}
-
-interface MergedResult {
-    key: string;
-    originalName: string;
-    isImage: boolean;
-    mimeType: string;
-    status: "pending" | "loading" | "ready" | "error";
-    blob?: Blob;
-    objectUrl?: string;
-    error?: string;
-}
-
-type ChunkMessage = {
-    channel_id?: string;
-    channelId?: string;
-} & Partial<Pick<Message, "id" | "content" | "attachments">> & {
-    attachments?: MessageAttachment[];
-};
-
-type AttachmentWithUrls = MessageAttachment & {
-    download_url?: string;
-    proxyUrl?: string;
-};
-
-type StoredMessageCollection = ChunkMessage[] | {
-    toArray?: () => ChunkMessage[];
-    values?: () => Iterable<ChunkMessage>;
-    _array?: ChunkMessage[];
-    array?: ChunkMessage[];
-    _map?: {
-        values?: () => Iterable<ChunkMessage>;
-    };
-    [key: string]: unknown;
-};
-
-interface CloudUploadInstance {
-    filename: string;
-    uploadedFilename: string;
-    on(event: "complete", callback: () => void): void;
-    on(event: "error", callback: (error: unknown) => void): void;
-    upload(): void;
-}
-
-type CloudUploadConstructor = new (
-    data: { file: File; platform: number; },
-    channelId: string
-) => CloudUploadInstance;
-
-const cs: Record<string, ChunkStorageEntry> = {};
+const chunkStore: Record<string, ChunkEntry> = {};
 const mergedResults = new Map<string, MergedResult>();
 const storeListeners = new Set<() => void>();
 let storeVersion = 0;
-let delayedChannelScan: ReturnType<typeof setTimeout> | undefined;
-let cleanupInterval: ReturnType<typeof setInterval> | undefined;
 
-const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
-    avif: "image/avif",
-    bmp: "image/bmp",
-    gif: "image/gif",
-    jpeg: "image/jpeg",
-    jpg: "image/jpeg",
-    png: "image/png",
-    webp: "image/webp"
-};
-
-function emitStoreChange() {
+function emitChange() {
     storeVersion++;
     for (const listener of storeListeners) listener();
 }
 
-function useFileSplitterStore() {
+function useStore() {
     const [, setVersion] = React.useState(storeVersion);
-
     React.useEffect(() => {
         const listener = () => setVersion(storeVersion);
         storeListeners.add(listener);
@@ -130,290 +56,105 @@ function useFileSplitterStore() {
     }, []);
 }
 
-async function downloadBlob(blob: Blob, filename: string) {
-    if (IS_DISCORD_DESKTOP) {
-        try {
-            const buffer = await blob.arrayBuffer();
-            await DiscordNative.fileManager.saveWithDialog(new Uint8Array(buffer), filename);
-            return;
-        } catch { }
-    }
-
-    saveFile(new File([blob], filename, { type: blob.type ?? "application/octet-stream" }));
+function chunkKey(c: Pick<ChunkMeta, "originalName" | "originalSize" | "timestamp">) {
+    return `${c.originalName}_${c.originalSize}_${c.timestamp}`;
 }
 
-function getChunkKey(c: Pick<ChunkData, "originalName" | "timestamp"> & Partial<Pick<ChunkData, "originalSize">>) {
-    return `${c.originalName}_${c.originalSize ?? "unknown"}_${c.timestamp}`;
+function mimeType(filename: string) {
+    const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+    return IMAGE_MIME[ext] ?? null;
 }
 
-function normalizeAttachmentUrl(url: string | null | undefined) {
+function isImage(filename: string) {
+    return mimeType(filename)?.startsWith("image/") ?? false;
+}
+
+function normalizeUrl(url: string | null | undefined): string | null {
     if (!url) return null;
-
     try {
-        const parsed = new URL(url);
-        if (parsed.hostname === "media.discordapp.net") {
-            parsed.hostname = "cdn.discordapp.com";
-        }
-        return parsed.toString();
+        const u = new URL(url);
+        if (u.hostname === "media.discordapp.net") u.hostname = "cdn.discordapp.com";
+        return u.toString();
     } catch {
         return url.replace("://media.discordapp.net/", "://cdn.discordapp.com/");
     }
 }
 
-function getAttachmentUrl(attachment: AttachmentWithUrls) {
-    return attachment?.url
-        ?? attachment?.proxy_url
-        ?? attachment?.download_url
-        ?? attachment?.proxyUrl
-        ?? null;
-}
-
-function getMessageId(message: ChunkMessage) {
-    return message.id ?? "";
-}
-
-function getMessageChannelId(message: ChunkMessage) {
-    return message.channel_id ?? message.channelId ?? "";
-}
-
-function getErrorMessage(error: unknown): string {
-    if (error instanceof Error) return error.message;
-    if (typeof error === "string") return error;
-
-    try {
-        return JSON.stringify(error) ?? String(error);
-    } catch {
-        return String(error);
-    }
-}
-
-function isChunkMessageLike(message: unknown): message is ChunkMessage {
-    return typeof message === "object"
-        && message !== null
-        && typeof (message as { content?: unknown; }).content === "string";
-}
-
-function parseChunkMeta(content: string | undefined): Omit<ChunkData, "url" | "channelId" | "messageId"> | null {
-    if (!content) return null;
-
-    try {
-        const c = JSON.parse(content) as Partial<FileSplitterMetadata> & { type?: unknown; };
-        const {
-            index,
-            total,
-            originalName,
-            originalSize,
-            timestamp
-        } = c;
-
-        if (
-            typeof c === "object"
-            && c?.type === "FileSplitterChunk"
-            && Number.isInteger(index)
-            && typeof index === "number"
-            && index >= 0
-            && Number.isInteger(total)
-            && typeof total === "number"
-            && total > 0
-            && index < total
-            && typeof originalName === "string"
-            && typeof originalSize === "number"
-            && typeof timestamp === "number"
-        ) {
-            return {
-                index,
-                total,
-                originalName,
-                originalSize,
-                timestamp
-            };
-        }
-    } catch { }
-
-    return null;
-}
-
-function getStoredMessages(channelId: string): ChunkMessage[] {
-    const messages = MessageStore.getMessages(channelId) as StoredMessageCollection | null | undefined;
-    if (!messages) return [];
-
-    if (Array.isArray(messages)) return messages;
-    if (typeof messages.toArray === "function") return messages.toArray();
-    if (typeof messages.values === "function") return Array.from(messages.values());
-    if (Array.isArray(messages._array)) return messages._array;
-    if (Array.isArray(messages.array)) return messages.array;
-    if (messages._map && typeof messages._map.values === "function") {
-        return Array.from(messages._map.values());
-    }
-
-    return Object.values(messages).filter(isChunkMessageLike);
-}
-
-function inferMimeType(filename: string) {
-    const extension = filename.split(".").pop()?.toLowerCase();
-    return extension ? IMAGE_MIME_BY_EXTENSION[extension] ?? null : null;
-}
-
-function isInlinePreviewableImage(filename: string) {
-    const mimeType = inferMimeType(filename);
-    return mimeType?.startsWith("image/") ?? false;
-}
-
-function getFileBadge(filename: string) {
-    const extension = filename.split(".").pop()?.toLowerCase() ?? "";
-    if (["zip", "rar", "7z", "tar", "gz"].includes(extension)) return { kind: "archive", label: extension.toUpperCase() };
-    if (["pdf"].includes(extension)) return { kind: "document", label: "PDF" };
-    if (["txt", "md", "json", "csv", "xml", "yaml", "yml"].includes(extension)) return { kind: "text", label: extension.toUpperCase() };
-    if (["mp3", "wav", "flac", "ogg", "m4a"].includes(extension)) return { kind: "audio", label: extension.toUpperCase() };
-    if (["mp4", "mkv", "avi", "mov", "webm"].includes(extension)) return { kind: "video", label: extension.toUpperCase() };
-    if (["exe", "msi", "apk"].includes(extension)) return { kind: "app", label: extension.toUpperCase() };
-    const label = extension.toUpperCase();
-    return { kind: "file", label: label ? label.slice(0, 4) : "FILE" };
-}
-
-function getChunkFromMessage(message: ChunkMessage): (ChunkData & { attachmentUrl: string; }) | null {
-    if (!message?.attachments?.length) return null;
-
-    const meta = parseChunkMeta(message.content);
-    if (!meta) return null;
-
-    const attachmentUrl = normalizeAttachmentUrl(getAttachmentUrl(message.attachments[0]));
-    if (!attachmentUrl) return null;
-
-    return {
-        ...meta,
-        url: attachmentUrl,
-        attachmentUrl,
-        channelId: getMessageChannelId(message),
-        messageId: getMessageId(message)
-    };
-}
-
-function getAnchorChunk(key: string) {
-    const entry = cs[key];
-    if (!entry?.ch.length) return null;
-
-    return [...entry.ch].sort((a, b) => a.index - b.index)[0] ?? null;
-}
-
-function getCompleteChunkCount(entry: ChunkStorageEntry) {
-    return new Set(entry.ch.map(chunk => chunk.index)).size;
-}
-
-function hasAllChunks(entry: ChunkStorageEntry) {
-    if (!entry.ch.length) return false;
-
-    const expectedCount = entry.ch[0].total;
-    if (getCompleteChunkCount(entry) !== expectedCount) return false;
-
-    const indexes = new Set(entry.ch.map(chunk => chunk.index));
-    for (let i = 0; i < expectedCount; i++) {
-        if (!indexes.has(i)) return false;
-    }
-
+function isComplete(entry: ChunkEntry) {
+    if (!entry.chunks.length) return false;
+    const { total } = entry.chunks[0];
+    const indices = new Set(entry.chunks.map(c => c.index));
+    if (indices.size !== total) return false;
+    for (let i = 0; i < total; i++) if (!indices.has(i)) return false;
     return true;
 }
 
-function storeChunk(c: ChunkData) {
-    const key = getChunkKey(c);
-    const entry = cs[key] ?? (cs[key] = { ch: [], lu: Date.now() });
-    const existing = entry.ch.find(chunk => chunk.index === c.index);
-    let changed = false;
+function parseChunkMeta(content: string | undefined): Omit<ChunkMeta, "type"> | null {
+    if (!content) return null;
+    try {
+        const c = JSON.parse(content);
+        const { type, index, total, originalName, originalSize, timestamp } = c;
+        if (
+            type === "FileSplitterChunk"
+            && Number.isInteger(index) && index >= 0
+            && Number.isInteger(total) && total > 0 && index < total
+            && typeof originalName === "string"
+            && typeof originalSize === "number"
+            && typeof timestamp === "number"
+        ) return { index, total, originalName, originalSize, timestamp };
+    } catch { }
+    return null;
+}
 
-    if (!existing) {
-        entry.ch.push(c);
-        changed = true;
-    } else if (existing.url !== c.url || existing.messageId !== c.messageId || existing.channelId !== c.channelId) {
-        Object.assign(existing, c);
-        changed = true;
-    }
+function getChunkFromMessage(message: Message): ChunkData | null {
+    if (!message.attachments?.length) return null;
+    const meta = parseChunkMeta(message.content);
+    if (!meta) return null;
+    const url = normalizeUrl(message.attachments[0].url ?? message.attachments[0].proxy_url);
+    if (!url) return null;
+    return { ...meta, type: "FileSplitterChunk", url, channelId: message.channel_id, messageId: message.id };
+}
 
-    entry.ch.sort((a, b) => a.index - b.index);
-    entry.lu = Date.now();
-
-    if (changed) emitStoreChange();
-    return { key, entry, changed };
+function anchorMessageId(key: string): string | null {
+    const entry = chunkStore[key];
+    if (!entry?.chunks.length) return null;
+    return [...entry.chunks].sort((a, b) => a.index - b.index)[0].messageId;
 }
 
 async function fetchBlob(url: string, filename?: string): Promise<Blob> {
-    const normalizedUrl = normalizeAttachmentUrl(url) ?? url;
+    const normalized = normalizeUrl(url) ?? url;
 
     if (Native) {
         try {
-            const res = await Native.fetchChunk(normalizedUrl);
-            if (res.success && res.data) {
-                return new Blob([res.data], {
-                    type: res.contentType ?? (filename ? inferMimeType(filename) : null) ?? "application/octet-stream"
-                });
-            }
+            const res = await Native.fetchChunk(normalized);
+            if (res.success && res.data)
+                return new Blob([res.data], { type: res.contentType ?? (filename ? mimeType(filename) : null) ?? "application/octet-stream" });
         } catch { }
     }
 
-    const r = await fetch(normalizedUrl);
+    const r = await fetch(normalized);
     if (!r.ok) throw new Error(`HTTP ${r.status}`);
-    return await r.blob();
+    return r.blob();
 }
 
-async function assembleBlob(key: string) {
-    const entry = cs[key];
-    if (!entry?.ch.length) throw new Error("No chunks available");
+async function assembleBlob(key: string): Promise<{ blob: Blob; mimeType: string; }> {
+    const entry = chunkStore[key];
+    if (!entry?.chunks.length) throw new Error("No chunks available");
 
-    const filename = entry.ch[0].originalName;
-    const parts: Blob[] = [];
-    for (const chunk of entry.ch) {
-        parts.push(await fetchBlob(chunk.url, filename));
-    }
-
-    const mimeType = inferMimeType(filename) ?? "application/octet-stream";
-    return {
-        blob: new Blob(parts, { type: mimeType }),
-        mimeType
-    };
+    const name = entry.chunks[0].originalName;
+    const parts = await Promise.all(entry.chunks.map(c => fetchBlob(c.url, name)));
+    const mime = mimeType(name) ?? "application/octet-stream";
+    return { blob: new Blob(parts, { type: mime }), mimeType: mime };
 }
 
-async function ensureMergedResult(key: string, eagerImagePreview = false) {
-    const entry = cs[key];
-    if (!entry?.ch.length) return;
-
-    const [{ originalName }] = entry.ch;
-    const isImage = isInlinePreviewableImage(originalName);
-    let result = mergedResults.get(key);
-    let changed = false;
-
-    if (!result) {
-        result = {
-            key,
-            originalName,
-            isImage,
-            mimeType: inferMimeType(originalName) ?? "application/octet-stream",
-            status: "pending"
-        };
-        mergedResults.set(key, result);
-        changed = true;
+async function downloadBlob(blob: Blob, filename: string) {
+    if (IS_DISCORD_DESKTOP) {
+        try {
+            await DiscordNative.fileManager.saveWithDialog(new Uint8Array(await blob.arrayBuffer()), filename);
+            return;
+        } catch { }
     }
-
-    const shouldPreparePreview = isImage && eagerImagePreview && !result.objectUrl && result.status !== "loading";
-    if (changed) emitStoreChange();
-    if (!shouldPreparePreview) return;
-
-    result.status = "loading";
-    result.error = undefined;
-    emitStoreChange();
-
-    try {
-        const { blob, mimeType } = await assembleBlob(key);
-        if (result.objectUrl) URL.revokeObjectURL(result.objectUrl);
-        result.blob = blob;
-        result.mimeType = mimeType;
-        result.objectUrl = URL.createObjectURL(blob);
-        result.status = "ready";
-        result.error = undefined;
-    } catch (e: unknown) {
-        result.status = "error";
-        result.error = getErrorMessage(e);
-    }
-
-    emitStoreChange();
+    saveFile(new File([blob], filename, { type: blob.type || "application/octet-stream" }));
 }
 
 async function handleDownload(key: string) {
@@ -424,115 +165,141 @@ async function handleDownload(key: string) {
         if (!result.blob) {
             result.status = "loading";
             result.error = undefined;
-            emitStoreChange();
-
+            emitChange();
             const assembled = await assembleBlob(key);
             result.blob = assembled.blob;
             result.mimeType = assembled.mimeType;
             result.status = "ready";
         }
-
         await downloadBlob(result.blob, result.originalName);
-    } catch (e: unknown) {
+    } catch (e) {
         result.status = "error";
-        result.error = getErrorMessage(e);
-        emitStoreChange();
-        Toasts.show({
-            message: `Download failed: ${getErrorMessage(e)}`,
-            id: Toasts.genId(),
-            type: Toasts.Type.FAILURE
-        });
+        result.error = e instanceof Error ? e.message : String(e);
+        emitChange();
+        Toasts.show({ message: `Download failed: ${result.error}`, id: Toasts.genId(), type: Toasts.Type.FAILURE });
         return;
     }
 
-    emitStoreChange();
-    Toasts.show({
-        message: `Downloaded: ${result.originalName}`,
-        id: Toasts.genId(),
-        type: Toasts.Type.SUCCESS
-    });
+    emitChange();
+    Toasts.show({ message: `Downloaded: ${result.originalName}`, id: Toasts.genId(), type: Toasts.Type.SUCCESS });
 }
 
-function tryMergeChunks(key: string) {
-    const entry = cs[key];
-    if (!entry || entry.mg || !hasAllChunks(entry)) return;
+function storeChunk(chunk: ChunkData) {
+    const key = chunkKey(chunk);
+    const entry = chunkStore[key] ?? (chunkStore[key] = { chunks: [], lastUpdated: Date.now() });
+    const existing = entry.chunks.find(c => c.index === chunk.index);
 
-    entry.mg = true;
-    entry.ch.sort((a, b) => a.index - b.index);
-    emitStoreChange();
-    void ensureMergedResult(key, isInlinePreviewableImage(entry.ch[0].originalName));
+    let changed = false;
+    if (!existing) {
+        entry.chunks.push(chunk);
+        changed = true;
+    } else if (existing.url !== chunk.url || existing.messageId !== chunk.messageId) {
+        Object.assign(existing, chunk);
+        changed = true;
+    }
+
+    entry.chunks.sort((a, b) => a.index - b.index);
+    entry.lastUpdated = Date.now();
+    if (changed) emitChange();
+    return key;
 }
 
-function processMessage(message: ChunkMessage) {
-    const chunk = getChunkFromMessage(message);
-    if (!chunk) return false;
+async function prepareImagePreview(key: string) {
+    const result = mergedResults.get(key);
+    if (!result || result.objectUrl || result.status === "loading") return;
 
-    const { key } = storeChunk(chunk);
-    tryMergeChunks(key);
-    return true;
-}
+    result.status = "loading";
+    emitChange();
 
-function scanExistingMessages(channelId: string) {
     try {
-        const messages = getStoredMessages(channelId);
-        for (const msg of messages) {
-            processMessage(msg);
-        }
+        const { blob, mimeType: mime } = await assembleBlob(key);
+        if (result.objectUrl) URL.revokeObjectURL(result.objectUrl);
+        result.blob = blob;
+        result.mimeType = mime;
+        result.objectUrl = URL.createObjectURL(blob);
+        result.status = "ready";
+    } catch (e) {
+        result.status = "error";
+        result.error = e instanceof Error ? e.message : String(e);
+    }
+
+    emitChange();
+}
+
+function processComplete(key: string) {
+    const entry = chunkStore[key];
+    if (!entry) return;
+
+    const name = entry.chunks[0].originalName;
+    if (!mergedResults.has(key)) {
+        mergedResults.set(key, {
+            key,
+            originalName: name,
+            isImage: isImage(name),
+            mimeType: mimeType(name) ?? "application/octet-stream",
+            status: "pending"
+        });
+        emitChange();
+    }
+
+    if (isImage(name)) void prepareImagePreview(key);
+}
+
+function processMessage(message: Message) {
+    const chunk = getChunkFromMessage(message);
+    if (!chunk) return;
+    const key = storeChunk(chunk);
+    if (isComplete(chunkStore[key])) processComplete(key);
+}
+
+function scanChannel(channelId: string) {
+    try {
+        const messages = MessageStore.getMessages(channelId).toArray();
+        for (const msg of messages) processMessage(msg);
     } catch { }
 }
 
-function clearAllState() {
-    for (const result of mergedResults.values()) {
-        if (result.objectUrl) URL.revokeObjectURL(result.objectUrl);
-    }
-
-    for (const key of Object.keys(cs)) delete cs[key];
+function clearAll() {
+    for (const r of mergedResults.values()) if (r.objectUrl) URL.revokeObjectURL(r.objectUrl);
+    for (const k of Object.keys(chunkStore)) delete chunkStore[k];
     mergedResults.clear();
-    emitStoreChange();
+    emitChange();
 }
 
 function pruneOldChunks() {
     const now = Date.now();
     let changed = false;
-
-    for (const key of Object.keys(cs)) {
-        if (!cs[key].mg && now - cs[key].lu > CHUNK_TIMEOUT) {
-            delete cs[key];
+    for (const key of Object.keys(chunkStore)) {
+        if (!mergedResults.has(key) && now - chunkStore[key].lastUpdated > CHUNK_TIMEOUT) {
+            delete chunkStore[key];
             changed = true;
         }
     }
-
-    if (changed) emitStoreChange();
+    if (changed) emitChange();
 }
 
-function uploadChunk(channelId: string, chunkFile: File, metadata: FileSplitterMetadata): Promise<void> {
+function uploadChunk(channelId: string, file: File, meta: ChunkMeta): Promise<void> {
     return new Promise((resolve, reject) => {
         try {
-            const uploader = new CloudUpload({ file: chunkFile, platform: CloudUploadPlatform.WEB }, channelId);
-
+            const uploader = new CloudUpload({ file, platform: CloudUploadPlatform.WEB }, channelId);
             uploader.on("complete", () => {
                 RestAPI.post({
                     url: Constants.Endpoints.MESSAGES(channelId),
                     body: {
                         flags: 0,
                         channel_id: channelId,
-                        content: JSON.stringify(metadata),
+                        content: JSON.stringify(meta),
                         nonce: SnowflakeUtils.fromTimestamp(Date.now()),
                         sticker_ids: [],
                         type: 0,
-                        attachments: [{
-                            id: "0",
-                            filename: uploader.filename,
-                            uploaded_filename: uploader.uploadedFilename
-                        }]
+                        attachments: [{ id: "0", filename: uploader.filename, uploaded_filename: uploader.uploadedFilename }]
                     }
-                }).then(() => resolve()).catch((e: unknown) => reject(new Error(`Send failed: ${getErrorMessage(e)}`)));
+                }).then(() => resolve()).catch((e: unknown) => reject(new Error(`Send failed: ${e instanceof Error ? e.message : String(e)}`)));
             });
-
-            uploader.on("error", (e: unknown) => reject(new Error(`Upload failed: ${getErrorMessage(e)}`)));
+            uploader.on("error", (e: unknown) => reject(new Error(`Upload failed: ${e instanceof Error ? e.message : String(e)}`)));
             uploader.upload();
-        } catch (e: unknown) {
-            reject(new Error(getErrorMessage(e)));
+        } catch (e) {
+            reject(new Error(e instanceof Error ? e.message : String(e)));
         }
     });
 }
@@ -543,37 +310,49 @@ const SplitIcon = () => (
     </svg>
 );
 
-const FileTypeIcon = ({ kind, label }: { kind: string; label: string; }) => {
-    const paths = [
-        "M14 2H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7z",
-        "M14 2v5h5"
-    ];
+const FILE_BADGE_KINDS: Array<[string[], string]> = [
+    [["zip", "rar", "7z", "tar", "gz"], "archive"],
+    [["pdf"], "document"],
+    [["txt", "md", "json", "csv", "xml", "yaml", "yml"], "text"],
+    [["mp3", "wav", "flac", "ogg", "m4a"], "audio"],
+    [["mp4", "mkv", "avi", "mov", "webm"], "video"],
+    [["exe", "msi", "apk"], "app"],
+];
 
-    if (kind === "archive") paths.push("M10 10v8", "M12 10v8", "M10 12h2", "M10 15h2", "M10 18h2");
-    else if (kind === "video") paths.push("M10 10.5v5l4-2.5z");
-    else if (kind === "audio") paths.push("M10 10v6", "M14 9v5", "M10 16a1.5 1.5 0 1 1-1.5 1.5", "M14 14a1.5 1.5 0 1 1-1.5 1.5");
-    else if (kind === "text") paths.push("M9 11h6", "M9 14h6", "M9 17h4");
-    else if (kind === "document") paths.push("M9 11h6", "M9 15h6");
-    else if (kind === "app") paths.push("M9 10h6v6H9z");
-    else paths.push("M9 11h6", "M9 15h6", "M9 19h4");
+function getFileBadge(filename: string) {
+    const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+    const kind = FILE_BADGE_KINDS.find(([exts]) => exts.includes(ext))?.[1] ?? "file";
+    return { kind, label: ext.toUpperCase().slice(0, 4) || "FILE" };
+}
 
-    return (
-        <div className={cl("file-icon")} title={label}>
-            <svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                {paths.map(path => <path key={path} d={path} />)}
-            </svg>
-        </div>
-    );
+const FILE_ICON_PATHS: Record<string, string[]> = {
+    archive: ["M10 10v8", "M12 10v8", "M10 12h2", "M10 15h2", "M10 18h2"],
+    video: ["M10 10.5v5l4-2.5z"],
+    audio: ["M10 10v6", "M14 9v5", "M10 16a1.5 1.5 0 1 1-1.5 1.5", "M14 14a1.5 1.5 0 1 1-1.5 1.5"],
+    text: ["M9 11h6", "M9 14h6", "M9 17h4"],
+    document: ["M9 11h6", "M9 15h6"],
+    app: ["M9 10h6v6H9z"],
+    file: ["M9 11h6", "M9 15h6", "M9 19h4"],
 };
+
+const FileTypeIcon = ({ kind, label }: { kind: string; label: string; }) => (
+    <div className={cl("file-icon")} title={label}>
+        <svg viewBox="0 0 24 24" width="26" height="26" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M14 2H7a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V7z" />
+            <path d="M14 2v5h5" />
+            {(FILE_ICON_PATHS[kind] ?? FILE_ICON_PATHS.file).map(d => <path key={d} d={d} />)}
+        </svg>
+    </div>
+);
 
 const ActionButton = ({ children, disabled, onClick }: { children: React.ReactNode; disabled?: boolean; onClick: () => void; }) => (
     <button
         className={cl("action")}
         type="button"
         disabled={disabled}
-        onClick={event => {
-            event.preventDefault();
-            event.stopPropagation();
+        onClick={e => {
+            e.preventDefault();
+            e.stopPropagation();
             onClick();
         }}
     >
@@ -581,17 +360,15 @@ const ActionButton = ({ children, disabled, onClick }: { children: React.ReactNo
     </button>
 );
 
-function ProgressCard({ entry }: { entry: ChunkStorageEntry; }) {
-    const first = entry.ch[0];
-    const count = getCompleteChunkCount(entry);
-    const total = first?.total ?? 0;
-
+function ProgressCard({ entry }: { entry: ChunkEntry; }) {
+    const first = entry.chunks[0];
+    const count = new Set(entry.chunks.map(c => c.index)).size;
     return (
         <div className={cl("card")} data-status="pending">
             <div className={cl("body")}>
                 <div className={cl("text")}>
                     <div className={cl("title")}>{first?.originalName ?? "Split file"}</div>
-                    <div className={cl("subtitle")}>Waiting for chunks: {count}/{total}</div>
+                    <div className={cl("subtitle")}>Waiting for chunks: {count}/{first?.total ?? 0}</div>
                 </div>
             </div>
         </div>
@@ -599,16 +376,12 @@ function ProgressCard({ entry }: { entry: ChunkStorageEntry; }) {
 }
 
 function MergedResultCard({ result }: { result: MergedResult; }) {
-    const badgeInfo = getFileBadge(result.originalName);
+    const badge = getFileBadge(result.originalName);
     const subtitle = result.error
         ? `Merge failed: ${result.error}`
         : result.isImage
-            ? result.status === "ready"
-                ? "Merged image preview"
-                : "Preparing image preview..."
-            : result.status === "loading"
-                ? "Preparing download..."
-                : "Merged file ready to download";
+            ? result.status === "ready" ? "Merged image preview" : "Preparing image preview..."
+            : result.status === "loading" ? "Preparing download..." : "Merged file ready to download";
 
     return (
         <div className={cl("card")} data-status={result.status} data-image={String(result.isImage)}>
@@ -616,7 +389,7 @@ function MergedResultCard({ result }: { result: MergedResult; }) {
                 <img className={cl("image")} src={result.objectUrl} alt={result.originalName} />
             )}
             <div className={cl("body")}>
-                {!result.isImage && <FileTypeIcon kind={badgeInfo.kind} label={badgeInfo.label} />}
+                {!result.isImage && <FileTypeIcon kind={badge.kind} label={badge.label} />}
                 <div className={cl("text")}>
                     <div className={cl("title")}>{result.originalName}</div>
                     <div className={cl("subtitle")}>{subtitle}</div>
@@ -624,7 +397,7 @@ function MergedResultCard({ result }: { result: MergedResult; }) {
                 <div className={cl("actions")}>
                     {result.status === "error" ? (
                         <ActionButton onClick={() => {
-                            if (result.isImage) void ensureMergedResult(result.key, true);
+                            if (result.isImage) void prepareImagePreview(result.key);
                             else void handleDownload(result.key);
                         }}>
                             Retry
@@ -640,53 +413,26 @@ function MergedResultCard({ result }: { result: MergedResult; }) {
     );
 }
 
-function FileSplitterAccessory({ message }: { message: ChunkMessage; }) {
-    useFileSplitterStore();
+function FileSplitterAccessory({ message }) {
+    useStore();
 
     React.useEffect(() => {
         processMessage(message);
-    }, [message?.id, message?.content, message?.attachments?.length]);
+    }, [message.id, message.content, message.attachments.length]);
 
     const chunk = getChunkFromMessage(message);
-    const key = chunk ? getChunkKey(chunk) : null;
-    const entry = key ? cs[key] : null;
-    const anchorChunk = key ? getAnchorChunk(key) : null;
-    const isAnchor = Boolean(anchorChunk?.messageId && anchorChunk.messageId === getMessageId(message));
-    const count = entry ? getCompleteChunkCount(entry) : 0;
-    const total = entry?.ch[0]?.total ?? 0;
-    const complete = Boolean(entry && count === total && hasAllChunks(entry));
+    const key = chunk ? chunkKey(chunk) : null;
+    const entry = key ? chunkStore[key] : null;
+    const complete = Boolean(entry && isComplete(entry));
     const result = key ? mergedResults.get(key) : null;
 
-    React.useEffect(() => {
-        if (!key || !entry || !complete) return;
-        void ensureMergedResult(key, isInlinePreviewableImage(entry.ch[0].originalName));
-    }, [key, count, total, complete]);
-
-    if (!chunk || !key || !entry || !isAnchor) return null;
+    if (!chunk || !key || !entry || anchorMessageId(key) !== message.id) return null;
     if (!complete) return <ProgressCard entry={entry} />;
     if (!result) return null;
-
     return <MergedResultCard result={result} />;
 }
 
 const SafeFileSplitterAccessory = ErrorBoundary.wrap(FileSplitterAccessory, { noop: true });
-
-function isFileSplitterChunkMessage(message?: ChunkMessage | null) {
-    return Boolean(message && getChunkFromMessage(message));
-}
-
-function shouldHideFileSplitterChunkMessage(message?: ChunkMessage | null) {
-    if (!message) return false;
-
-    const chunk = getChunkFromMessage(message);
-    if (!chunk) return false;
-
-    const key = getChunkKey(chunk);
-    const knownChunks = cs[key]?.ch ?? [];
-    const anchorChunk = [...knownChunks, chunk].sort((a, b) => a.index - b.index)[0];
-
-    return Boolean(anchorChunk?.messageId && anchorChunk.messageId !== getMessageId(message));
-}
 
 const SplitButton: ChatBarButtonFactory = ({ isMainChat }) => {
     const [status, setStatus] = React.useState<string | null>(null);
@@ -699,7 +445,6 @@ const SplitButton: ChatBarButtonFactory = ({ isMainChat }) => {
             Toasts.show({ message: "File exceeds 500MB limit.", id: Toasts.genId(), type: Toasts.Type.FAILURE });
             return;
         }
-
         if (file.size <= CHUNK_SIZE) {
             Toasts.show({ message: "File is small enough to send directly.", id: Toasts.genId(), type: Toasts.Type.MESSAGE });
             return;
@@ -716,34 +461,25 @@ const SplitButton: ChatBarButtonFactory = ({ isMainChat }) => {
         setStatus("0%");
 
         try {
-            const uploadTimestamp = Date.now();
+            const timestamp = Date.now();
             for (let i = 0; i < totalChunks; i++) {
                 const start = i * CHUNK_SIZE;
-                const end = Math.min(start + CHUNK_SIZE, file.size);
-                const chunkBlob = file.slice(start, end);
-
-                const metadata: FileSplitterMetadata = {
-                    type: "FileSplitterChunk",
-                    index: i,
-                    total: totalChunks,
-                    originalName: file.name,
-                    originalSize: file.size,
-                    timestamp: uploadTimestamp
-                };
-
                 const chunkFile = new File(
-                    [chunkBlob],
+                    [file.slice(start, start + CHUNK_SIZE)],
                     `${file.name}.part${String(i + 1).padStart(3, "0")}`,
                     { type: "application/octet-stream" }
                 );
-
-                await uploadChunk(channelId, chunkFile, metadata);
+                await uploadChunk(channelId, chunkFile, {
+                    type: "FileSplitterChunk",
+                    index: i, total: totalChunks,
+                    originalName: file.name, originalSize: file.size,
+                    timestamp
+                });
                 setStatus(`${Math.round(((i + 1) / totalChunks) * 100)}%`);
             }
-
             Toasts.show({ message: `Uploaded ${totalChunks} parts for ${file.name}`, id: Toasts.genId(), type: Toasts.Type.SUCCESS });
-        } catch (e: unknown) {
-            Toasts.show({ message: `Error: ${getErrorMessage(e)}`, id: Toasts.genId(), type: Toasts.Type.FAILURE });
+        } catch (e) {
+            Toasts.show({ message: `Error: ${e instanceof Error ? e.message : String(e)}`, id: Toasts.genId(), type: Toasts.Type.FAILURE });
         } finally {
             setStatus(null);
         }
@@ -751,14 +487,15 @@ const SplitButton: ChatBarButtonFactory = ({ isMainChat }) => {
 
     if (!isMainChat) return null;
 
-    const label = status ? `Uploading ${status}` : "Split & Upload";
-
     return (
-        <ChatBarButton tooltip={label} onClick={status ? () => { } : () => void doUpload()}>
+        <ChatBarButton tooltip={status ? `Uploading ${status}` : "Split & Upload"} onClick={status ? () => { } : () => void doUpload()}>
             <SplitIcon />
         </ChatBarButton>
     );
 };
+
+let delayedScan: ReturnType<typeof setTimeout> | undefined;
+let cleanupInterval: ReturnType<typeof setInterval> | undefined;
 
 export default definePlugin({
     name: "FileSplitter",
@@ -796,55 +533,53 @@ export default definePlugin({
     ],
 
     renderMessageAccessory({ message }) {
-        return <SafeFileSplitterAccessory message={message as ChunkMessage} />;
+        return <SafeFileSplitterAccessory message={message} />;
     },
 
-    isChunkMessage(message?: ChunkMessage | null) {
-        return isFileSplitterChunkMessage(message);
+    isChunkMessage(message?: Message | null) {
+        return Boolean(message && getChunkFromMessage(message));
     },
 
-    shouldHideChunkMessage(message?: ChunkMessage | null) {
-        return shouldHideFileSplitterChunkMessage(message);
+    shouldHideChunkMessage(message?: Message | null) {
+        if (!message) return false;
+        const chunk = getChunkFromMessage(message);
+        if (!chunk) return false;
+        const key = chunkKey(chunk);
+        return anchorMessageId(key) !== message.id;
     },
 
     flux: {
-        MESSAGE_CREATE({ message }: { message: ChunkMessage; }) {
+        MESSAGE_CREATE({ message }) {
             processMessage(message);
         },
-        MESSAGE_UPDATE({ message }: { message: ChunkMessage; }) {
+        MESSAGE_UPDATE({ message }) {
             processMessage(message);
         },
-        LOAD_MESSAGES_SUCCESS({ channelId }: { channelId?: string; }) {
-            if (channelId) scanExistingMessages(channelId);
+        LOAD_MESSAGES_SUCCESS({ channelId }) {
+            if (channelId) scanChannel(channelId);
         },
-        CHANNEL_SELECT({ channelId }: { channelId?: string; }) {
+        CHANNEL_SELECT({ channelId }) {
             if (!channelId) return;
-
-            scanExistingMessages(channelId);
-            if (delayedChannelScan) clearTimeout(delayedChannelScan);
-            delayedChannelScan = setTimeout(() => {
-                scanExistingMessages(channelId);
-            }, 1500);
+            scanChannel(channelId);
+            clearTimeout(delayedScan);
+            delayedScan = setTimeout(() => scanChannel(channelId), 1500);
         }
     },
 
     start() {
-        clearAllState();
-
-        const currentChannel = SelectedChannelStore.getChannelId();
-        if (currentChannel) {
-            scanExistingMessages(currentChannel);
-            delayedChannelScan = setTimeout(() => scanExistingMessages(currentChannel), 1500);
+        clearAll();
+        const ch = SelectedChannelStore.getChannelId();
+        if (ch) {
+            scanChannel(ch);
+            delayedScan = setTimeout(() => scanChannel(ch), 1500);
         }
-
-        cleanupInterval = setInterval(pruneOldChunks, 60000);
+        cleanupInterval = setInterval(pruneOldChunks, 60_000);
     },
 
     stop() {
-        if (delayedChannelScan) clearTimeout(delayedChannelScan);
-        if (cleanupInterval) clearInterval(cleanupInterval);
-        delayedChannelScan = undefined;
-        cleanupInterval = undefined;
-        clearAllState();
+        clearTimeout(delayedScan);
+        clearInterval(cleanupInterval);
+        delayedScan = cleanupInterval = undefined;
+        clearAll();
     }
 });

--- a/src/equicordplugins/fileSplitter/index.tsx
+++ b/src/equicordplugins/fileSplitter/index.tsx
@@ -13,6 +13,7 @@ import { classNameFactory } from "@utils/css";
 import definePlugin, { PluginNative } from "@utils/types";
 import { chooseFile, saveFile } from "@utils/web";
 import type { Message, MessageAttachment } from "@vencord/discord-types";
+import { CloudUploadPlatform } from "@vencord/discord-types/enums";
 import { findLazy } from "@webpack";
 import { Constants, MessageStore, React, RestAPI, SelectedChannelStore, SnowflakeUtils, Toasts } from "@webpack/common";
 
@@ -507,7 +508,7 @@ function pruneOldChunks() {
 function uploadChunk(channelId: string, chunkFile: File, metadata: FileSplitterMetadata): Promise<void> {
     return new Promise((resolve, reject) => {
         try {
-            const uploader = new CloudUpload({ file: chunkFile, platform: 1 }, channelId);
+            const uploader = new CloudUpload({ file: chunkFile, platform: CloudUploadPlatform.WEB }, channelId);
 
             uploader.on("complete", () => {
                 RestAPI.post({
@@ -680,10 +681,10 @@ function shouldHideFileSplitterChunkMessage(message?: ChunkMessage | null) {
     const chunk = getChunkFromMessage(message);
     if (!chunk) return false;
 
-    const { key } = storeChunk(chunk);
-    tryMergeChunks(key);
+    const key = getChunkKey(chunk);
+    const knownChunks = cs[key]?.ch ?? [];
+    const anchorChunk = [...knownChunks, chunk].sort((a, b) => a.index - b.index)[0];
 
-    const anchorChunk = getAnchorChunk(key);
     return Boolean(anchorChunk?.messageId && anchorChunk.messageId !== getMessageId(message));
 }
 

--- a/src/equicordplugins/fileSplitter/native.ts
+++ b/src/equicordplugins/fileSplitter/native.ts
@@ -27,7 +27,7 @@ export async function fetchChunk(
         return {
             success: true,
             data: await response.arrayBuffer(),
-            contentType: response.headers.get("content-type") || ""
+            contentType: response.headers.get("content-type") ?? ""
         };
     } catch (e) {
         return { success: false, error: e instanceof Error ? e.message : "Unknown error" };

--- a/src/equicordplugins/fileSplitter/native.ts
+++ b/src/equicordplugins/fileSplitter/native.ts
@@ -1,0 +1,35 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 sioaeko and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { IpcMainInvokeEvent, net } from "electron";
+
+export async function fetchChunk(
+    _: IpcMainInvokeEvent,
+    url: string
+): Promise<{ success: boolean; data?: ArrayBuffer; contentType?: string; error?: string; }> {
+    try {
+        const parsed = new URL(url);
+        if (
+            parsed.protocol !== "https:"
+            || !["cdn.discordapp.com", "media.discordapp.net"].includes(parsed.hostname)
+        ) {
+            return { success: false, error: "Unsupported attachment URL" };
+        }
+
+        const response = await net.fetch(url);
+        if (!response.ok) {
+            return { success: false, error: `Fetch failed: ${response.status} ${response.statusText}` };
+        }
+
+        return {
+            success: true,
+            data: await response.arrayBuffer(),
+            contentType: response.headers.get("content-type") || ""
+        };
+    } catch (e) {
+        return { success: false, error: e instanceof Error ? e.message : "Unknown error" };
+    }
+}

--- a/src/equicordplugins/fileSplitter/styles.css
+++ b/src/equicordplugins/fileSplitter/styles.css
@@ -1,0 +1,102 @@
+.vc-file-splitter-card {
+    width: 100%;
+    max-width: 420px;
+    margin-top: 8px;
+    overflow: hidden;
+    border: 1px solid var(--border-subtle, var(--background-modifier-accent));
+    border-radius: 8px;
+    background: var(--background-secondary);
+    box-shadow: 0 6px 18px rgb(0 0 0 / 24%);
+}
+
+[data-filesplitter-hidden="true"] {
+    display: none !important;
+}
+
+.vc-file-splitter-card[data-status="error"] {
+    border-color: var(--status-danger);
+}
+
+.vc-file-splitter-image {
+    display: block;
+    width: 100%;
+    max-height: 420px;
+    object-fit: contain;
+    background: var(--background-primary);
+}
+
+.vc-file-splitter-body {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+}
+
+.vc-file-splitter-file-icon {
+    display: grid;
+    flex-shrink: 0;
+    width: 52px;
+    height: 52px;
+    place-items: center;
+    border-radius: 8px;
+    color: var(--white-500);
+    background: linear-gradient(135deg, var(--brand-500), var(--background-accent));
+}
+
+.vc-file-splitter-text {
+    display: flex;
+    flex: 1;
+    min-width: 0;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.vc-file-splitter-title {
+    overflow: hidden;
+    color: var(--text-normal, #f2f3f5);
+    font-family: var(--font-primary, "gg sans", sans-serif);
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.vc-file-splitter-subtitle {
+    overflow: hidden;
+    color: var(--text-muted, var(--channels-default));
+    font-family: var(--font-primary, "gg sans", sans-serif);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.3;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.vc-file-splitter-actions {
+    display: flex;
+    flex-shrink: 0;
+    gap: 8px;
+}
+
+.vc-file-splitter-action {
+    border: 0;
+    border-radius: 6px;
+    padding: 8px 12px;
+    background: var(--button-secondary-background);
+    color: var(--white-500);
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.vc-file-splitter-action:hover:not(:disabled) {
+    background: var(--button-secondary-background-hover);
+}
+
+.vc-file-splitter-action:disabled {
+    cursor: default;
+    opacity: 0.6;
+}

--- a/src/equicordplugins/fileSplitter/styles.css
+++ b/src/equicordplugins/fileSplitter/styles.css
@@ -92,11 +92,11 @@
     line-height: 1.2;
 }
 
-.vc-file-splitter-action:hover:not(:disabled) {
-    background: var(--button-secondary-background-hover);
-}
-
 .vc-file-splitter-action:disabled {
     cursor: default;
     opacity: 0.6;
+}
+
+.vc-file-splitter-action:hover:not(:disabled) {
+    background: var(--button-secondary-background-hover);
 }

--- a/src/equicordplugins/fileSplitter/styles.css
+++ b/src/equicordplugins/fileSplitter/styles.css
@@ -9,10 +9,6 @@
     box-shadow: 0 6px 18px rgb(0 0 0 / 24%);
 }
 
-[data-filesplitter-hidden="true"] {
-    display: none !important;
-}
-
 .vc-file-splitter-card[data-status="error"] {
     border-color: var(--status-danger);
 }

--- a/src/equicordplugins/fileSplitter/types.ts
+++ b/src/equicordplugins/fileSplitter/types.ts
@@ -1,0 +1,36 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface ChunkMeta {
+    type: "FileSplitterChunk";
+    index: number;
+    total: number;
+    originalName: string;
+    originalSize: number;
+    timestamp: number;
+}
+
+export interface ChunkData extends ChunkMeta {
+    url: string;
+    channelId: string;
+    messageId: string;
+}
+
+export interface ChunkEntry {
+    chunks: ChunkData[];
+    lastUpdated: number;
+}
+
+export interface MergedResult {
+    key: string;
+    originalName: string;
+    isImage: boolean;
+    mimeType: string;
+    status: "pending" | "loading" | "ready" | "error";
+    blob?: Blob;
+    objectUrl?: string;
+    error?: string;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -664,6 +664,10 @@ export const EquicordDevs = Object.freeze({
         name: "nobody",
         id: 0n
     },
+    sioaeko: {
+        name: "sioaeko",
+        id: 0n
+    },
     thororen: {
         name: "thororen",
         id: 848339671629299742n

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -666,7 +666,7 @@ export const EquicordDevs = Object.freeze({
     },
     sioaeko: {
         name: "sioaeko",
-        id: 0n
+        id: 1505110745258397849n
     },
     thororen: {
         name: "thororen",


### PR DESCRIPTION
## Summary

Adds FileSplitter, a plugin that lets users split large files into smaller Discord attachments and merge them back locally in the client.

It adds a chat bar button. When a file is larger than 10MB, it uploads `.part001`, `.part002`, etc. chunks with metadata. If the receiver also has FileSplitter enabled, the client detects the parts and shows a merged preview/download card.

## What it does

- Adds a `Split & Upload` chat bar button
- Splits large files into 10MB chunks
- Uploads chunks through Discord's normal upload flow
- Detects chunks from existing messages and new messages
- Merges files locally in the client
- Shows image previews after merge
- Shows a download card for non-image files
- Hides raw chunk messages after the merged card is shown

## Notes

Users without the plugin will still see the raw part files, so the files are still usable manually if needed.

The plugin does not use an external server. File merging happens locally in the client.

## Tested

- Equicord on Windows
- Equicord on Apple Silicon macOS
- Splitting and merging an image
- Detecting old chunk messages after restarting/reloading the channel
- Hiding `.part001` / `.part002` chunk messages after merge