### PR TITLE
Adjust EyeIcon size and styles in hideMessages component

### DIFF
--- a/src/equicordplugins/hideMessages/index.tsx
+++ b/src/equicordplugins/hideMessages/index.tsx
@@ -149,7 +149,7 @@ export default definePlugin({
                         role="button"
                         tabIndex={0}
                         aria-label={label}
-                        style={{ height: "16px", marginRight: "0.2rem" }}
+                        style={{ width: "16px", height: "16px", marginRight: "0.2rem", display: "flex", alignItems: "center", justifyContent: "center" }}
                         aria-disabled={!hasHiddenDms}
                         onClick={event => {
                             event.preventDefault();
@@ -159,7 +159,7 @@ export default definePlugin({
                             notifyHiddenDmsUpdate();
                         }}
                     >
-                        <EyeIcon width={16} height={16} />
+                        <EyeIcon width={14} height={14} />
                     </Clickable>
                 )}
             </Tooltip>

--- a/src/equicordplugins/hideMessages/index.tsx
+++ b/src/equicordplugins/hideMessages/index.tsx
@@ -149,6 +149,7 @@ export default definePlugin({
                         role="button"
                         tabIndex={0}
                         aria-label={label}
+                        style={{ height: "16px", marginRight: "0.2rem" }}
                         aria-disabled={!hasHiddenDms}
                         onClick={event => {
                             event.preventDefault();
@@ -158,7 +159,7 @@ export default definePlugin({
                             notifyHiddenDmsUpdate();
                         }}
                     >
-                        <EyeIcon width={18} height={18} />
+                        <EyeIcon width={16} height={16} />
                     </Clickable>
                 )}
             </Tooltip>

--- a/src/equicordplugins/hideMessages/index.tsx
+++ b/src/equicordplugins/hideMessages/index.tsx
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import "./styles.css";
+
 import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
 import { isPluginEnabled } from "@api/PluginManager";
 import { definePluginSettings } from "@api/Settings";
@@ -12,6 +14,7 @@ import { EyeIcon } from "@components/Icons";
 import pinDms from "@plugins/pinDms";
 import { isPinned } from "@plugins/pinDms/data";
 import { EquicordDevs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
 import definePlugin, { OptionType } from "@utils/types";
 import { Channel, Message } from "@vencord/discord-types";
 import { ChannelStore, Clickable, FluxDispatcher, Menu, Tooltip } from "@webpack/common";
@@ -24,6 +27,7 @@ interface PrivateChannelsListInstance {
     forceUpdate(callback?: () => void): void;
 }
 
+const cl = classNameFactory("vc-hide-messages-");
 const hiddenDmIds = new Set<string>();
 let privateChannelsListInstance: PrivateChannelsListInstance | null = null;
 let showHiddenDms = false;
@@ -146,10 +150,10 @@ export default definePlugin({
                 {tooltipProps => (
                     <Clickable
                         {...tooltipProps}
+                        className={cl("eye")}
                         role="button"
                         tabIndex={0}
                         aria-label={label}
-                        style={{ width: "16px", height: "16px", marginRight: "0.2rem", display: "flex", alignItems: "center", justifyContent: "center" }}
                         aria-disabled={!hasHiddenDms}
                         onClick={event => {
                             event.preventDefault();

--- a/src/equicordplugins/hideMessages/styles.css
+++ b/src/equicordplugins/hideMessages/styles.css
@@ -1,0 +1,8 @@
+.vc-hide-messages-eye {
+    width: 16px;
+    height: 16px;
+    margin-right: 0.2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}


### PR DESCRIPTION
Before:
<img width="292" height="37" alt="Discord_uRl9fZBRCs" src="https://github.com/user-attachments/assets/436ca4e6-c85b-4797-a68d-0596ee0b0189" />

After:
<img width="283" height="36" alt="Discord_8Zgx4mIppR" src="https://github.com/user-attachments/assets/9188e698-5f50-4610-a232-6aff2057907d" />

You can adjust the padding if you want.. I made it 0.2 because it looks fine to me.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts the `EyeIcon` in the `hideMessages` plugin: it reduces the icon size from 18×18 to 14×14 px, extracts the previously inline styles into a new `styles.css` file, and wires up a `classNameFactory` for the CSS class — addressing the feedback from the prior review round.

- **`index.tsx`**: Adds `import "./styles.css"`, introduces `classNameFactory("vc-hide-messages-")` as `cl`, applies `className={cl("eye")}` to the `Clickable` wrapper, and shrinks `EyeIcon` to 14×14 px.
- **`styles.css`**: New file with `.vc-hide-messages-eye` that sets the container to 16×16 px, centers content with flexbox, and adds `margin-right: 0.2rem` for spacing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are purely visual, scoped to a single plugin, and carry no logic risk.

The change is a straightforward cosmetic adjustment: an icon size reduction and a stylesheet extraction. No logic, data handling, or API interactions are modified.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/equicordplugins/hideMessages/index.tsx | Moves static eye icon styles out of inline JSX into a CSS class via classNameFactory; shrinks EyeIcon from 18x18 to 14x14 px. Clean adoption of the project's CSS utilities. |
| src/equicordplugins/hideMessages/styles.css | New stylesheet for the plugin. Correctly prefixed with .vc-hide-messages-. Missing trailing newline at EOF. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["renderHiddenMessagesToggle()"] --> B["ErrorBoundary.wrap"]
    B --> C["Tooltip"]
    C --> D["Clickable .vc-hide-messages-eye 16x16px container"]
    D --> E["EyeIcon 14x14px"]
    F["styles.css"] -- "imported at module top" --> A
```
</details>

<sub>Reviews (2): Last reviewed commit: ["t"](https://github.com/equicord/equicord/commit/b4ed5bf6b3a51da645899c5f0157ad24d70d17bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33015242)</sub>

<!-- /greptile_comment -->