### PR TITLE
feat(TextReplace): add search and naming functionality for text replacement rules

### DIFF
--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -189,7 +189,7 @@ function TextReplace({ title, description, rulesArray, isRegex = false }: TextRe
         rulesArray[index][key] = e;
 
         // If a rule is empty after editing and is not the last rule, remove it
-        if (rulesArray[index].find === "" && rulesArray[index].replace === "" && rulesArray[index].onlyIfIncludes === "" && index !== rulesArray.length - 1) {
+        if (rulesArray[index].name === "" && rulesArray[index].find === "" && rulesArray[index].replace === "" && rulesArray[index].onlyIfIncludes === "" && index !== rulesArray.length - 1) {
             rulesArray.splice(index, 1);
         }
     }
@@ -231,7 +231,7 @@ function TextReplace({ title, description, rulesArray, isRegex = false }: TextRe
                                 <div className={cl("input-grid")}>
                                     <TextRow
                                         label="Name"
-                                        description="A name to help you identify this rule. This is optional"
+                                        description="An optional name to help you identify this rule."
                                         value={rule.name ?? ""}
                                         onChange={e => onChange(e, index, "name")}
                                     />
@@ -249,7 +249,7 @@ function TextReplace({ title, description, rulesArray, isRegex = false }: TextRe
                                     />
                                     <TextRow
                                         label="Only if includes"
-                                        description="This rule will only be applied if the message includes this text. This is optional"
+                                        description="Optionally, only apply this rule if the message includes this text."
                                         value={rule.onlyIfIncludes}
                                         onChange={e => onChange(e, index, "onlyIfIncludes")}
                                     />

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -35,7 +35,14 @@ import { React, Select, TextInput, UserStore, useState } from "@webpack/common";
 
 const cl = classNameFactory("vc-textReplace-");
 
-type Rule = Record<"find" | "replace" | "onlyIfIncludes" | "scope" | "id", string>;
+interface Rule {
+    name?: string;
+    find: string;
+    replace: string;
+    onlyIfIncludes: string;
+    scope: string;
+    id: string;
+}
 
 interface TextReplaceProps {
     title: string;
@@ -50,6 +57,7 @@ interface RuleWithIndex {
 }
 
 const makeEmptyRule: () => Rule = () => ({
+    name: "",
     find: "",
     replace: "",
     onlyIfIncludes: "",
@@ -159,9 +167,15 @@ const isEmptyRule = (rule: Rule) => !rule.find;
 function matchesRuleSearch(rule: Rule, query: string) {
     if (!query) return true;
 
-    const normalizedQuery = query.toLowerCase();
-    return [rule.find, rule.replace, rule.onlyIfIncludes]
+    const normalizedQuery = query.trim().toLowerCase();
+    return [rule.name ?? "", rule.find, rule.replace, rule.onlyIfIncludes]
         .some(value => value.toLowerCase().includes(normalizedQuery));
+}
+
+function normalizeRule(rule: Rule) {
+    rule.name ??= "";
+    rule.scope ??= "myMessages";
+    rule.id ??= crypto.randomUUID();
 }
 
 function TextReplace({ title, description, rulesArray, isRegex = false }: TextReplaceProps) {
@@ -216,6 +230,12 @@ function TextReplace({ title, description, rulesArray, isRegex = false }: TextRe
                             <>
                                 <div className={cl("input-grid")}>
                                     <TextRow
+                                        label="Name"
+                                        description="A name to help you identify this rule. This is optional"
+                                        value={rule.name ?? ""}
+                                        onChange={e => onChange(e, index, "name")}
+                                    />
+                                    <TextRow
                                         label="Find"
                                         description={isRegex ? "The regex pattern" : "The text to replace"}
                                         value={rule.find}
@@ -254,9 +274,11 @@ function TextReplace({ title, description, rulesArray, isRegex = false }: TextRe
                         )}
                     >
                         <Paragraph weight="medium" size="md">
-                            {isEmptyRule(rule)
-                                ? `Empty Rule ${index + 1}`
-                                : `Rule ${index + 1} - ${rule.find}`
+                            {rule.name
+                                ? rule.name
+                                : isEmptyRule(rule)
+                                    ? `Empty Rule ${index + 1}`
+                                    : `Rule ${index + 1} - ${rule.find}`
                             }
                         </Paragraph>
                     </ExpandableSection>
@@ -355,15 +377,8 @@ export default definePlugin({
     start() {
         const { stringRules, regexRules } = settings.store;
 
-        stringRules.forEach(rule => {
-            rule.scope ??= "myMessages";
-            rule.id ??= crypto.randomUUID();
-        });
-
-        regexRules.forEach(rule => {
-            rule.scope ??= "myMessages";
-            rule.id ??= crypto.randomUUID();
-        });
+        stringRules.forEach(normalizeRule);
+        regexRules.forEach(normalizeRule);
     },
 
     onBeforeMessageSend(channelId, msg) {

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -44,6 +44,11 @@ interface TextReplaceProps {
     isRegex?: boolean;
 }
 
+interface RuleWithIndex {
+    rule: Rule;
+    index: number;
+}
+
 const makeEmptyRule: () => Rule = () => ({
     find: "",
     replace: "",
@@ -151,7 +156,17 @@ function TextRow({ label, description, value, onChange }: { label: string; descr
 
 const isEmptyRule = (rule: Rule) => !rule.find;
 
+function matchesRuleSearch(rule: Rule, query: string) {
+    if (!query) return true;
+
+    const normalizedQuery = query.toLowerCase();
+    return [rule.find, rule.replace, rule.onlyIfIncludes]
+        .some(value => value.toLowerCase().includes(normalizedQuery));
+}
+
 function TextReplace({ title, description, rulesArray, isRegex = false }: TextReplaceProps) {
+    const [searchQuery, setSearchQuery] = useState("");
+
     function onClickRemove(index: number) {
         rulesArray.splice(index, 1);
     }
@@ -171,14 +186,30 @@ function TextReplace({ title, description, rulesArray, isRegex = false }: TextRe
         { label: "Apply to all messages", value: "allMessages" }
     ];
 
+    const filteredRules = rulesArray.reduce((acc: RuleWithIndex[], rule, index) => {
+        if (matchesRuleSearch(rule, searchQuery)) {
+            acc.push({ rule, index });
+        }
+
+        return acc;
+    }, []);
+
     return (
         <>
             <div>
                 <HeadingSecondary>{title}</HeadingSecondary>
                 <Paragraph>{description}</Paragraph>
+                <TextInput
+                    placeholder="Search for a rule..."
+                    value={searchQuery}
+                    onChange={setSearchQuery}
+                />
             </div>
             <Flex flexDirection="column" style={{ gap: "0.5em", paddingBottom: "1.25em" }}>
-                {rulesArray.map((rule, index) =>
+                {!filteredRules.length && searchQuery && (
+                    <Paragraph>No rules match your search criteria.</Paragraph>
+                )}
+                {filteredRules.map(({ rule, index }) =>
                     <ExpandableSection
                         key={rule.id}
                         renderContent={() => (
@@ -306,7 +337,7 @@ export default definePlugin({
     description: "Replace text in your messages. You can find pre-made rules in the #textreplace-rules channel in Vencord's Server",
     dependencies: ["MessagePopoverAPI"],
     tags: ["Chat", "Customisation", "Utility"],
-    authors: [Devs.AutumnVN, Devs.TheKodeToad, EquicordDevs.Etorix],
+    authors: [Devs.AutumnVN, Devs.TheKodeToad, EquicordDevs.Etorix, EquicordDevs.Ape],
     isModified: true,
     settings,
     modifyIncomingMessage,

--- a/src/plugins/textReplace/index.tsx
+++ b/src/plugins/textReplace/index.tsx
@@ -284,7 +284,10 @@ function TextReplace({ title, description, rulesArray, isRegex = false }: TextRe
                     </ExpandableSection>
                 )}
                 <Button
-                    onClick={() => rulesArray.push(makeEmptyRule())}
+                    onClick={() => {
+                        setSearchQuery("");
+                        rulesArray.push(makeEmptyRule());
+                    }}
                     disabled={rulesArray.length > 0 && isEmptyRule(rulesArray[rulesArray.length - 1])}
                 >
                     Add Rule


### PR DESCRIPTION
added search for rules and name (optional)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a `name` field (optional) to text replacement rules and a per-section search bar that filters rules by name, find, replace, or "only if includes" text. The two previously flagged blocking issues — an orphaned rule when adding during an active search, and silent deletion of a named-but-empty rule — are both resolved in this revision.

- A `name?: string` field is added to the `Rule` interface, with `normalizeRule` back-filling it for saved rules on startup, and the label now prefers the rule name over the index-based fallback.
- A `searchQuery` state and `filteredRules` derived array drive the filtered display; \"Add Rule\" now clears the query before pushing so the new rule is always visible.
- The auto-remove heuristic now requires `name === \"\"` in addition to the other empty-field checks, preventing accidental deletion of named rules that haven't yet filled in `find`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR is safe to merge. Both previously flagged bugs have been correctly addressed, and no new defects were introduced.

The two blocking issues from earlier review rounds — the orphaned empty rule when adding during an active search, and the silent deletion of a named rule when its find field is empty — are both correctly resolved. The name field migration in normalizeRule correctly back-fills existing saved rules on startup. The matchesRuleSearch helper handles edge cases correctly. No regressions were found in the apply-rules path.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/plugins/textReplace/index.tsx | Adds optional rule naming, per-section search/filter, and fixes two previously flagged bugs (orphaned rule on add-during-search; silent rule deletion on name edit). All new descriptions follow the style guide period rule. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens TextReplace settings] --> B{searchQuery empty?}
    B -- Yes --> C[Show all rulesArray entries]
    B -- No --> D[matchesRuleSearch: check name / find / replace / onlyIfIncludes]
    D --> E[filteredRules with original indices]
    E --> F{any match?}
    F -- No --> G[Show 'No rules match' message]
    F -- Yes --> H[Render ExpandableSection for each filtered rule]
    H --> I{rule.name set?}
    I -- Yes --> J[Header = rule.name]
    I -- No --> K{isEmptyRule?}
    K -- Yes --> L[Header = 'Empty Rule N']
    K -- No --> M[Header = 'Rule N - find text']
    H --> N[onChange mutates rulesArray at original index]
    N --> O{all fields empty AND not last?}
    O -- Yes --> P[splice rule out]
    O -- No --> Q[keep rule]
    R[Add Rule button clicked] --> S[setSearchQuery '' then push makeEmptyRule]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/plugins/textReplace/index.tsx`, line 188-194 ([link](https://github.com/equicord/equicord/blob/d54c4d7725f64feaf5f8bc18a8a183ad0e22961d/src/plugins/textReplace/index.tsx#L188-L194)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Named rule silently deleted on name edit**

   `onChange` auto-removes a rule when `find`, `replace`, and `onlyIfIncludes` are all empty — but the new `name` field is not checked. If a user has a named rule (with `find` still empty) that isn't the last in the list, editing the `name` field then blurring will trigger the splice and silently destroy the rule. The fix is to also require `name` to be empty (or falsy) before auto-removing.

2. `src/plugins/textReplace/index.tsx`, line 286-291 ([link](https://github.com/equicord/equicord/blob/f8e3cf34952f1c6224e3f4c44ba34dd0d3f91d48/src/plugins/textReplace/index.tsx#L286-L291)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Add Rule while search is active creates an invisible, orphaned rule**

   When `searchQuery` is non-empty, clicking "Add Rule" pushes a new `makeEmptyRule()` to `rulesArray`. Because all its fields are empty strings, `matchesRuleSearch` returns `false` for any non-empty query, so the rule never appears in `filteredRules`. The user sees nothing change. On the very next render `isEmptyRule(rulesArray[rulesArray.length - 1])` becomes `true`, so the button silently disables itself — trapping the user in a state where "Add Rule" is greyed out but no rule is visible. They'd have to clear the search bar to find the hidden empty rule. The simplest fix is to call `setSearchQuery("")` inside the `onClick` handler before pushing the new rule.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["feat(TextReplace): handle new rules whil..."](https://github.com/equicord/equicord/commit/af16358bc01144c53eb6e852c6349288aedd44d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32840409)</sub>

<!-- /greptile_comment -->