### PR TITLE
feat(plugin): add downloadAllAttachments

### DIFF
--- a/src/equicordplugins/downloadAllAttachments/index.tsx
+++ b/src/equicordplugins/downloadAllAttachments/index.tsx
@@ -7,6 +7,7 @@
 import { CloudDownloadIcon } from "@components/Icons";
 import { EquicordDevs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
+import { pluralise } from "@utils/misc";
 import definePlugin from "@utils/types";
 import { Message, MessageAttachment } from "@vencord/discord-types";
 import { ChannelStore, showToast, Toasts } from "@webpack/common";
@@ -18,30 +19,64 @@ async function downloadAll(attachments: MessageAttachment[]) {
     try {
         dir = await window.showDirectoryPicker({ mode: "readwrite" });
     } catch (e) {
-        if (e instanceof DOMException && e.name === "AbortError") return; // user cancelled
+        if (e instanceof DOMException && e.name === "AbortError") return;
         logger.error("Failed to open directory picker:", e);
         return;
     }
 
-    let failed = 0;
-    await Promise.all(attachments.map(async a => {
+    const usedNames = new Map<string, number>();
+
+    function uniqueName(original: string): string {
+        const count = usedNames.get(original) ?? 0;
+        usedNames.set(original, count + 1);
+        if (count === 0) return original;
+        const dot = original.lastIndexOf(".");
+        return dot === -1
+            ? `${original}_${count}`
+            : `${original.slice(0, dot)}_${count}${original.slice(dot)}`;
+    }
+
+    const tasks = attachments.map(a => ({ attachment: a, filename: uniqueName(a.filename) }));
+
+    const results = await Promise.allSettled(tasks.map(async ({ attachment, filename }) => {
+        if (!attachment.proxy_url) throw new Error("Missing Proxy URL");
+
+        const res = await fetch(attachment.proxy_url);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        if (!res.body) throw new Error("Response body is empty");
+
+        let fileHandle: FileSystemFileHandle | undefined;
         try {
-            const res = await fetch(a.proxy_url);
-            if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            if (!res.body) throw new Error("Response body is empty");
-            const file = await dir.getFileHandle(a.filename, { create: true });
-            const writable = await file.createWritable();
-            await res.body.pipeTo(writable);
+            fileHandle = await dir.getFileHandle(filename, { create: true });
+            const writable = await fileHandle.createWritable();
+            try {
+                await res.body.pipeTo(writable);
+            } catch (e) {
+                await writable.abort();
+                throw e;
+            }
         } catch (e) {
-            logger.warn(`Failed to download ${a.filename}:`, e);
-            failed++;
+            if (fileHandle) {
+                try { await dir.removeEntry(filename); } catch { }
+            }
+            throw e;
         }
     }));
 
+    const failed = results.filter(r => {
+        if (r.status === "rejected") {
+            logger.warn("Failed to download attachment:", r.reason);
+            return true;
+        }
+        return false;
+    }).length;
+
+    const succeeded = attachments.length - failed;
+
     if (failed === 0)
-        showToast(`Downloaded ${attachments.length} attachment${attachments.length === 1 ? "" : "s"}.`, Toasts.Type.SUCCESS);
+        showToast(`Downloaded ${pluralise(succeeded, "attachment")}.`, Toasts.Type.SUCCESS);
     else
-        showToast(`Downloaded ${attachments.length - failed} of ${attachments.length} attachments. ${failed} failed.`, Toasts.Type.FAILURE);
+        showToast(`Downloaded ${succeeded} of ${attachments.length} attachments. ${failed} failed.`, Toasts.Type.FAILURE);
 }
 
 export default definePlugin({

--- a/src/equicordplugins/downloadAllAttachments/index.tsx
+++ b/src/equicordplugins/downloadAllAttachments/index.tsx
@@ -1,0 +1,66 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { CloudDownloadIcon } from "@components/Icons";
+import { EquicordDevs } from "@utils/constants";
+import { Logger } from "@utils/Logger";
+import definePlugin from "@utils/types";
+import { Message, MessageAttachment } from "@vencord/discord-types";
+import { ChannelStore, showToast, Toasts } from "@webpack/common";
+
+const logger = new Logger("DownloadAllAttachments");
+
+async function downloadAll(attachments: MessageAttachment[]) {
+    let dir: FileSystemDirectoryHandle;
+    try {
+        dir = await window.showDirectoryPicker({ mode: "readwrite" });
+    } catch (e) {
+        if (e instanceof DOMException && e.name === "AbortError") return; // user cancelled
+        logger.error("Failed to open directory picker:", e);
+        return;
+    }
+
+    let failed = 0;
+    await Promise.all(attachments.map(async a => {
+        try {
+            const res = await fetch(a.proxy_url);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            if (!res.body) throw new Error("Response body is empty");
+            const file = await dir.getFileHandle(a.filename, { create: true });
+            const writable = await file.createWritable();
+            await res.body.pipeTo(writable);
+        } catch (e) {
+            logger.warn(`Failed to download ${a.filename}:`, e);
+            failed++;
+        }
+    }));
+
+    if (failed === 0)
+        showToast(`Downloaded ${attachments.length} attachment${attachments.length === 1 ? "" : "s"}.`, Toasts.Type.SUCCESS);
+    else
+        showToast(`Downloaded ${attachments.length - failed} of ${attachments.length} attachments. ${failed} failed.`, Toasts.Type.FAILURE);
+}
+
+export default definePlugin({
+    name: "DownloadAllAttachments",
+    description: "Adds a popover button to download all attachments in a message at once.",
+    tags: ["Utility", "Chat"],
+    authors: [EquicordDevs.dhopcs],
+    dependencies: ["MessagePopoverAPI"],
+    messagePopoverButton: {
+        icon: CloudDownloadIcon,
+        render(message: Message) {
+            if (!message.attachments.length) return null;
+            return {
+                label: "Download All Attachments",
+                icon: CloudDownloadIcon,
+                message,
+                channel: ChannelStore.getChannel(message.channel_id),
+                onClick: () => downloadAll(message.attachments)
+            };
+        }
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1325,6 +1325,10 @@ export const EquicordDevs = Object.freeze({
         name: "NassCT",
         id: 354996937868705793n
     },
+    dhopcs: {
+        name: "dhopcs",
+        id: 206309860038410240n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
This PR adds `DownloadAllAttachments`

Useful in scenarios where you have been sent 10 media files in one message for example if you work through discord.

UX Flow starts at the attached image -> opens a directory dialog -> downloads all to given directory

## Testing proof

<img width="312" height="123" alt="image" src="https://github.com/user-attachments/assets/6ae38d31-47c6-4a2c-9ab3-57a02d9f7dee" />

(pick directory here, flameshot doesn't seem to capture mine)

<img width="250" height="51" alt="image" src="https://github.com/user-attachments/assets/7abbdc72-c67f-49d1-8ca1-f519a6c93bdc" />

<img width="584" height="196" alt="image" src="https://github.com/user-attachments/assets/e1f6875a-84fa-4ac4-b921-5b70c0ff73bc" />
