### PR TITLE
Patch Fixes.

### DIFF
--- a/src/equicordplugins/questify/index.tsx
+++ b/src/equicordplugins/questify/index.tsx
@@ -353,8 +353,8 @@ export default definePlugin({
             find: "QUESTS_BAR,questId",
             predicate: () => !getQuestifySettings().disableQuestsEverything && hasEnabledAutoCompleteQuestTypes(),
             replacement: {
-                match: /(?<=SELECT&&!\i&&!\i,\i=\i\.\i\.useConfig\({location:\i\.\i\.QUESTS_BAR}\),\i=\(0,\i\.\i\)\((\i)\);)(if\()(.{0,300}?let (\i)=null;return )/,
-                replace: 'const questifyButton=$self.enrolledIncompleteButton({quest:$1,size:"sm"});$2!questifyButton&&$3questifyButton?$4=questifyButton:'
+                match: /(?<=SELECT&&!\i&&!\i,(\i)=null;)(return )(\i\?\i=\(0,\i.\i\)\(\i,{quest:(\i))/,
+                replace: "const questifyButton=$self.enrolledIncompleteButton({quest:$4});$2questifyButton?$1=questifyButton:$3"
             }
         },
         {
@@ -367,7 +367,7 @@ export default definePlugin({
             }
         },
         {
-            find: ".rowIndex,trackGuildAndChannelMetadata",
+            find: "return`quest-tile-",
             group: true,
             predicate: () => !getQuestifySettings().disableQuestsEverything,
             replacement: [
@@ -410,7 +410,7 @@ export default definePlugin({
             ]
         },
         {
-            find: ".rowIndex,trackGuildAndChannelMetadata",
+            find: "return`quest-tile-",
             group: true,
             predicate: () => !getQuestifySettings().disableQuestsEverything,
             replacement: [

--- a/src/equicordplugins/questify/index.tsx
+++ b/src/equicordplugins/questify/index.tsx
@@ -354,7 +354,7 @@ export default definePlugin({
             predicate: () => !getQuestifySettings().disableQuestsEverything && hasEnabledAutoCompleteQuestTypes(),
             replacement: {
                 match: /(?<=SELECT&&!\i&&!\i,(\i)=null;)(return )(\i\?\i=\(0,\i.\i\)\(\i,{quest:(\i))/,
-                replace: "const questifyButton=$self.enrolledIncompleteButton({quest:$4});$2questifyButton?$1=questifyButton:$3"
+                replace: "const questifyButton=$self.enrolledIncompleteButton({quest:$4,size:\"sm\"});$2questifyButton?$1=questifyButton:$3"
             }
         },
         {


### PR DESCRIPTION
Title.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes three Webpack patch anchors in the Questify plugin that broke after a Discord bundle reshuffle.

- The Quest-bar button patch regex is replaced with a tighter pattern that matches Discord's new bundle layout; `size:\"sm\"` is correctly preserved in the replacement, and the ternary injection logic is simplified.
- Two quest-tile patches previously anchored on the now-missing `.rowIndex,trackGuildAndChannelMetadata` token are re-anchored to `return\`quest-tile-\``, the stable template-literal prefix that already serves as the find string for the other tile patches in the file.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three changes are targeted regex/find-string fixes with no logic changes outside the patching layer.

The Quest-bar regex is narrowly scoped and still passes size:"sm" through. The two tile patches move to a find string that already anchors other patches in the same file successfully. No runtime logic, settings, or component behaviour outside the patch replacements is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/equicordplugins/questify/index.tsx | Three patch anchor updates: Quest-bar button regex modernised with size:"sm" preserved; two tile patches re-anchored from the defunct .rowIndex,trackGuildAndChannelMetadata find to the stable return`quest-tile- literal. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Prop."](https://github.com/equicord/equicord/commit/c3ac83b5eceacdab36f7d98fdf5baaba88c6274e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32898095)</sub>

<!-- /greptile_comment -->