### PR TITLE
hide dm addition (user request)

### DIFF
--- a/src/equicordplugins/hideMessages/index.tsx
+++ b/src/equicordplugins/hideMessages/index.tsx
@@ -97,22 +97,22 @@ export default definePlugin({
     authors: [EquicordDevs.yash],
     patches: [
         {
-            find: "\"dm-quick-launcher\"===",
+            find: '"dm-quick-launcher"===',
             replacement: [
                 {
-                    match: /(render\(\)\{let\{privateChannelIds:(\i),padding:\i\}=this\.props,\{preRenderedChildren:\i\}=this\.state;)/,
-                    replace: "$1$2=$self.filterPrivateChannelIds($2,this);"
+                    match: /render\(\)\{/,
+                    replace: "$&this.props.privateChannelIds=$self.filterPrivateChannelIds(this.props.privateChannelIds,this);"
                 },
                 {
-                    match: /(renderRow=\i=>\{let\{section:\i,row:\i\}=\i,\{privateChannelIds:(\i)\}=this\.props;)/,
-                    replace: "$1$2=$self.filterPrivateChannelIds($2,this);"
+                    match: /renderRow=\i=>\{/,
+                    replace: "$&this.props.privateChannelIds=$self.filterPrivateChannelIds(this.props.privateChannelIds,this);"
                 },
                 {
-                    match: /(renderDM=\(\i,\i\)=>\{let\{privateChannelIds:(\i),channels:\i,selectedChannelId:\i\}=this\.props,\{totalRowCount:\i,preRenderedChildren:\i\}=this\.state),(\i)=/,
-                    replace: "$1;$2=$self.filterPrivateChannelIds($2,this);let $3="
+                    match: /renderDM=\(\i,\i\)=>\{/,
+                    replace: "$&this.props.privateChannelIds=$self.filterPrivateChannelIds(this.props.privateChannelIds,this);"
                 },
                 {
-                    match: /children:\[\(0,\i\.jsx\)\(.{0,20}\{className:\i\.TK,children:\i\.intl\.string\(\i\.t#{intl::DIRECT_MESSAGES}\)\}\),/,
+                    match: /#{intl::DIRECT_MESSAGES}\)\}\),/,
                     replace: "$&$self.renderHiddenMessagesToggle(),"
                 }
             ]

--- a/src/equicordplugins/hideMessages/index.tsx
+++ b/src/equicordplugins/hideMessages/index.tsx
@@ -136,7 +136,7 @@ export default definePlugin({
     },
     renderHiddenMessagesToggle: ErrorBoundary.wrap(() => {
         const hasHiddenDms = hiddenDmIds.size > 0;
-        const label = hasHiddenDms ? showHiddenDms ? "Hide Hidden DMs" : "Show Hidden DMs" : "No Hidden DMs";
+        const label = !hasHiddenDms ? "No Hidden DMs" : showHiddenDms ? "Hide Hidden DMs" : "Show Hidden DMs";
 
         return (
             <Tooltip text={label}>

--- a/src/equicordplugins/hideMessages/index.tsx
+++ b/src/equicordplugins/hideMessages/index.tsx
@@ -70,9 +70,8 @@ const userCtxPatch: NavContextMenuPatchCallback = (children, { channel }: UserCo
     if (!group) return;
 
     const hidden = hiddenDmIds.has(channel.id);
-    const closeDmIndex = group.findIndex(c => c?.props?.id === "close-dm");
 
-    group.splice(closeDmIndex, 0, (
+    group.splice(group.findIndex(c => c?.props?.id === "close-dm"), 0, (
         <Menu.MenuItem
             id="vc-hidemessages-dm"
             label={hidden ? "Unhide DM" : "Hide DM"}

--- a/src/equicordplugins/hideMessages/index.tsx
+++ b/src/equicordplugins/hideMessages/index.tsx
@@ -6,11 +6,28 @@
 
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { definePluginSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
 import { EyeIcon } from "@components/Icons";
 import { EquicordDevs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
-import { Message } from "@vencord/discord-types";
-import { ChannelStore, FluxDispatcher, Menu } from "@webpack/common";
+import { Channel, Message } from "@vencord/discord-types";
+import { ChannelStore, Clickable, FluxDispatcher, Menu, Tooltip } from "@webpack/common";
+
+interface UserContextProps {
+    channel?: Channel;
+}
+
+interface PrivateChannelsListInstance {
+    forceUpdate(callback?: () => void): void;
+}
+
+const hiddenDmIds = new Set<string>();
+let privateChannelsListInstance: PrivateChannelsListInstance | null = null;
+let showHiddenDms = false;
+
+function notifyHiddenDmsUpdate() {
+    privateChannelsListInstance?.forceUpdate();
+}
 
 const hideMessage = (messageId: string, channelId: string) => {
     FluxDispatcher.dispatch({
@@ -20,6 +37,17 @@ const hideMessage = (messageId: string, channelId: string) => {
         mlDeleted: true,
     });
 };
+
+function toggleDm(channelId: string) {
+    if (hiddenDmIds.has(channelId)) {
+        hiddenDmIds.delete(channelId);
+        if (!hiddenDmIds.size) showHiddenDms = false;
+    } else {
+        hiddenDmIds.add(channelId);
+    }
+
+    notifyHiddenDmsUpdate();
+}
 
 const messageCtxPatch: NavContextMenuPatchCallback = (children, { message }: { message: Message; }) => {
     const group = findGroupChildrenByChildId("copy-text", children);
@@ -35,6 +63,25 @@ const messageCtxPatch: NavContextMenuPatchCallback = (children, { message }: { m
     ));
 };
 
+const userCtxPatch: NavContextMenuPatchCallback = (children, { channel }: UserContextProps) => {
+    if (!channel?.isDM()) return;
+
+    const group = findGroupChildrenByChildId("close-dm", children);
+    if (!group) return;
+
+    const hidden = hiddenDmIds.has(channel.id);
+    const closeDmIndex = group.findIndex(c => c?.props?.id === "close-dm");
+
+    group.splice(closeDmIndex, 0, (
+        <Menu.MenuItem
+            id="vc-hidemessages-dm"
+            label={hidden ? "Unhide DM" : "Hide DM"}
+            icon={EyeIcon}
+            action={() => toggleDm(channel.id)}
+        />
+    ));
+};
+
 const settings = definePluginSettings({
     hidePopoverButton: {
         type: OptionType.BOOLEAN,
@@ -45,14 +92,75 @@ const settings = definePluginSettings({
 
 export default definePlugin({
     name: "HideMessages",
-    description: "A plugin to temporarily hide messages until you restart.",
+    description: "Temporarily hide messages and DMs until you restart.",
     dependencies: ["MessagePopoverAPI"],
     tags: ["Chat", "Utility"],
     authors: [EquicordDevs.yash],
+    patches: [
+        {
+            find: "\"dm-quick-launcher\"===",
+            replacement: [
+                {
+                    match: /(render\(\)\{let\{privateChannelIds:(\i),padding:\i\}=this\.props,\{preRenderedChildren:\i\}=this\.state;)/,
+                    replace: "$1$2=$self.filterPrivateChannelIds($2,this);"
+                },
+                {
+                    match: /(renderRow=\i=>\{let\{section:\i,row:\i\}=\i,\{privateChannelIds:(\i)\}=this\.props;)/,
+                    replace: "$1$2=$self.filterPrivateChannelIds($2,this);"
+                },
+                {
+                    match: /(renderDM=\(\i,\i\)=>\{let\{privateChannelIds:(\i),channels:\i,selectedChannelId:\i\}=this\.props,\{totalRowCount:\i,preRenderedChildren:\i\}=this\.state),(\i)=/,
+                    replace: "$1;$2=$self.filterPrivateChannelIds($2,this);let $3="
+                },
+                {
+                    match: /children:\[\(0,\i\.jsx\)\(.{0,20}\{className:\i\.TK,children:\i\.intl\.string\(\i\.t#{intl::DIRECT_MESSAGES}\)\}\),/,
+                    replace: "$&$self.renderHiddenMessagesToggle(),"
+                }
+            ]
+        }
+    ],
     contextMenus: {
-        "message": messageCtxPatch
+        "message": messageCtxPatch,
+        "user-context": userCtxPatch
     },
     settings,
+    stop() {
+        hiddenDmIds.clear();
+        showHiddenDms = false;
+        notifyHiddenDmsUpdate();
+        privateChannelsListInstance = null;
+    },
+    filterPrivateChannelIds(privateChannelIds: string[], instance?: PrivateChannelsListInstance) {
+        privateChannelsListInstance = instance ?? privateChannelsListInstance;
+        return showHiddenDms ? privateChannelIds : privateChannelIds.filter(id => !hiddenDmIds.has(id));
+    },
+    renderHiddenMessagesToggle: ErrorBoundary.wrap(() => {
+        const hasHiddenDms = hiddenDmIds.size > 0;
+        const label = hasHiddenDms ? showHiddenDms ? "Hide Hidden DMs" : "Show Hidden DMs" : "No Hidden DMs";
+
+        return (
+            <Tooltip text={label}>
+                {tooltipProps => (
+                    <Clickable
+                        {...tooltipProps}
+                        role="button"
+                        tabIndex={0}
+                        aria-label={label}
+                        aria-disabled={!hasHiddenDms}
+                        onClick={event => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            if (!hasHiddenDms) return;
+                            showHiddenDms = !showHiddenDms;
+                            notifyHiddenDmsUpdate();
+                        }}
+                    >
+                        <EyeIcon width={18} height={18} />
+                    </Clickable>
+                )}
+            </Tooltip>
+        );
+    }, { noop: true }),
     messagePopoverButton: {
         icon: EyeIcon,
         render(message: Message) {


### PR DESCRIPTION
https://github.com/user-attachments/assets/d4b72d70-b5ac-4f9d-a629-054f60bc47e5

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR extends the existing `HideMessages` plugin to also support hiding DMs from the sidebar. It adds a `"user-context"` context menu patch for toggling individual DMs hidden/visible, module-level state (`hiddenDmIds`, `showHiddenDms`, `privateChannelsListInstance`) to track the hide set across renders, and a webpack patch against `'"dm-quick-launcher"==='` to filter `privateChannelIds` and inject a toggle button into the DM list header.

- Adds `userCtxPatch` on `"user-context"` with `channel?.isDM()` and `findGroupChildrenByChildId("close-dm")` guards, so the \"Hide DM / Unhide DM\" item only appears for direct messages.
- Injects `filterPrivateChannelIds` into three render methods (`render`, `renderRow`, `renderDM`) of the private channels list to ensure filtering is applied across Discord's virtualized list render paths, and injects a `renderHiddenMessagesToggle` eye-icon button anchored on the stable `#{intl::DIRECT_MESSAGES}` intl key.
- The `stop()` lifecycle correctly clears `hiddenDmIds`, resets `showHiddenDms`, triggers a `forceUpdate` to un-hide all DMs, then nulls the instance reference.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The DM hiding logic is self-contained, the patching uses stable intl anchors, and plugin stop correctly restores the full DM list before clearing the instance reference.

All patch match patterns avoid hardcoded minified identifiers; the header injection is anchored on #{intl::DIRECT_MESSAGES} which is the most stable option available. Module-level state is cleared in stop() in the correct order (clear → notify → null instance), so the DM list reverts cleanly when the plugin is disabled. Guards in userCtxPatch (channel?.isDM() and findGroupChildrenByChildId) prevent the menu item from appearing in wrong contexts. No crashes, data loss, or auth issues identified.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/equicordplugins/hideMessages/index.tsx | Adds DM hiding capability via module-level state, a userCtxPatch context menu entry, three filterPrivateChannelIds patch injections, and a header toggle button; cleanup in stop() is correct and the patching uses stable intl anchors. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["update patches"](https://github.com/equicord/equicord/commit/9c6671cb74a60ade3f46fd926a5a486e97e4b4d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32325918)</sub>

<!-- /greptile_comment -->