### PR TITLE
Questify & SMYN: Has Selector & Stuff.

### DIFF
--- a/src/equicordplugins/questify/components/shared.tsx
+++ b/src/equicordplugins/questify/components/shared.tsx
@@ -351,6 +351,8 @@ function SettingsTooltip({
                 position={position}
                 color="brand"
                 tooltipStyle={{ maxWidth: wider ? "602px" : "350px" }}
+                tooltipClassName={q("settings-tooltip")}
+                tooltipPointerClassName={q("settings-tooltip-pointer")}
                 tooltipContentClassName={q("settings-tooltip-content")}
                 delay={50}
             >

--- a/src/equicordplugins/questify/styles.css
+++ b/src/equicordplugins/questify/styles.css
@@ -74,7 +74,7 @@
     line-height: 0.2em;
 }
 
-[class*="clickTrapContainer"] > div > div:has(.questify-settings-tooltip-content) {
+[class*="clickTrapContainer"] > div > .questify-settings-tooltip {
     margin-right: 4px;
 }
 

--- a/src/plugins/showMeYourName/index.tsx
+++ b/src/plugins/showMeYourName/index.tsx
@@ -1132,8 +1132,8 @@ export default definePlugin({
             // Replace name in solo DM title bar and tooltip.
             find: "channel.isSystemDM(),",
             replacement: {
-                match: /(?<=}\);)(return.{0,500}?{text:)(\i,position:"bottom",children:.{0,40}?children:)(\i\?\?\i.\i.getName\(\i\))/,
-                replace: "const smynName=arguments[0].channel.recipients.length===1?$self.getTypingMemberListProfilesReactionsVoiceNameText({user:$self.UserStore.getUser(arguments[0].channel.recipients[0]),type:\"profilesPopout\"})??null:null;$1smynName??$2smynName??$3"
+                match: /(?<=length>0,)(\i=)(.{0,280}?"aria-label":)(\i.\i.getName\(\i\).{0,400}?text:)/,
+                replace: "smynName=arguments[0].channel.recipients.length===1?$self.getTypingMemberListProfilesReactionsVoiceNameText({user:$self.UserStore.getUser(arguments[0].channel.recipients[0]),type:\"profilesPopout\"})??null:null,$1smynName??$2smynName??$3smynName??"
             },
         },
         {


### PR DESCRIPTION
Title.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes two targeted changes: the Questify plugin gains explicit CSS class hooks on the tooltip container and pointer (via new `tooltipClassName`/`tooltipPointerClassName` props), letting the stylesheet use a direct class selector instead of `:has()`; and the ShowMeYourName plugin updates its solo-DM title-bar patch to match a new Discord bundle layout.

- **questify/shared.tsx + styles.css**: `tooltipClassName` and `tooltipPointerClassName` are added to `ManaTooltip`, and the CSS selector is simplified from `[class*=\"clickTrapContainer\"] > div > div:has(.questify-settings-tooltip-content)` to `[class*=\"clickTrapContainer\"] > div > .questify-settings-tooltip`. The trailing newline was accidentally dropped from the CSS file.
- **showMeYourName/index.tsx**: The DM title-bar patch match anchor shifts from a post-`return` statement site to a comma-expression site (`(?<=length>0,)`), and the replacement changes from `const smynName=...;` to bare `smynName=...` — relying on the surrounding minified code being a `var` declaration list for the variable to be implicitly scoped.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

The Questify changes are safe; the SMYN patch change warrants verification before merging.

The SMYN DM title-bar patch injects `smynName=...` into a comma-expression without declaring the variable. If the surrounding minified code turns out not to be a `var` declaration list, the assignment hits an undeclared identifier in strict-mode and the entire DM title bar name feature silently breaks for all users. The two Questify files are clean and low-risk.

src/plugins/showMeYourName/index.tsx — specifically the new match anchor and replacement string around line 1135.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/plugins/showMeYourName/index.tsx | Patch for solo DM title bar name replacement updated with a new match anchor and comma-expression injection; injects `smynName=` without an explicit variable declaration, which may fail in strict-mode if the runtime context is not a `var` declaration list. |
| src/equicordplugins/questify/components/shared.tsx | Adds `tooltipClassName` and `tooltipPointerClassName` props to `ManaTooltip` in `SettingsTooltip`, giving the CSS a direct class handle on the tooltip container and pointer; straightforward and clean. |
| src/equicordplugins/questify/styles.css | CSS selector updated from `:has(.questify-settings-tooltip-content)` to the direct class `.questify-settings-tooltip` (more performant and explicit); trailing newline inadvertently removed. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SettingsTooltip (shared.tsx)"] -->|tooltipClassName| B[".questify-settings-tooltip"]
    A -->|tooltipPointerClassName| C[".questify-settings-tooltip-pointer"]
    A -->|tooltipContentClassName| D[".questify-settings-tooltip-content"]
    B --> E["CSS selector simplified to direct class match"]
    F["SMYN patch: channel.isSystemDM()"] -->|"(?<=length>0,) anchor"| G["Comma-expression injection"]
    G --> H["smynName = getCustomName() ?? null"]
    H --> I["aria-label, text: fields use smynName"]
    H --> J["DM title bar display updated"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix SMYN."](https://github.com/equicord/equicord/commit/83c09c5e6ca4821eb5ffe8278364c1149ba012f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32930199)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->