### PR TITLE
fix(commandPalette): fix visual fixes caused by modal migration

### DIFF
--- a/src/equicordplugins/commandPalette/CommandPicker.tsx
+++ b/src/equicordplugins/commandPalette/CommandPicker.tsx
@@ -7,8 +7,10 @@
 import { CogWheel } from "@components/Icons";
 import { classNameFactory } from "@utils/css";
 import { classes } from "@utils/misc";
-import { type ModalProps,ModalRoot, ModalSize, openModal } from "@utils/modal";
+import { ModalRoot, ModalSize, openModal } from "@utils/modal";
+import { RenderModalProps } from "@vencord/discord-types";
 import { TextInput, useCallback, useEffect, useMemo, useRef, useState } from "@webpack/common";
+import type { ComponentType, ReactNode } from "react";
 
 import {
     type CommandEntry, getCategoryGroupLabel, getCategoryWeight, getCommandSearchText, getRecentRank, getRegistryVersion, listCommands, subscribeRegistry
@@ -36,6 +38,7 @@ const getNextSelectableIndex = (start: number, direction: 1 | -1, items: PickerI
 
 const cl = classNameFactory("vc-command-palette-");
 const cn = classNameFactory();
+const LegacyModalRoot = ModalRoot as ComponentType<RenderModalProps & { children?: ReactNode; className?: string; size?: ModalSize; }>;
 
 interface CommandPickerProps {
     commands?: CommandEntry[];
@@ -56,7 +59,7 @@ export function openCommandPicker(props: CommandPickerProps) {
     ));
 }
 
-function CommandPickerModal({ modalProps, commands: providedCommands, allowMultiple = false, initialQuery = "", initialSelectedIds = [], includeHiddenInSearch = false, emptyStateText = "No commands found", filter: filterPredicate, onSelect, onComplete, onClose }: CommandPickerProps & { modalProps: ModalProps; }) {
+function CommandPickerModal({ modalProps, commands: providedCommands, allowMultiple = false, initialQuery = "", initialSelectedIds = [], includeHiddenInSearch = false, emptyStateText = "No commands found", filter: filterPredicate, onSelect, onComplete, onClose }: CommandPickerProps & { modalProps: RenderModalProps; }) {
     const [query, setQuery] = useState(initialQuery);
     const [registryVersion, setRegistryVersion] = useState(() => getRegistryVersion());
     const [selectedIndex, setSelectedIndex] = useState(-1);
@@ -321,7 +324,7 @@ function CommandPickerModal({ modalProps, commands: providedCommands, allowMulti
     };
 
     return (
-        <ModalRoot {...modalProps} size={ModalSize.SMALL} className={classes(cn("vc-command-palette"), cl("picker"))}>
+        <LegacyModalRoot {...modalProps} size={ModalSize.SMALL} className={classes(cn("vc-command-palette"), cl("picker"))}>
             <div className={classes(cl("shell"), cl("picker-shell"))} onKeyDown={handleKeyDown}>
                 <div className={cl("input")}>
                     <TextInput
@@ -373,6 +376,6 @@ function CommandPickerModal({ modalProps, commands: providedCommands, allowMulti
                     })}
                 </div>
             </div>
-        </ModalRoot>
+        </LegacyModalRoot>
     );
 }

--- a/src/equicordplugins/commandPalette/CommandPicker.tsx
+++ b/src/equicordplugins/commandPalette/CommandPicker.tsx
@@ -7,8 +7,8 @@
 import { CogWheel } from "@components/Icons";
 import { classNameFactory } from "@utils/css";
 import { classes } from "@utils/misc";
-import { RenderModalProps } from "@vencord/discord-types";
-import { Modal,openModal, TextInput, useCallback, useEffect, useMemo, useRef, useState } from "@webpack/common";
+import { type ModalProps,ModalRoot, ModalSize, openModal } from "@utils/modal";
+import { TextInput, useCallback, useEffect, useMemo, useRef, useState } from "@webpack/common";
 
 import {
     type CommandEntry, getCategoryGroupLabel, getCategoryWeight, getCommandSearchText, getRecentRank, getRegistryVersion, listCommands, subscribeRegistry
@@ -56,7 +56,7 @@ export function openCommandPicker(props: CommandPickerProps) {
     ));
 }
 
-function CommandPickerModal({ modalProps, commands: providedCommands, allowMultiple = false, initialQuery = "", initialSelectedIds = [], includeHiddenInSearch = false, emptyStateText = "No commands found", filter: filterPredicate, onSelect, onComplete, onClose }: CommandPickerProps & { modalProps: RenderModalProps; }) {
+function CommandPickerModal({ modalProps, commands: providedCommands, allowMultiple = false, initialQuery = "", initialSelectedIds = [], includeHiddenInSearch = false, emptyStateText = "No commands found", filter: filterPredicate, onSelect, onComplete, onClose }: CommandPickerProps & { modalProps: ModalProps; }) {
     const [query, setQuery] = useState(initialQuery);
     const [registryVersion, setRegistryVersion] = useState(() => getRegistryVersion());
     const [selectedIndex, setSelectedIndex] = useState(-1);
@@ -321,8 +321,8 @@ function CommandPickerModal({ modalProps, commands: providedCommands, allowMulti
     };
 
     return (
-        <Modal {...modalProps} size="sm" title="Command Picker">
-            <div className={classes(cl("shell"), cl("picker-shell"), cn("vc-command-palette"), cl("picker"))} onKeyDown={handleKeyDown}>
+        <ModalRoot {...modalProps} size={ModalSize.SMALL} className={classes(cn("vc-command-palette"), cl("picker"))}>
+            <div className={classes(cl("shell"), cl("picker-shell"))} onKeyDown={handleKeyDown}>
                 <div className={cl("input")}>
                     <TextInput
                         autoFocus
@@ -373,6 +373,6 @@ function CommandPickerModal({ modalProps, commands: providedCommands, allowMulti
                     })}
                 </div>
             </div>
-        </Modal>
+        </ModalRoot>
     );
 }

--- a/src/equicordplugins/commandPalette/style.css
+++ b/src/equicordplugins/commandPalette/style.css
@@ -62,11 +62,14 @@
 }
 
 .vc-command-palette-main-input input {
+    width: 100% !important;
+    box-sizing: border-box !important;
     background: transparent !important;
     border: none !important;
     color: var(--cp-text-primary) !important;
     font-size: 20px !important;
     font-weight: 400 !important;
+    line-height: 48px !important;
     padding: 0 0 2px !important;
     min-height: 48px !important;
     height: 48px !important;

--- a/src/equicordplugins/commandPalette/ui.tsx
+++ b/src/equicordplugins/commandPalette/ui.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { closeModal, openModal } from "@webpack/common";
+import { closeModal, openModal } from "@utils/modal";
 
 import { CommandPaletteModal } from "./ui/CommandPaletteModal";
 

--- a/src/equicordplugins/commandPalette/ui/CommandPaletteModal.tsx
+++ b/src/equicordplugins/commandPalette/ui/CommandPaletteModal.tsx
@@ -11,9 +11,10 @@ import { classNameFactory, classNameToSelector } from "@utils/css";
 import { copyWithToast } from "@utils/discord";
 import { Logger } from "@utils/Logger";
 import { classes } from "@utils/misc";
-import { type ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import { ModalRoot, ModalSize } from "@utils/modal";
+import { RenderModalProps } from "@vencord/discord-types";
 import { TextInput, Toasts, useEffect, useMemo, useRef, useState } from "@webpack/common";
-import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import type { ComponentType, KeyboardEvent as ReactKeyboardEvent, ReactNode } from "react";
 
 import { buildQueryResolution } from "../actions/executors";
 import { resolveCalculatorQuery } from "../calculator";
@@ -82,6 +83,8 @@ const SINGLE_SELECT_PROMPT_COMMAND_IDS = new Set([
 const logger = new Logger("CommandPaletteModal");
 const cl = classNameFactory("vc-command-palette-");
 const cn = classNameFactory();
+// TODO: Fully migrate this modal to the new Discord modal API and update the palette CSS around the new structure.
+const LegacyModalRoot = ModalRoot as ComponentType<RenderModalProps & { children?: ReactNode; className?: string; size?: ModalSize; }>;
 const promptActiveSelector = classNameToSelector(cl("prompt-active-input"));
 const mainInputSelectorClass = classNameToSelector(cl("main-input"));
 const pageSelector = classNameToSelector(cl("page"));
@@ -282,7 +285,7 @@ function createInitialPageState(ref: PalettePageRef): PalettePageValuesState {
     };
 }
 
-export function CommandPaletteModal({ modalProps, instanceKey }: { modalProps: ModalProps; instanceKey: number; }) {
+export function CommandPaletteModal({ modalProps, instanceKey }: { modalProps: RenderModalProps; instanceKey: number; }) {
     const {
         compactStartEnabled = true,
         closeAfterExecute = true
@@ -1469,7 +1472,7 @@ export function CommandPaletteModal({ modalProps, instanceKey }: { modalProps: M
     }, [activePage, activePageFieldKey, activePageSpec, activePageState, activePageSuggestions]);
 
     return (
-        <ModalRoot
+        <LegacyModalRoot
             {...modalProps}
             className={cn("vc-command-palette", compact && cl("compact"))}
             size={compact ? ModalSize.SMALL : ModalSize.LARGE}
@@ -1656,6 +1659,6 @@ export function CommandPaletteModal({ modalProps, instanceKey }: { modalProps: M
                     />
                 )}
             </div>
-        </ModalRoot>
+        </LegacyModalRoot>
     );
 }

--- a/src/equicordplugins/commandPalette/ui/CommandPaletteModal.tsx
+++ b/src/equicordplugins/commandPalette/ui/CommandPaletteModal.tsx
@@ -11,8 +11,8 @@ import { classNameFactory, classNameToSelector } from "@utils/css";
 import { copyWithToast } from "@utils/discord";
 import { Logger } from "@utils/Logger";
 import { classes } from "@utils/misc";
-import { RenderModalProps } from "@vencord/discord-types";
-import { Modal,TextInput, Toasts, useEffect, useMemo, useRef, useState } from "@webpack/common";
+import { type ModalProps, ModalRoot, ModalSize } from "@utils/modal";
+import { TextInput, Toasts, useEffect, useMemo, useRef, useState } from "@webpack/common";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
 import { buildQueryResolution } from "../actions/executors";
@@ -282,7 +282,7 @@ function createInitialPageState(ref: PalettePageRef): PalettePageValuesState {
     };
 }
 
-export function CommandPaletteModal({ modalProps, instanceKey }: { modalProps: RenderModalProps; instanceKey: number; }) {
+export function CommandPaletteModal({ modalProps, instanceKey }: { modalProps: ModalProps; instanceKey: number; }) {
     const {
         compactStartEnabled = true,
         closeAfterExecute = true
@@ -1469,12 +1469,12 @@ export function CommandPaletteModal({ modalProps, instanceKey }: { modalProps: R
     }, [activePage, activePageFieldKey, activePageSpec, activePageState, activePageSuggestions]);
 
     return (
-        <Modal
+        <ModalRoot
             {...modalProps}
-            size={compact ? "sm" : "lg"}
-            title="Command Palette"
+            className={cn("vc-command-palette", compact && cl("compact"))}
+            size={compact ? ModalSize.SMALL : ModalSize.LARGE}
         >
-            <div className={cn("vc-command-palette", cl("shell"), compact && cl("compact"))} onKeyDown={onKeyDown}>
+            <div className={cl("shell")} onKeyDown={onKeyDown}>
                 {!isPageOpen && (
                     <CommandPaletteInput
                         inputRef={mainInputRef}
@@ -1656,6 +1656,6 @@ export function CommandPaletteModal({ modalProps, instanceKey }: { modalProps: R
                     />
                 )}
             </div>
-        </Modal>
+        </ModalRoot>
     );
 }


### PR DESCRIPTION
please thor just merge

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reverts the command palette from the new `Modal` component (`@webpack/common`) back to the legacy `ModalRoot` from `@utils/modal`, fixing layout/visual regressions introduced by the previous modal migration. A few CSS properties are added to the main input rule to correct width and line-height issues exposed by the structural change.

- **`CommandPicker.tsx` / `CommandPaletteModal.tsx`**: Replace `<Modal>` with a locally-cast `LegacyModalRoot`, moving the `vc-command-palette` class from the inner shell `<div>` to the modal root itself to restore correct sizing and class scoping.
- **`style.css`**: Adds `width: 100%`, `box-sizing: border-box`, and `line-height: 48px` (all `!important`) to `.vc-command-palette-main-input input` to fix the input overflow and height regression.
- **`ui.tsx`**: Updates `closeModal`/`openModal` imports to `@utils/modal` for consistency with the revert.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the change is a targeted revert of a modal migration that caused visual regressions, with no logic changes outside of the modal wrapper.

All four changed files make straightforward substitutions — swapping Modal for LegacyModalRoot, updating import sources, and patching a handful of CSS properties. The only finding is an added TODO comment that violates the project style rule but has no runtime impact.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/equicordplugins/commandPalette/CommandPicker.tsx | Reverts to legacy ModalRoot from @utils/modal; adds LegacyModalRoot cast and moves class names from inner div to modal root. Intentional regression to fix visual issues; no logic errors found. |
| src/equicordplugins/commandPalette/ui/CommandPaletteModal.tsx | Same legacy-modal revert as CommandPicker; new TODO comment added, violating the "never add comments unless asked" rule. |
| src/equicordplugins/commandPalette/ui.tsx | Switches closeModal/openModal import source from @webpack/common to @utils/modal to be consistent with the rest of the revert; no issues. |
| src/equicordplugins/commandPalette/style.css | Adds width: 100%, box-sizing: border-box, and line-height: 48px (all !important) to the main input rule, fixing overflow and sizing regressions introduced by the modal migration. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant K as Keybind
    participant U as ui.tsx
    participant CM as CommandPaletteModal
    participant CP as CommandPicker
    participant LMR as LegacyModalRoot (@utils/modal)

    K->>U: trigger shortcut
    U->>U: "openModal() from @utils/modal"
    U->>CM: render CommandPaletteModal(modalProps)
    CM->>LMR: "LegacyModalRoot size=SMALL|LARGE className=vc-command-palette"
    LMR-->>CM: modal shell rendered

    K->>U: close shortcut / Escape
    U->>U: "closeModal() from @utils/modal"

    note over CP: CommandPicker uses same LegacyModalRoot path
    CP->>LMR: "LegacyModalRoot size=SMALL className=vc-command-palette vc-command-palette-picker"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Fix command palette legacy modal visuals"](https://github.com/equicord/equicord/commit/f462903ac0be66182000011ef682dcb9ad4e206c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32918627)</sub>

**Context used:**

- Context used - .rules ([source](https://app.greptile.com/review/custom-context?memory=fcad107d-4d07-4fb5-9ff0-b425e41d5d1e))

<!-- /greptile_comment -->