### PR TITLE
FileUpload: fix zipline on desktop

### DIFF
--- a/src/equicordplugins/fileUpload/utils/upload.ts
+++ b/src/equicordplugins/fileUpload/utils/upload.ts
@@ -28,7 +28,7 @@ const logger = new Logger("FileUpload", "#7cb7ff");
 function toProxyUrl(url: string): string {
     const corsProxyUrl = normalizeCorsProxyUrl((settings.store as { corsProxyUrl?: string; }).corsProxyUrl);
 
-    if (Native || url.startsWith(`${corsProxyUrl}?url=`)) {
+    if (url.startsWith(`${corsProxyUrl}?url=`)) {
         return url;
     }
 


### PR DESCRIPTION
was ignoring the proxy on desktop but apparently zipline doesnt like that very much, the cors is configured weirdly so its broken even on native.

sorry for the huge diff :(