### PR TITLE
RandomVoice Keybinds

### DIFF
--- a/src/equicordplugins/randomVoice/index.tsx
+++ b/src/equicordplugins/randomVoice/index.tsx
@@ -6,17 +6,20 @@
 
 import { definePluginSettings } from "@api/Settings";
 import { UserAreaButton, UserAreaRenderProps } from "@api/UserArea";
+import { Button } from "@components/Button";
+import { Switch } from "@components/Switch";
 import { debounce } from "@shared/debounce";
 import { Devs, EquicordDevs } from "@utils/constants";
 import definePlugin, { makeRange, OptionType } from "@utils/types";
 import type { Channel, VoiceState } from "@vencord/discord-types";
 import { findByCodeLazy, findByPropsLazy } from "@webpack";
-import { ChannelActions, ChannelRouter, ChannelStore, ContextMenuApi, FluxDispatcher, GuildStore, MediaEngineStore, Menu, PermissionsBits, PermissionStore, React, RelationshipStore, SelectedChannelStore, Toasts, UserStore, VoiceActions, VoiceStateStore } from "@webpack/common";
+import { ChannelActions, ChannelRouter, ChannelStore, ContextMenuApi, FluxDispatcher, GuildStore, MediaEngineStore, Menu, PermissionsBits, PermissionStore, React, RelationshipStore, SelectedChannelStore, Toasts, UserStore, VoiceActions, VoiceStateStore, useEffect, useState } from "@webpack/common";
 
 const startStream = findByCodeLazy('type:"STREAM_START"');
 const getDesktopSources = findByCodeLazy("desktop sources");
 const { isVideoEnabled } = findByPropsLazy("isVideoEnabled");
 const NO_SERVERS = "__NONE__";
+const DEFAULT_KEYBIND = ["Control", "Shift", "R"];
 
 type RandomVoiceOperation = "<" | ">" | "==";
 type StateFilterKey = "mute" | "deafen" | "video" | "stream";
@@ -68,7 +71,107 @@ interface RandomVoiceStateLike {
     selfVideo?: boolean | null;
 }
 
+function RandomVoiceKeybindSettings() {
+    const [isListening, setIsListening] = useState(false);
+    const { keybind, keybindEnabled } = settings.use(["keybind", "keybindEnabled"]);
+
+    useEffect(() => {
+        if (!isListening) return;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+
+            settings.store.keybind = eventToKeybind(event);
+            setIsListening(false);
+        };
+
+        const handleBlur = () => setIsListening(false);
+
+        document.addEventListener("keydown", handleKeyDown, true);
+        window.addEventListener("blur", handleBlur);
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown, true);
+            window.removeEventListener("blur", handleBlur);
+        };
+    }, [isListening]);
+
+    return (
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+            <div style={{ color: "var(--text-muted)" }}>Keybind</div>
+            <Switch checked={keybindEnabled} onChange={value => { settings.store.keybindEnabled = value; }} />
+            {keybindEnabled && (
+                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                    <Button type="button" variant="secondary" onClick={() => setIsListening(true)} disabled={isListening}>
+                        {isListening ? "Recording..." : formatKeybind(keybind)}
+                    </Button>
+                    <Button type="button" variant="secondary" onClick={() => { settings.store.keybind = DEFAULT_KEYBIND; }} disabled={isListening}>
+                        Reset
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function formatKeybind(keybind: string | string[]) {
+    const keybindString = Array.isArray(keybind) ? keybind.join("+") : keybind;
+    return navigator.platform.toUpperCase().includes("MAC")
+        ? keybindString.replace(/Control/gi, "⌘").replace(/Meta/gi, "⌘").replace(/Alt/gi, "⌥").replace(/Shift/gi, "⇧")
+        : keybindString;
+}
+
+function eventToKeybind(event: KeyboardEvent) {
+    const keys = [];
+    if (event.ctrlKey) keys.push("Control");
+    if (event.shiftKey) keys.push("Shift");
+    if (event.altKey) keys.push("Alt");
+    if (event.metaKey) keys.push("Meta");
+    const mainKey = event.key === " " ? "Space" : event.key;
+    return [...keys, mainKey];
+}
+
+function getConfiguredKeybind() {
+    const raw = settings.store.keybind;
+    return Array.isArray(raw) && raw.length ? raw : DEFAULT_KEYBIND;
+}
+
+function matchesKeybind(event: KeyboardEvent) {
+    const keybind = getConfiguredKeybind().map(key => key.toLowerCase());
+    const pressed = event.key === " " ? "space" : event.key.toLowerCase();
+    const modifiers = ["control", "ctrl", "shift", "alt", "meta", "cmd", "command", "option"];
+    let nonModifierMatched = false;
+
+    for (const key of keybind) {
+        if (key === "control" || key === "ctrl") { if (!event.ctrlKey) return false; continue; }
+        if (key === "shift") { if (!event.shiftKey) return false; continue; }
+        if (key === "alt" || key === "option") { if (!event.altKey) return false; continue; }
+        if (key === "meta" || key === "cmd" || key === "command") { if (!event.metaKey) return false; continue; }
+        if (pressed !== key) return false;
+        nonModifierMatched = true;
+    }
+
+    return nonModifierMatched || keybind.every(key => modifiers.includes(key));
+}
+
+function shouldIgnoreKeybindTarget(target: EventTarget | null) {
+    return target instanceof HTMLElement && (target.isContentEditable || ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName));
+}
+
 const settings = definePluginSettings({
+    keybind: {
+        description: "Keybind to hop to a random voice channel",
+        type: OptionType.COMPONENT,
+        default: DEFAULT_KEYBIND,
+        component: RandomVoiceKeybindSettings,
+    },
+    keybindEnabled: {
+        description: "Show the random voice keybind controls",
+        type: OptionType.BOOLEAN,
+        default: false,
+        hidden: true,
+    },
     UserAmountOperation: {
         description: "Select an operation for the amounts of users",
         type: OptionType.SELECT,
@@ -679,6 +782,24 @@ export default definePlugin({
     userAreaButton: {
         icon: RandomVoiceIcon,
         render: RandomVoiceButton,
+    },
+
+    start() {
+        document.addEventListener("keydown", this.onKeyDown);
+    },
+
+    stop() {
+        document.removeEventListener("keydown", this.onKeyDown);
+    },
+
+    onKeyDown(event: KeyboardEvent) {
+        if (!settings.store.keybindEnabled) return;
+        if (shouldIgnoreKeybindTarget(event.target)) return;
+        if (!matchesKeybind(event)) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+        void joinRandomVoice();
     },
 
     flux: {

--- a/src/equicordplugins/randomVoice/index.tsx
+++ b/src/equicordplugins/randomVoice/index.tsx
@@ -9,17 +9,20 @@ import { UserAreaButton, UserAreaRenderProps } from "@api/UserArea";
 import { Button } from "@components/Button";
 import { Switch } from "@components/Switch";
 import { debounce } from "@shared/debounce";
-import { Devs, EquicordDevs } from "@utils/constants";
+import { Devs, EquicordDevs, IS_MAC } from "@utils/constants";
 import definePlugin, { makeRange, OptionType } from "@utils/types";
 import type { Channel, VoiceState } from "@vencord/discord-types";
 import { findByCodeLazy, findByPropsLazy } from "@webpack";
-import { ChannelActions, ChannelRouter, ChannelStore, ContextMenuApi, FluxDispatcher, GuildStore, MediaEngineStore, Menu, PermissionsBits, PermissionStore, React, RelationshipStore, SelectedChannelStore, Toasts, UserStore, VoiceActions, VoiceStateStore, useEffect, useState } from "@webpack/common";
+import { ChannelActions, ChannelRouter, ChannelStore, ContextMenuApi, FluxDispatcher, GuildStore, MediaEngineStore, Menu, PermissionsBits, PermissionStore, React, RelationshipStore, SelectedChannelStore, Toasts, useEffect, UserStore, useState, VoiceActions, VoiceStateStore } from "@webpack/common";
 
 const startStream = findByCodeLazy('type:"STREAM_START"');
 const getDesktopSources = findByCodeLazy("desktop sources");
 const { isVideoEnabled } = findByPropsLazy("isVideoEnabled");
 const NO_SERVERS = "__NONE__";
-const DEFAULT_KEYBIND = ["Control", "Shift", "R"];
+const DEFAULT_KEYBIND = IS_MAC ? ["Meta", "Shift", "R"] : ["Control", "Shift", "R"];
+const MODIFIER_KEYS = new Set(["control", "ctrl", "shift", "alt", "option", "meta", "cmd", "command", "mod"]);
+
+let isRecordingKeybind = false;
 
 type RandomVoiceOperation = "<" | ">" | "==";
 type StateFilterKey = "mute" | "deafen" | "video" | "stream";
@@ -73,14 +76,17 @@ interface RandomVoiceStateLike {
 
 function RandomVoiceKeybindSettings() {
     const [isListening, setIsListening] = useState(false);
-    const { keybind, keybindEnabled } = settings.use(["keybind", "keybindEnabled"]);
+    const { keybind, keybindEnabled } = settings.use();
 
     useEffect(() => {
+        isRecordingKeybind = isListening;
         if (!isListening) return;
 
         const handleKeyDown = (event: KeyboardEvent) => {
             event.preventDefault();
             event.stopPropagation();
+
+            if (isModifierKey(event.key)) return;
 
             settings.store.keybind = eventToKeybind(event);
             setIsListening(false);
@@ -92,6 +98,7 @@ function RandomVoiceKeybindSettings() {
         window.addEventListener("blur", handleBlur);
 
         return () => {
+            isRecordingKeybind = false;
             document.removeEventListener("keydown", handleKeyDown, true);
             window.removeEventListener("blur", handleBlur);
         };
@@ -117,42 +124,91 @@ function RandomVoiceKeybindSettings() {
 
 function formatKeybind(keybind: string | string[]) {
     const keybindString = Array.isArray(keybind) ? keybind.join("+") : keybind;
-    return navigator.platform.toUpperCase().includes("MAC")
-        ? keybindString.replace(/Control/gi, "⌘").replace(/Meta/gi, "⌘").replace(/Alt/gi, "⌥").replace(/Shift/gi, "⇧")
+    return IS_MAC
+        ? keybindString.replace(/Control/gi, "^").replace(/Meta|Command|Cmd/gi, "⌘").replace(/Alt|Option/gi, "⌥").replace(/Shift/gi, "⇧")
         : keybindString;
 }
 
 function eventToKeybind(event: KeyboardEvent) {
-    const keys = [];
-    if (event.ctrlKey) keys.push("Control");
-    if (event.shiftKey) keys.push("Shift");
-    if (event.altKey) keys.push("Alt");
-    if (event.metaKey) keys.push("Meta");
-    const mainKey = event.key === " " ? "Space" : event.key;
-    return [...keys, mainKey];
+    const keys: string[] = [];
+    addPressedModifiers(event, keys);
+    keys.push(normalizeKey(event.key));
+    return keys;
 }
 
 function getConfiguredKeybind() {
     const raw = settings.store.keybind;
-    return Array.isArray(raw) && raw.length ? raw : DEFAULT_KEYBIND;
+    if (Array.isArray(raw) && raw.some(key => !isModifierKey(key))) return raw;
+    return DEFAULT_KEYBIND;
 }
 
 function matchesKeybind(event: KeyboardEvent) {
     const keybind = getConfiguredKeybind().map(key => key.toLowerCase());
-    const pressed = event.key === " " ? "space" : event.key.toLowerCase();
-    const modifiers = ["control", "ctrl", "shift", "alt", "meta", "cmd", "command", "option"];
+    const pressed = normalizeKey(event.key).toLowerCase();
+    const code = normalizeCode(event.code);
     let nonModifierMatched = false;
 
     for (const key of keybind) {
-        if (key === "control" || key === "ctrl") { if (!event.ctrlKey) return false; continue; }
-        if (key === "shift") { if (!event.shiftKey) return false; continue; }
-        if (key === "alt" || key === "option") { if (!event.altKey) return false; continue; }
-        if (key === "meta" || key === "cmd" || key === "command") { if (!event.metaKey) return false; continue; }
-        if (pressed !== key) return false;
+        if (isModifierKey(key)) {
+            if (!isModifierPressed(event, key)) return false;
+            continue;
+        }
+
+        if (pressed !== key && code !== key) return false;
         nonModifierMatched = true;
     }
 
-    return nonModifierMatched || keybind.every(key => modifiers.includes(key));
+    return nonModifierMatched;
+}
+
+function isModifierKey(key: string) {
+    return MODIFIER_KEYS.has(key.toLowerCase());
+}
+
+function isModifierPressed(event: KeyboardEvent, key: string) {
+    switch (key) {
+        case "mod":
+            return IS_MAC ? event.metaKey : event.ctrlKey;
+        case "control":
+        case "ctrl":
+            return event.ctrlKey;
+        case "shift":
+            return event.shiftKey;
+        case "alt":
+        case "option":
+            return event.altKey;
+        case "meta":
+        case "cmd":
+        case "command":
+            return event.metaKey;
+        default:
+            return false;
+    }
+}
+
+function addPressedModifiers(event: KeyboardEvent, keys: string[]) {
+    if (event.metaKey) keys.push("Meta");
+    if (event.ctrlKey) keys.push("Control");
+    if (event.shiftKey) keys.push("Shift");
+    if (event.altKey) keys.push("Alt");
+}
+
+function keybindUsesModifier() {
+    return getConfiguredKeybind().some(isModifierKey);
+}
+
+function normalizeKey(key: string) {
+    if (key === " ") return "Space";
+    if (key === "Esc") return "Escape";
+    return key.length === 1 ? key.toUpperCase() : key;
+}
+
+function normalizeCode(code: string) {
+    return code
+        .toLowerCase()
+        .replace(/^key/, "")
+        .replace(/^digit/, "")
+        .replace(/^numpad/, "");
 }
 
 function shouldIgnoreKeybindTarget(target: EventTarget | null) {
@@ -785,16 +841,17 @@ export default definePlugin({
     },
 
     start() {
-        document.addEventListener("keydown", this.onKeyDown);
+        window.addEventListener("keydown", this.onKeyDown, true);
     },
 
     stop() {
-        document.removeEventListener("keydown", this.onKeyDown);
+        window.removeEventListener("keydown", this.onKeyDown, true);
     },
 
     onKeyDown(event: KeyboardEvent) {
+        if (isRecordingKeybind) return;
         if (!settings.store.keybindEnabled) return;
-        if (shouldIgnoreKeybindTarget(event.target)) return;
+        if (shouldIgnoreKeybindTarget(event.target) && !keybindUsesModifier()) return;
         if (!matchesKeybind(event)) return;
 
         event.preventDefault();

--- a/src/equicordplugins/randomVoice/index.tsx
+++ b/src/equicordplugins/randomVoice/index.tsx
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import "./styles.css";
+
 import { definePluginSettings } from "@api/Settings";
 import { UserAreaButton, UserAreaRenderProps } from "@api/UserArea";
 import { Button } from "@components/Button";
@@ -11,6 +13,7 @@ import ErrorBoundary from "@components/ErrorBoundary";
 import { Switch } from "@components/Switch";
 import { debounce } from "@shared/debounce";
 import { Devs, EquicordDevs, IS_MAC } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
 import definePlugin, { makeRange, OptionType } from "@utils/types";
 import type { Channel, VoiceState } from "@vencord/discord-types";
 import { findByCodeLazy, findByPropsLazy } from "@webpack";
@@ -24,8 +27,9 @@ const DEFAULT_KEYBIND = IS_MAC ? ["Meta", "Shift", "R"] : ["Control", "Shift", "
 const MODIFIER_KEYS = new Set(["control", "ctrl", "shift", "alt", "option", "meta", "cmd", "command", "mod"]);
 
 let isRecordingKeybind = false;
+const cl = classNameFactory("vc-random-voice-");
 
-type RandomVoiceOperation = "<" | ">" | "==";
+type RandomVoiceOperation = "<" | ">" | "==" | string;
 type StateFilterKey = "mute" | "deafen" | "video" | "stream";
 type SelfSettingKey = "selfMute" | "selfDeafen" | "autoCamera" | "autoStream" | "leaveEmpty" | "autoNavigate" | "avoidStages" | "avoidAfk" | "prioritizeFriends";
 type PostJoinAction = () => void | Promise<void>;
@@ -106,11 +110,11 @@ function RandomVoiceKeybindSettings() {
     }, [isListening]);
 
     return (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            <div style={{ color: "var(--text-muted)" }}>Keybind</div>
+        <div className={cl("record")}>
+            <div className={cl("keybind")}>Keybind</div>
             <Switch checked={keybindEnabled} onChange={value => { settings.store.keybindEnabled = value; }} />
             {keybindEnabled && (
-                <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <div className={cl("recording")}>
                     <Button type="button" variant="secondary" onClick={() => setIsListening(true)} disabled={isListening}>
                         {isListening ? "Recording..." : formatKeybind(keybind)}
                     </Button>
@@ -166,7 +170,7 @@ function isModifierKey(key: string) {
 }
 
 function matchesModifiers(event: KeyboardEvent, keybind: string[]) {
-    const expected = new Set(keybind.map(getModifierKey).filter(Boolean));
+    const expected = new Set(keybind.map(getModifierKey).filter(key => key !== null));
     const pressed = new Set<string>();
 
     if (event.ctrlKey) pressed.add("control");
@@ -229,7 +233,6 @@ function shouldIgnoreKeybindTarget(target: EventTarget | null) {
 
 const settings = definePluginSettings({
     keybind: {
-        description: "Keybind to hop to a random voice channel",
         type: OptionType.COMPONENT,
         default: DEFAULT_KEYBIND,
         component: ErrorBoundary.wrap(RandomVoiceKeybindSettings),
@@ -243,8 +246,11 @@ const settings = definePluginSettings({
     UserAmountOperation: {
         description: "Select an operation for the amounts of users",
         type: OptionType.SELECT,
-        options: [...operationOptions],
-        default: "<",
+        options: [
+            { label: "More than", value: "<", default: true },
+            { label: "Less than", value: ">", default: false },
+            { label: "Equal to", value: "==", default: false },
+        ],
     },
     UserAmount: {
         description: "Select amount of users",
@@ -256,8 +262,11 @@ const settings = definePluginSettings({
     spacesLeftOperation: {
         description: "Select an operation for the maximum amounts of users",
         type: OptionType.SELECT,
-        options: [...operationOptions],
-        default: "<",
+        options: [
+            { label: "More than", value: "<", default: true },
+            { label: "Less than", value: ">", default: false },
+            { label: "Equal to", value: "==", default: false },
+        ],
     },
     spacesLeft: {
         description: "Select amount of max users",
@@ -269,8 +278,11 @@ const settings = definePluginSettings({
     vcLimitOperation: {
         description: "Select an operation for the voice-channel.",
         type: OptionType.SELECT,
-        options: [...operationOptions],
-        default: "<",
+        options: [
+            { label: "More than", value: "<", default: true },
+            { label: "Less than", value: ">", default: false },
+            { label: "Equal to", value: "==", default: false },
+        ],
     },
     vcLimit: {
         description: "Select a voice-channel limit",

--- a/src/equicordplugins/randomVoice/index.tsx
+++ b/src/equicordplugins/randomVoice/index.tsx
@@ -7,6 +7,7 @@
 import { definePluginSettings } from "@api/Settings";
 import { UserAreaButton, UserAreaRenderProps } from "@api/UserArea";
 import { Button } from "@components/Button";
+import ErrorBoundary from "@components/ErrorBoundary";
 import { Switch } from "@components/Switch";
 import { debounce } from "@shared/debounce";
 import { Devs, EquicordDevs, IS_MAC } from "@utils/constants";
@@ -148,11 +149,10 @@ function matchesKeybind(event: KeyboardEvent) {
     const code = normalizeCode(event.code);
     let nonModifierMatched = false;
 
+    if (!matchesModifiers(event, keybind)) return false;
+
     for (const key of keybind) {
-        if (isModifierKey(key)) {
-            if (!isModifierPressed(event, key)) return false;
-            continue;
-        }
+        if (isModifierKey(key)) continue;
 
         if (pressed !== key && code !== key) return false;
         nonModifierMatched = true;
@@ -165,24 +165,36 @@ function isModifierKey(key: string) {
     return MODIFIER_KEYS.has(key.toLowerCase());
 }
 
-function isModifierPressed(event: KeyboardEvent, key: string) {
+function matchesModifiers(event: KeyboardEvent, keybind: string[]) {
+    const expected = new Set(keybind.map(getModifierKey).filter(Boolean));
+    const pressed = new Set<string>();
+
+    if (event.ctrlKey) pressed.add("control");
+    if (event.shiftKey) pressed.add("shift");
+    if (event.altKey) pressed.add("alt");
+    if (event.metaKey) pressed.add("meta");
+
+    return expected.size === pressed.size && [...expected].every(key => pressed.has(key));
+}
+
+function getModifierKey(key: string) {
     switch (key) {
         case "mod":
-            return IS_MAC ? event.metaKey : event.ctrlKey;
+            return IS_MAC ? "meta" : "control";
         case "control":
         case "ctrl":
-            return event.ctrlKey;
+            return "control";
         case "shift":
-            return event.shiftKey;
+            return "shift";
         case "alt":
         case "option":
-            return event.altKey;
+            return "alt";
         case "meta":
         case "cmd":
         case "command":
-            return event.metaKey;
+            return "meta";
         default:
-            return false;
+            return null;
     }
 }
 
@@ -220,7 +232,7 @@ const settings = definePluginSettings({
         description: "Keybind to hop to a random voice channel",
         type: OptionType.COMPONENT,
         default: DEFAULT_KEYBIND,
-        component: RandomVoiceKeybindSettings,
+        component: ErrorBoundary.wrap(RandomVoiceKeybindSettings),
     },
     keybindEnabled: {
         description: "Show the random voice keybind controls",

--- a/src/equicordplugins/randomVoice/styles.css
+++ b/src/equicordplugins/randomVoice/styles.css
@@ -1,0 +1,15 @@
+.vc-random-voice-record {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.vc-random-voice-keybind {
+    color: "var(--text-muted)"
+}
+
+.vc-random-voice-recording {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}


### PR DESCRIPTION
Title.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a configurable keybind to the RandomVoice plugin, allowing users to trigger `joinRandomVoice()` via a keyboard shortcut without clicking the button. The implementation includes a recording UI component in the settings panel, a global `keydown` listener registered in `start()`/`stop()`, and helper utilities for modifier normalisation and keybind matching.

- **Keybind recording** (`RandomVoiceKeybindSettings`): a `useEffect`-driven listener captures the first non-modifier key pressed after the user clicks "Record", stores it in `settings.store.keybind`, then tears down the listener. A blur handler cancels recording if the window loses focus.
- **Global dispatch** (`onKeyDown`): registered on `window` at plugin start; skips text inputs when no modifier is in the keybind, checks exact modifier parity via `matchesModifiers`, and calls `joinRandomVoice()` on a match.
- **CSS companion** (`styles.css`): provides layout for the recording UI row, but contains an invalid quoted colour value that prevents the `--text-muted` token from applying.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The keybind machinery is broadly correct but the stylesheet ships with a broken CSS declaration that silently drops the intended text colour.

The invalid quoted CSS value in styles.css means the --text-muted colour on the Keybind label never applies. Combined with unresolved issues from previous review rounds still present in the code, the change needs at least one more pass.

src/equicordplugins/randomVoice/styles.css (invalid CSS colour value) and src/equicordplugins/randomVoice/index.tsx (keybind recording and dispatch logic)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/equicordplugins/randomVoice/index.tsx | Adds keybind recording/dispatch logic, a settings UI component, and global keydown listener lifecycle. Contains a type-widening regression on RandomVoiceOperation. |
| src/equicordplugins/randomVoice/styles.css | New stylesheet for keybind UI. Line 8 has a quoted CSS value that is invalid and means the muted-text colour is never applied. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Component as RandomVoiceKeybindSettings
    participant Store as settings.store
    participant Window as window keydown
    participant Plugin as Plugin.onKeyDown
    participant Action as joinRandomVoice

    User->>Component: Clicks Record button
    Component->>Window: addEventListener keydown
    Note over Component: isRecordingKeybind = true
    User->>Window: Presses key combo
    Window->>Component: keydown event
    Component->>Store: "keybind = eventToKeybind(event)"
    Component->>Window: removeEventListener cleanup
    Note over Component: isRecordingKeybind = false

    User->>Window: Presses configured keybind
    Window->>Plugin: keydown event captured
    Plugin->>Plugin: "matchesKeybind = true"
    Plugin->>Action: joinRandomVoice()
    Action-->>User: selectVoiceChannel(channelId)
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix styles"](https://github.com/equicord/equicord/commit/98cfd6531c8a2ef4b5bd65bf31c9b93d0a6d1c11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32350205)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->