### PR TITLE
feat(plugins): add MessageBookmarks and MessageInsight

### DIFF
--- a/src/equicordplugins/messageBookmarks/BookmarksModal.tsx
+++ b/src/equicordplugins/messageBookmarks/BookmarksModal.tsx
@@ -1,0 +1,216 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { findByPropsLazy } from "@webpack";
+import { ChannelStore, GuildStore, Modal, React, useEffect, useState } from "@webpack/common";
+
+import { getBookmarks, saveBookmarks } from "./store";
+import type { Bookmark, BookmarkCategory } from "./types";
+
+const jumper = findByPropsLazy("jumpToMessage");
+
+const NEXT_CATEGORY: Record<BookmarkCategory, BookmarkCategory> = {
+    general: "important",
+    important: "later",
+    later: "general",
+};
+
+function categoryLabel(cat: BookmarkCategory): string {
+    if (cat === "important") return "Important";
+    if (cat === "later") return "Later";
+    return "General";
+}
+
+function avatarUrl(authorId: string, avatar: string | null | undefined): string {
+    if (!avatar) {
+        const index = Number(BigInt(authorId) >> 22n) % 6;
+        return `https://cdn.discordapp.com/embed/avatars/${index}.png`;
+    }
+    const ext = avatar.startsWith("a_") ? "gif" : "png";
+    return `https://cdn.discordapp.com/avatars/${authorId}/${avatar}.${ext}?size=32`;
+}
+
+function relativeTime(savedAt: number): string {
+    const min = Math.floor((Date.now() - savedAt) / 60000);
+    if (min < 1) return "just now";
+    if (min < 60) return `${min}m ago`;
+    const h = Math.floor(min / 60);
+    if (h < 24) return `${h}h ago`;
+    const d = Math.floor(h / 24);
+    return `${d}d ago`;
+}
+
+export function BookmarksModal({ modalProps }: { modalProps: any; }) {
+    const [bookmarks, setBookmarks] = useState<Bookmark[]>([]);
+    const [search, setSearch] = useState("");
+    const [activeTab, setActiveTab] = useState<BookmarkCategory | "all">("all");
+
+    useEffect(() => {
+        getBookmarks().then(setBookmarks);
+    }, []);
+
+    const filtered = bookmarks.filter(b => {
+        if (activeTab !== "all" && b.category !== activeTab) return false;
+        if (search) {
+            const q = search.toLowerCase();
+            return b.content.toLowerCase().includes(q) || b.authorUsername.toLowerCase().includes(q);
+        }
+        return true;
+    });
+
+    async function handleDelete(id: string) {
+        const updated = bookmarks.filter(b => b.id !== id);
+        await saveBookmarks(updated);
+        setBookmarks(updated);
+    }
+
+    async function handleCycleCategory(id: string) {
+        const updated = bookmarks.map(b =>
+            b.id === id ? { ...b, category: NEXT_CATEGORY[b.category] } : b
+        );
+        await saveBookmarks(updated);
+        setBookmarks(updated);
+    }
+
+    function handleJump(bookmark: Bookmark) {
+        modalProps.onClose();
+        jumper.jumpToMessage({
+            channelId: bookmark.channelId,
+            messageId: bookmark.messageId,
+            flash: true,
+            jumpType: "INSTANT",
+        });
+    }
+
+    const counts = {
+        all: bookmarks.length,
+        important: bookmarks.filter(b => b.category === "important").length,
+        later: bookmarks.filter(b => b.category === "later").length,
+    };
+
+    return (
+        <Modal
+            {...modalProps}
+            size="lg"
+            title={`Bookmarks (${bookmarks.length})`}
+        >
+            <div className="mb-body">
+                <div className="mb-search-wrap">
+                    <svg className="mb-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z" />
+                    </svg>
+                    <input
+                        className="mb-search"
+                        type="text"
+                        placeholder="Search bookmarks..."
+                        value={search}
+                        onChange={e => setSearch((e.target as HTMLInputElement).value)}
+                    />
+                    {search && (
+                        <button className="mb-search-clear" onClick={() => setSearch("")}>×</button>
+                    )}
+                </div>
+
+                <div className="mb-tabs">
+                    {(["all", "important", "later"] as const).map(tab => (
+                        <button
+                            key={tab}
+                            className={`mb-tab${activeTab === tab ? " mb-tab-active" : ""}`}
+                            onClick={() => setActiveTab(tab)}
+                        >
+                            {tab === "all" && `All (${counts.all})`}
+                            {tab === "important" && `📌 Important (${counts.important})`}
+                            {tab === "later" && `🕐 Later (${counts.later})`}
+                        </button>
+                    ))}
+                </div>
+
+                <div className="mb-list">
+                    {filtered.length === 0 ? (
+                        <div className="mb-empty">
+                            <svg width="52" height="52" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.2">
+                                <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+                            </svg>
+                            <p className="mb-empty-title">
+                                {search
+                                    ? "No results found"
+                                    : "No bookmarks yet"}
+                            </p>
+                            {!search && (
+                                <span className="mb-empty-hint">
+                                    Right-click any message and choose &quot;Add to Bookmarks&quot;
+                                </span>
+                            )}
+                        </div>
+                    ) : (
+                        filtered.map(bookmark => {
+                            const channel = ChannelStore.getChannel(bookmark.channelId);
+                            const channelName = channel?.name ?? bookmark.channelId;
+                            const guild = bookmark.guildId ? GuildStore.getGuild(bookmark.guildId) : null;
+                            const location = guild
+                                ? `${guild.name} › #${channelName}`
+                                : `#${channelName}`;
+
+                            return (
+                                <div key={bookmark.id} className={`mb-item mb-item-${bookmark.category}`}>
+                                    <div className="mb-item-header">
+                                        {bookmark.authorId && (
+                                            <img
+                                                className="mb-avatar"
+                                                src={avatarUrl(bookmark.authorId, bookmark.authorAvatar)}
+                                                alt=""
+                                            />
+                                        )}
+                                        <div className="mb-item-meta">
+                                            <span className="mb-author">{bookmark.authorUsername}</span>
+                                            <span className="mb-location">{location}</span>
+                                        </div>
+                                        <span className="mb-time">{relativeTime(bookmark.savedAt)}</span>
+                                    </div>
+
+                                    {(bookmark.content || bookmark.attachmentCount > 0) && (
+                                        <div className="mb-content">
+                                            {bookmark.content
+                                                ? bookmark.content.slice(0, 160) + (bookmark.content.length > 160 ? "…" : "")
+                                                : "Attachment"}
+                                            {bookmark.content && bookmark.attachmentCount > 0 && " 📎"}
+                                        </div>
+                                    )}
+
+                                    <div className="mb-item-actions">
+                                        <button
+                                            className={`mb-category-badge mb-cat-${bookmark.category}`}
+                                            title="Click to change category"
+                                            onClick={() => handleCycleCategory(bookmark.id)}
+                                        >
+                                            {categoryLabel(bookmark.category)}
+                                        </button>
+                                        <div className="mb-item-right">
+                                            <button
+                                                className="mb-action mb-jump"
+                                                title="Jump to message"
+                                                onClick={() => handleJump(bookmark)}
+                                            >
+                                                ↗ Jump
+                                            </button>
+                                            <button
+                                                className="mb-action mb-delete"
+                                                title="Delete"
+                                                onClick={() => handleDelete(bookmark.id)}
+                                            >
+                                                🗑
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })
+                    )}
+                </div>
+            </div>
+        </Modal>
+    );
+}

--- a/src/equicordplugins/messageBookmarks/index.tsx
+++ b/src/equicordplugins/messageBookmarks/index.tsx
@@ -1,0 +1,154 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./styles.css";
+
+import { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { HeaderBarButton } from "@api/HeaderBar";
+import { addMessagePopoverButton, removeMessagePopoverButton } from "@api/MessagePopover";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { ChannelStore, Menu, openModal, React, showToast, Toasts } from "@webpack/common";
+
+import { BookmarksModal } from "./BookmarksModal";
+import { bookmarksCache, clearCache, getBookmarks, saveBookmarks } from "./store";
+import type { Bookmark } from "./types";
+
+function BookmarkIcon({ width = 20, height = 20, ...props }: { width?: number | string; height?: number | string; className?: string; [key: string]: any; }) {
+    return (
+        <svg width={width} height={height} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+        </svg>
+    );
+}
+
+function HeaderBarBookmarkButton() {
+    return (
+        <HeaderBarButton
+            icon={BookmarkIcon}
+            tooltip="Bookmarks"
+            onClick={openBookmarksModal}
+        />
+    );
+}
+
+function BookmarkFilledIcon({ width = 20, height = 20, ...props }: { width?: number | string; height?: number | string; className?: string; [key: string]: any; }) {
+    return (
+        <svg width={width} height={height} viewBox="0 0 24 24" fill="currentColor" {...props}>
+            <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+        </svg>
+    );
+}
+
+function openBookmarksModal() {
+    openModal(props => (
+        <ErrorBoundary>
+            <BookmarksModal modalProps={props} />
+        </ErrorBoundary>
+    ));
+}
+
+async function addBookmark(message: any) {
+    const bookmarks = await getBookmarks();
+    if (bookmarks.some(b => b.messageId === message.id)) return;
+
+    const channel = ChannelStore.getChannel(message.channel_id);
+    const bookmark: Bookmark = {
+        id: `${message.id}_${Date.now()}`,
+        messageId: message.id,
+        channelId: message.channel_id,
+        guildId: channel?.guild_id ?? null,
+        authorId: message.author?.id ?? "",
+        authorUsername: message.author?.globalName ?? message.author?.username ?? "Unknown",
+        authorAvatar: message.author?.avatar ?? null,
+        content: message.content ?? "",
+        attachmentCount: message.attachments?.length ?? 0,
+        timestamp: message.timestamp?.toString() ?? new Date().toISOString(),
+        category: "general",
+        savedAt: Date.now(),
+    };
+
+    bookmarks.push(bookmark);
+    await saveBookmarks(bookmarks);
+    showToast("✓ Bookmark saved", Toasts.Type.SUCCESS);
+}
+
+async function removeBookmark(messageId: string) {
+    const bookmarks = await getBookmarks();
+    await saveBookmarks(bookmarks.filter(b => b.messageId !== messageId));
+    showToast("Bookmark removed", Toasts.Type.MESSAGE);
+}
+
+function renderBookmarkButton(message: any) {
+    const isBookmarked = bookmarksCache?.some(b => b.messageId === message.id) ?? false;
+
+    return {
+        key: "mb-bookmark",
+        label: isBookmarked
+            ? "View Bookmarks"
+            : "Add Bookmark",
+        icon: isBookmarked ? BookmarkFilledIcon : BookmarkIcon,
+        message,
+        channel: ChannelStore.getChannel(message.channel_id),
+        onClick: () => {
+            if (isBookmarked) {
+                openBookmarksModal();
+            } else {
+                addBookmark(message);
+            }
+        },
+    };
+}
+
+const messageContextMenuPatch: NavContextMenuPatchCallback = (children, props) => {
+    const { message } = props as { message: any; };
+    if (!message?.id) return;
+
+    const isBookmarked = bookmarksCache?.some(b => b.messageId === message.id) ?? false;
+
+    children.push(
+        <Menu.MenuItem
+            key="mb-context-item"
+            id="mb-context-item"
+            label={isBookmarked
+                ? "Remove Bookmark"
+                : "Add Bookmark"}
+            icon={isBookmarked ? BookmarkFilledIcon : BookmarkIcon}
+            action={() => {
+                if (isBookmarked) {
+                    removeBookmark(message.id);
+                } else {
+                    addBookmark(message);
+                }
+            }}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "MessageBookmarks",
+    description: "Save messages as private bookmarks and organize them in a beautiful panel with search",
+    tags: ["Chat", "Utility"],
+    authors: [EquicordDevs.LOSTSTR, EquicordDevs.NRaymond],
+    dependencies: ["MessagePopoverAPI", "HeaderBarAPI"],
+    headerBarButton: {
+        icon: BookmarkIcon,
+        render: HeaderBarBookmarkButton,
+    },
+    contextMenus: {
+        message: messageContextMenuPatch,
+    },
+
+    start() {
+        addMessagePopoverButton("MessageBookmarks", renderBookmarkButton, BookmarkIcon);
+    },
+
+    stop() {
+        removeMessagePopoverButton("MessageBookmarks");
+        clearCache();
+    },
+});

--- a/src/equicordplugins/messageBookmarks/store.ts
+++ b/src/equicordplugins/messageBookmarks/store.ts
@@ -1,0 +1,29 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import * as DataStore from "@api/DataStore";
+
+import type { Bookmark } from "./types";
+
+// Same key as the previous userplugins version to preserve existing bookmarks
+const STORE_KEY = "LoststrHeart_bookmarks";
+export let bookmarksCache: Bookmark[] | null = null;
+
+export async function getBookmarks(): Promise<Bookmark[]> {
+    if (bookmarksCache === null) {
+        bookmarksCache = await DataStore.get<Bookmark[]>(STORE_KEY) ?? [];
+    }
+    return bookmarksCache!;
+}
+
+export async function saveBookmarks(bookmarks: Bookmark[]): Promise<void> {
+    bookmarksCache = [...bookmarks];
+    await DataStore.set(STORE_KEY, bookmarksCache);
+}
+
+export function clearCache(): void {
+    bookmarksCache = null;
+}

--- a/src/equicordplugins/messageBookmarks/styles.css
+++ b/src/equicordplugins/messageBookmarks/styles.css
@@ -1,0 +1,281 @@
+/* MessageBookmarks plugin styles */
+
+.mb-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 0;
+}
+
+.mb-search-wrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.mb-search-icon {
+    position: absolute;
+    left: 10px;
+    color: var(--text-muted);
+    pointer-events: none;
+}
+
+.mb-search {
+    width: 100%;
+    padding: 8px 36px;
+    background: var(--background-secondary);
+    border: 1.5px solid var(--background-modifier-accent);
+    border-radius: 8px;
+    color: var(--text-normal);
+    font-size: 14px;
+    outline: none;
+    transition: border-color 0.15s ease;
+}
+
+.mb-search:focus {
+    border-color: var(--brand-experiment);
+}
+
+.mb-search-clear {
+    position: absolute;
+    right: 10px;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 18px;
+    padding: 0;
+    line-height: 1;
+}
+
+.mb-search-clear:hover {
+    color: var(--text-normal);
+}
+
+.mb-tabs {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    background: var(--background-secondary);
+    border-radius: 10px;
+}
+
+.mb-tab {
+    flex: 1;
+    padding: 6px 12px;
+    border-radius: 7px;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 13px;
+    font-weight: 500;
+    transition: all 0.15s ease;
+}
+
+.mb-tab:hover {
+    color: var(--text-normal);
+    background: var(--background-modifier-hover);
+}
+
+.mb-tab-active {
+    background: var(--brand-experiment) !important;
+    color: white !important;
+}
+
+.mb-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    max-height: 440px;
+    overflow-y: auto;
+    padding-right: 2px;
+}
+
+.mb-list::-webkit-scrollbar {
+    width: 4px;
+}
+
+.mb-list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.mb-list::-webkit-scrollbar-thumb {
+    background: var(--background-modifier-accent);
+    border-radius: 4px;
+}
+
+.mb-item {
+    padding: 12px 14px;
+    border-radius: 8px;
+    background: var(--background-secondary);
+    border: 1px solid transparent;
+    border-left: 3px solid var(--brand-experiment);
+    transition: background 0.15s ease;
+}
+
+.mb-item:hover {
+    background: var(--background-modifier-hover);
+}
+
+.mb-item-important {
+    border-left-color: var(--text-danger);
+}
+
+.mb-item-later {
+    border-left-color: rgb(250 168 26);
+}
+
+.mb-item-general {
+    border-left-color: var(--brand-experiment);
+}
+
+.mb-item-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 7px;
+}
+
+.mb-avatar {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.mb-item-meta {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    gap: 2px;
+}
+
+.mb-author {
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--header-primary);
+}
+
+.mb-location {
+    font-size: 11px;
+    color: var(--text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.mb-time {
+    font-size: 11px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+.mb-content {
+    font-size: 13px;
+    color: var(--text-muted);
+    overflow-wrap: break-word;
+    line-height: 1.45;
+    margin-bottom: 8px;
+}
+
+.mb-item-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.mb-item-right {
+    display: flex;
+    gap: 6px;
+}
+
+.mb-category-badge {
+    font-size: 11px;
+    font-weight: 700;
+    padding: 3px 9px;
+    border-radius: 12px;
+    border: none;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    transition: opacity 0.15s ease;
+}
+
+.mb-category-badge:hover {
+    opacity: 0.75;
+}
+
+.mb-cat-general {
+    background: rgb(88 101 242 / 20%);
+    color: var(--brand-experiment);
+}
+
+.mb-cat-important {
+    background: rgb(237 66 69 / 20%);
+    color: var(--text-danger);
+}
+
+.mb-cat-later {
+    background: rgb(250 168 26 / 20%);
+    color: rgb(250 168 26);
+}
+
+.mb-action {
+    font-size: 12px;
+    font-weight: 500;
+    padding: 4px 10px;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.mb-jump {
+    background: rgb(88 101 242 / 15%);
+    color: var(--brand-experiment);
+}
+
+.mb-jump:hover {
+    background: rgb(88 101 242 / 28%);
+}
+
+.mb-delete {
+    background: var(--background-modifier-accent);
+    color: var(--text-muted);
+}
+
+.mb-delete:hover {
+    background: rgb(237 66 69 / 20%);
+    color: var(--text-danger);
+}
+
+.mb-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 52px 24px;
+    text-align: center;
+}
+
+.mb-empty svg {
+    opacity: 0.25;
+    color: var(--text-muted);
+}
+
+.mb-empty-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--header-secondary);
+    margin: 0;
+}
+
+.mb-empty-hint {
+    font-size: 13px;
+    color: var(--text-muted);
+    max-width: 260px;
+    line-height: 1.5;
+}

--- a/src/equicordplugins/messageBookmarks/types.ts
+++ b/src/equicordplugins/messageBookmarks/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export type BookmarkCategory = "general" | "important" | "later";
+
+export interface Bookmark {
+    id: string;
+    messageId: string;
+    channelId: string;
+    guildId?: string | null;
+    authorId: string;
+    authorUsername: string;
+    authorAvatar?: string | null;
+    content: string;
+    attachmentCount: number;
+    timestamp: string;
+    category: BookmarkCategory;
+    savedAt: number;
+}

--- a/src/equicordplugins/messageInsight/ChannelBrief.tsx
+++ b/src/equicordplugins/messageInsight/ChannelBrief.tsx
@@ -1,0 +1,91 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { findByPropsLazy } from "@webpack";
+import { Modal, React } from "@webpack/common";
+
+import { avatarUrl, formatTime, sanitizeContent } from "./utils";
+
+const jumper = findByPropsLazy("jumpToMessage");
+
+export function ChannelBriefModal({ modalProps, newMessages, totalCount, elapsed }: {
+    modalProps: any;
+    newMessages: any[];
+    totalCount: number;
+    elapsed: number;
+}) {
+    const showing = newMessages.length;
+    const hasMore = totalCount > showing;
+
+    return (
+        <Modal
+            {...modalProps}
+            size="sm"
+            title="Channel Brief"
+        >
+            <div style={{ padding: "8px 0 16px" }}>
+                <div style={{ fontSize: 13, color: "var(--text-muted)", marginBottom: 12 }}>
+                    {hasMore
+                        ? `${totalCount} new messages in the last ${elapsed} min — showing last ${showing}`
+                        : `${totalCount} new message${totalCount !== 1 ? "s" : ""} in the last ${elapsed} min`}
+                </div>
+                {newMessages.map((msg: any) => {
+                    const sanitized = sanitizeContent(msg.content ?? "");
+                    const hasAttachments = (msg.attachments?.length ?? 0) > 0;
+                    const time = formatTime(msg.timestamp);
+
+                    return (
+                        <div key={msg.id} className="mi-brief-item">
+                            <div className="mi-reply-header">
+                                {msg.author && (
+                                    <img
+                                        className="mi-reply-avatar"
+                                        src={avatarUrl(msg.author)}
+                                        alt=""
+                                    />
+                                )}
+                                <span className="mi-reply-author">
+                                    {msg.author?.username ?? "Unknown"}
+                                </span>
+                                {time && <span className="mi-reply-time">{time}</span>}
+                                {hasAttachments && (
+                                    <span
+                                        className="mi-reply-attachment"
+                                        title="Has attachments"
+                                    >
+                                        📎
+                                    </span>
+                                )}
+                            </div>
+                            <div className="mi-brief-content-row">
+                                <span className="mi-reply-content">
+                                    {sanitized
+                                        ? sanitized.slice(0, 120) + (sanitized.length > 120 ? "…" : "")
+                                        : "Attachment"}
+                                </span>
+                                <button
+                                    className="mi-brief-jump"
+                                    title="Jump to message"
+                                    onClick={() => {
+                                        modalProps.onClose();
+                                        jumper.jumpToMessage({
+                                            channelId: msg.channel_id,
+                                            messageId: msg.id,
+                                            flash: true,
+                                            jumpType: "INSTANT",
+                                        });
+                                    }}
+                                >
+                                    ↗
+                                </button>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </Modal>
+    );
+}

--- a/src/equicordplugins/messageInsight/EditDiff.tsx
+++ b/src/equicordplugins/messageInsight/EditDiff.tsx
@@ -1,0 +1,86 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Modal, React } from "@webpack/common";
+
+interface DiffToken {
+    type: "same" | "add" | "remove";
+    text: string;
+}
+
+function lcs(a: string[], b: string[]): number[][] {
+    const m = a.length, n = b.length;
+    const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+    for (let i = 1; i <= m; i++) {
+        for (let j = 1; j <= n; j++) {
+            dp[i][j] = a[i - 1] === b[j - 1]
+                ? dp[i - 1][j - 1] + 1
+                : Math.max(dp[i - 1][j], dp[i][j - 1]);
+        }
+    }
+    return dp;
+}
+
+export function wordDiff(before: string, after: string): DiffToken[] {
+    const a = before.split(/(\s+)/);
+    const b = after.split(/(\s+)/);
+    const dp = lcs(a, b);
+    const result: DiffToken[] = [];
+    let i = a.length, j = b.length;
+    while (i > 0 || j > 0) {
+        if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+            result.unshift({ type: "same", text: a[i - 1] });
+            i--; j--;
+        } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+            result.unshift({ type: "add", text: b[j - 1] });
+            j--;
+        } else {
+            result.unshift({ type: "remove", text: a[i - 1] });
+            i--;
+        }
+    }
+    return result;
+}
+
+function DiffView({ before, after }: { before: string; after: string; }) {
+    const tokens = wordDiff(before, after);
+    return (
+        <div className="mi-diff-view">
+            {tokens.map((token, i) => {
+                if (token.type === "same") return <span key={i}>{token.text}</span>;
+                if (token.type === "add") return <span key={i} className="mi-diff-add">{token.text}</span>;
+                return <span key={i} className="mi-diff-remove">{token.text}</span>;
+            })}
+        </div>
+    );
+}
+
+export function EditDiffModal({ modalProps, history }: { modalProps: any; history: string[]; }) {
+    return (
+        <Modal
+            {...modalProps}
+            size="lg"
+            title="Edit History"
+        >
+            <div style={{ padding: "16px 0" }}>
+                {history.length < 2 ? (
+                    <p style={{ color: "var(--text-muted)" }}>
+                        No edit history available.
+                    </p>
+                ) : (
+                    history.slice(0, -1).map((version, i) => (
+                        <div key={i} style={{ marginBottom: 16 }}>
+                            <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 4 }}>
+                                {`Edit ${i + 1}`}
+                            </div>
+                            <DiffView before={version} after={history[i + 1]} />
+                        </div>
+                    ))
+                )}
+            </div>
+        </Modal>
+    );
+}

--- a/src/equicordplugins/messageInsight/ReplyTree.tsx
+++ b/src/equicordplugins/messageInsight/ReplyTree.tsx
@@ -1,0 +1,95 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { findByPropsLazy } from "@webpack";
+import { Modal, React } from "@webpack/common";
+
+import { avatarUrl, formatTime, sanitizeContent } from "./utils";
+
+const jumper = findByPropsLazy("jumpToMessage");
+
+export function ReplyTreeModal({ modalProps, message, replies }: {
+    modalProps: any;
+    message: any;
+    replies: any[];
+}) {
+    const preview = sanitizeContent(message.content ?? "");
+
+    return (
+        <Modal
+            {...modalProps}
+            size="lg"
+            title="Message Replies"
+        >
+            <div style={{ padding: "16px 0" }}>
+                <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 12 }}>
+                    {`Message: "${preview.slice(0, 80)}${preview.length > 80 ? "…" : ""}"`}
+                </div>
+                {replies.length === 0 ? (
+                    <p style={{ color: "var(--text-muted)" }}>
+                        No loaded replies found for this message in the current channel.
+                    </p>
+                ) : (
+                    <>
+                        <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 8 }}>
+                            {`${replies.length} repl${replies.length === 1 ? "y" : "ies"}`}
+                        </div>
+                        {replies.map((reply: any) => {
+                            const sanitized = sanitizeContent(reply.content ?? "");
+                            const hasAttachments = (reply.attachments?.length ?? 0) > 0;
+                            const time = formatTime(reply.timestamp);
+
+                            return (
+                                <div
+                                    key={reply.id}
+                                    className="mi-reply-item"
+                                    onClick={() => {
+                                        modalProps.onClose();
+                                        jumper.jumpToMessage({
+                                            channelId: reply.channel_id,
+                                            messageId: reply.id,
+                                            flash: true,
+                                            jumpType: "INSTANT",
+                                        });
+                                    }}
+                                >
+                                    <div className="mi-reply-header">
+                                        {reply.author && (
+                                            <img
+                                                className="mi-reply-avatar"
+                                                src={avatarUrl(reply.author)}
+                                                alt=""
+                                            />
+                                        )}
+                                        <span className="mi-reply-author">
+                                            {reply.author?.username ?? "Unknown"}
+                                        </span>
+                                        {time && <span className="mi-reply-time">{time}</span>}
+                                        {hasAttachments && (
+                                            <span
+                                                className="mi-reply-attachment"
+                                                title="Has attachments"
+                                            >
+                                                📎
+                                            </span>
+                                        )}
+                                    </div>
+                                    {(sanitized || hasAttachments) && (
+                                        <span className="mi-reply-content">
+                                            {sanitized
+                                                ? sanitized.slice(0, 140) + (sanitized.length > 140 ? "…" : "")
+                                                : "Attachment"}
+                                        </span>
+                                    )}
+                                </div>
+                            );
+                        })}
+                    </>
+                )}
+            </div>
+        </Modal>
+    );
+}

--- a/src/equicordplugins/messageInsight/index.tsx
+++ b/src/equicordplugins/messageInsight/index.tsx
@@ -1,0 +1,169 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./styles.css";
+
+import { addMessagePopoverButton, removeMessagePopoverButton } from "@api/MessagePopover";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { ChannelStore, FluxDispatcher, MessageStore, openModal, React } from "@webpack/common";
+
+import { ChannelBriefModal } from "./ChannelBrief";
+import { EditDiffModal } from "./EditDiff";
+import { ReplyTreeModal } from "./ReplyTree";
+import { settings } from "./settings";
+
+// messageId -> [original, ...edits]
+const editHistory = new Map<string, string[]>();
+// messageId -> latest cached content (for capturing pre-edit state)
+const messageCache = new Map<string, string>();
+// channelId -> { lastVisitTime, messageCount }
+const channelVisitData = new Map<string, { time: number; count: number; }>();
+
+function onMessageCreate({ message }: any) {
+    if (message?.id && message.content !== undefined) {
+        messageCache.set(message.id, message.content);
+    }
+}
+
+function onMessageUpdate({ message }: any) {
+    if (!settings.store.editDiff) return;
+    if (!message?.id || message.content === undefined) return;
+
+    const oldContent = messageCache.get(message.id);
+    if (oldContent !== undefined && oldContent !== message.content) {
+        const history = editHistory.get(message.id);
+        if (!history) {
+            editHistory.set(message.id, [oldContent, message.content]);
+        } else {
+            history.push(message.content);
+        }
+    }
+    messageCache.set(message.id, message.content);
+}
+
+function onChannelSelect({ channelId }: any) {
+    if (!channelId || !settings.store.channelBrief) return;
+
+    const prev = channelVisitData.get(channelId);
+    const msgsArray: any[] = (MessageStore.getMessages(channelId) as any)?._array ?? [];
+
+    if (prev) {
+        const newMsgs = msgsArray.filter(m => {
+            try {
+                return new Date(m.timestamp.toString()).getTime() > prev.time;
+            } catch {
+                return false;
+            }
+        });
+        const newCount = newMsgs.length;
+        const elapsed = Math.floor((Date.now() - prev.time) / 60000);
+
+        if (newCount > 0 && elapsed >= settings.store.briefThresholdMinutes) {
+            const previewCount = Math.max(1, settings.store.briefPreviewCount ?? 5);
+            const preview = newMsgs.slice(-previewCount);
+            openModal(props => (
+                <ErrorBoundary>
+                    <ChannelBriefModal
+                        modalProps={props}
+                        newMessages={preview}
+                        totalCount={newCount}
+                        elapsed={elapsed}
+                    />
+                </ErrorBoundary>
+            ));
+        }
+    }
+
+    channelVisitData.set(channelId, { time: Date.now(), count: msgsArray.length });
+}
+
+function EditDiffIcon() {
+    return (
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+        </svg>
+    );
+}
+
+function ReplyTreeIcon() {
+    return (
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z" />
+        </svg>
+    );
+}
+
+function renderEditDiffButton(message: any) {
+    if (!settings.store.editDiff) return null;
+    const history = editHistory.get(message.id);
+    if (!history || history.length < 2) return null;
+
+    const editCount = history.length - 1;
+    return {
+        key: "mi-edit-diff",
+        label: `Show Edit History (${editCount}×)`,
+        icon: EditDiffIcon,
+        message,
+        channel: ChannelStore.getChannel(message.channel_id),
+        onClick: () => openModal(props => (
+            <ErrorBoundary>
+                <EditDiffModal modalProps={props} history={history} />
+            </ErrorBoundary>
+        )),
+    };
+}
+
+function renderReplyTreeButton(message: any) {
+    if (!settings.store.replyTree) return null;
+
+    return {
+        key: "mi-reply-tree",
+        label: "Show Reply Tree",
+        icon: ReplyTreeIcon,
+        message,
+        channel: ChannelStore.getChannel(message.channel_id),
+        onClick: () => {
+            const replies = ((MessageStore.getMessages(message.channel_id) as any)?._array ?? []).filter(
+                (m: any) => m.messageReference?.message_id === message.id
+            );
+            openModal(props => (
+                <ErrorBoundary>
+                    <ReplyTreeModal modalProps={props} message={message} replies={replies} />
+                </ErrorBoundary>
+            ));
+        },
+    };
+}
+
+export default definePlugin({
+    name: "MessageInsight",
+    description: "Advanced message tools: edit diff, reply tree, and channel brief",
+    authors: [EquicordDevs.LOSTSTR],
+    tags: ["Chat", "Utility"],
+    settings,
+    dependencies: ["MessagePopoverAPI"],
+
+    start() {
+        addMessagePopoverButton("MessageInsight-editDiff", renderEditDiffButton, EditDiffIcon);
+        addMessagePopoverButton("MessageInsight-replyTree", renderReplyTreeButton, ReplyTreeIcon);
+        FluxDispatcher.subscribe("MESSAGE_CREATE", onMessageCreate);
+        FluxDispatcher.subscribe("MESSAGE_UPDATE", onMessageUpdate);
+        FluxDispatcher.subscribe("CHANNEL_SELECT", onChannelSelect);
+    },
+
+    stop() {
+        removeMessagePopoverButton("MessageInsight-editDiff");
+        removeMessagePopoverButton("MessageInsight-replyTree");
+        FluxDispatcher.unsubscribe("MESSAGE_CREATE", onMessageCreate);
+        FluxDispatcher.unsubscribe("MESSAGE_UPDATE", onMessageUpdate);
+        FluxDispatcher.unsubscribe("CHANNEL_SELECT", onChannelSelect);
+        editHistory.clear();
+        messageCache.clear();
+        channelVisitData.clear();
+    },
+});

--- a/src/equicordplugins/messageInsight/settings.ts
+++ b/src/equicordplugins/messageInsight/settings.ts
@@ -1,0 +1,36 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { OptionType } from "@utils/types";
+
+export const settings = definePluginSettings({
+    editDiff: {
+        type: OptionType.BOOLEAN,
+        description: "Show word-level diff button on edited messages",
+        default: true,
+    },
+    replyTree: {
+        type: OptionType.BOOLEAN,
+        description: "Show reply tree button to list all replies to a message",
+        default: true,
+    },
+    channelBrief: {
+        type: OptionType.BOOLEAN,
+        description: "Show new messages preview when returning to a channel after inactivity",
+        default: true,
+    },
+    briefThresholdMinutes: {
+        type: OptionType.NUMBER,
+        description: "Minutes of inactivity before showing channel brief (default: 15)",
+        default: 15,
+    },
+    briefPreviewCount: {
+        type: OptionType.NUMBER,
+        description: "Number of messages to preview in channel brief (3, 5, or 10)",
+        default: 5,
+    },
+});

--- a/src/equicordplugins/messageInsight/styles.css
+++ b/src/equicordplugins/messageInsight/styles.css
@@ -1,0 +1,113 @@
+/* MessageInsight plugin styles */
+
+.mi-diff-view {
+    font-family: var(--font-code);
+    font-size: 14px;
+    background: var(--background-secondary);
+    padding: 10px 14px;
+    border-radius: 4px;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    line-height: 1.6;
+}
+
+.mi-diff-add {
+    background: rgb(59 165 92 / 25%);
+    color: var(--text-positive);
+    border-radius: 2px;
+    padding: 0 2px;
+}
+
+.mi-diff-remove {
+    background: rgb(237 66 69 / 25%);
+    color: var(--text-danger);
+    text-decoration: line-through;
+    border-radius: 2px;
+    padding: 0 2px;
+}
+
+.mi-reply-item {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 10px 14px;
+    border-radius: 4px;
+    margin-bottom: 4px;
+    background: var(--background-secondary);
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.mi-reply-item:hover {
+    background: var(--background-modifier-hover);
+}
+
+.mi-reply-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.mi-reply-avatar {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.mi-reply-author {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--header-primary);
+}
+
+.mi-reply-time {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-left: 2px;
+}
+
+.mi-reply-attachment {
+    font-size: 12px;
+    line-height: 1;
+}
+
+.mi-reply-content {
+    font-size: 13px;
+    color: var(--text-muted);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
+.mi-brief-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 12px;
+    border-radius: 4px;
+    margin-bottom: 4px;
+    background: var(--background-secondary);
+}
+
+.mi-brief-content-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.mi-brief-jump {
+    background: none;
+    border: none;
+    color: var(--text-link);
+    cursor: pointer;
+    font-size: 14px;
+    padding: 0 4px;
+    flex-shrink: 0;
+    line-height: 1.4;
+    border-radius: 3px;
+    transition: background 0.1s ease;
+}
+
+.mi-brief-jump:hover {
+    background: var(--background-modifier-hover);
+}

--- a/src/equicordplugins/messageInsight/utils.ts
+++ b/src/equicordplugins/messageInsight/utils.ts
@@ -1,0 +1,35 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export function sanitizeContent(content: string): string {
+    return content
+        .replace(/<a?:(\w+):\d+>/g, ":$1:")
+        .replace(/<@!?(\d+)>/g, "@user")
+        .replace(/<#\d+>/g, "#channel")
+        .replace(/<@&\d+>/g, "@role")
+        .replace(/\[([^\]]+)\]\(https?:\/\/cdn\.discordapp\.com\/emojis\/[^)]+\)/g, ":$1:")
+        .replace(/<t:(\d+)(?::[tTdDfFR])?>/g, (_, ts) => {
+            try { return new Date(parseInt(ts, 10) * 1000).toLocaleString(); } catch { return ts; }
+        });
+}
+
+export function avatarUrl(author: { id: string; avatar?: string | null; }): string {
+    if (!author?.avatar) {
+        const index = Number(BigInt(author.id) >> 22n) % 6;
+        return `https://cdn.discordapp.com/embed/avatars/${index}.png`;
+    }
+    const ext = author.avatar.startsWith("a_") ? "gif" : "png";
+    return `https://cdn.discordapp.com/avatars/${author.id}/${author.avatar}.${ext}?size=32`;
+}
+
+export function formatTime(timestamp: string | Date | undefined): string {
+    if (!timestamp) return "";
+    try {
+        return new Date(timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    } catch {
+        return "";
+    }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1337,6 +1337,14 @@ export const EquicordDevs = Object.freeze({
         name: "qdnx",
         id: 1374803023506702508n
     },
+    LOSTSTR: {
+        name: "LOSTSTR",
+        id: 681465758127226900n
+    },
+    NRaymond: {
+        name: "『N』𝚁𝙰𝚈𝙼𝙾𝙽𝙳♞",
+        id: 1072961475125182564n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Summary

Adds two new plugins to `equicordplugins`:

### 📌 MessageBookmarks
- Bookmark any message via the message context menu
- Header bar button to open your bookmarks panel
- Categories: **Important**, **Later**, **General** (click badge to cycle)
- Search through saved bookmarks
- Jump-to-message navigation
- Persistent storage via `DataStore`

### 🔍 MessageInsight
- **Edit Diff** — word-level diff viewer for edited messages (highlights added/removed words)
- **Reply Tree** — lists all replies to a message in a scrollable modal
- **Channel Brief** — previews recent messages when returning to a channel after inactivity
- Each feature is individually toggleable in settings

## Test plan
- [ ] Bookmark a message via right-click context menu
- [ ] Open bookmarks panel from header bar icon
- [ ] Cycle categories by clicking the badge
- [ ] Search bookmarks by content or author
- [ ] Click ↗ Jump to navigate to the original message
- [ ] Edit a message and click the diff button to see word-level changes
- [ ] Reply to a message and use Reply Tree to see all replies
- [ ] Leave a channel and return after the configured inactivity timeout to see Channel Brief
- [ ] Toggle each MessageInsight feature on/off in settings independently