### PR TITLE
feat(plugin): add BetterAudioDefaults

### DIFF
--- a/src/equicordplugins/betterAudioDefaults/index.ts
+++ b/src/equicordplugins/betterAudioDefaults/index.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { Devs } from "@utils/constants";
+import { EquicordDevs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { findByProps } from "@webpack";
 
@@ -13,7 +13,7 @@ export default definePlugin({
   name: "BetterAudioDefaults",
   description:
     "Enables Studio Profile and QoS while disabling audio attenuation and VC-switching/mic silence warnings.",
-  authors: [Devs.greyxp1],
+  authors: [EquicordDevs.greyxp1],
   tags: ["Voice", "Utility"],
 
   start() {

--- a/src/equicordplugins/betterAudioDefaults/index.ts
+++ b/src/equicordplugins/betterAudioDefaults/index.ts
@@ -30,11 +30,11 @@ export default definePlugin({
     if (vcModule?.handleVoiceConnect) {
       const originalFn = vcModule.handleVoiceConnect;
       vcModule.handleVoiceConnect = Object.assign(
-        (...args: any[]) =>
+        (...args: unknown[]) =>
           originalFn.call(
             vcModule,
             {
-              ...args[0],
+              ...(args[0] as Record<string, unknown>),
               bypassChangeModal: true,
             },
             ...args.slice(1),

--- a/src/equicordplugins/betterAudioDefaults/index.ts
+++ b/src/equicordplugins/betterAudioDefaults/index.ts
@@ -1,0 +1,55 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Devs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { findByProps } from "@webpack";
+
+let unpatchVoiceConnect: (() => void) | undefined;
+export default definePlugin({
+  name: "BetterAudioDefaults",
+  description:
+    "Enables Studio Profile and QoS while disabling audio attenuation and VC-switching/mic silence warnings.",
+  authors: [Devs.greyxp1],
+  tags: ["Voice", "Utility"],
+
+  start() {
+    const mediaEngine = findByProps("setActiveInputProfile");
+    if (mediaEngine) {
+      mediaEngine.setActiveInputProfile("STUDIO");
+      mediaEngine.setSilenceWarning(false);
+      mediaEngine.setQoS(true);
+      mediaEngine.setSidechainCompression(false);
+      mediaEngine.setAttenuation(0, false, false);
+    }
+
+    const vcModule = findByProps("handleVoiceConnect");
+    if (vcModule?.handleVoiceConnect) {
+      const originalFn = vcModule.handleVoiceConnect;
+      vcModule.handleVoiceConnect = Object.assign(
+        (...args: any[]) =>
+          originalFn.call(
+            vcModule,
+            {
+              ...args[0],
+              bypassChangeModal: true,
+            },
+            ...args.slice(1),
+          ),
+        originalFn,
+      );
+
+      unpatchVoiceConnect = () => {
+        vcModule.handleVoiceConnect = originalFn;
+      };
+    }
+  },
+
+  stop() {
+    unpatchVoiceConnect?.();
+    unpatchVoiceConnect = undefined;
+  },
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -657,13 +657,13 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+} satisfies Record<string, Dev>);
+
+export const EquicordDevs = Object.freeze({
     greyxp1: {
         name: "greyxp1",
         id: 1233920168196046892n,
     },
-} satisfies Record<string, Dev>);
-
-export const EquicordDevs = Object.freeze({
     nobody: {
         name: "nobody",
         id: 0n

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -659,7 +659,7 @@ export const Devs = /* #__PURE__*/ Object.freeze({
     },
     greyxp1: {
         name: "greyxp1",
-        id: 1233920168196046892n
+        id: 1233920168196046892n,
     },
 } satisfies Record<string, Dev>);
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -657,6 +657,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "prism",
         id: 390884143749136386n,
     },
+    greyxp1: {
+        name: "greyxp1",
+        id: 1233920168196046892n
+    },
 } satisfies Record<string, Dev>);
 
 export const EquicordDevs = Object.freeze({


### PR DESCRIPTION
- Sets the Input Profile to Studio
- Enables Quality Of Service
- Disables Global Audio Attenuation as well as Stream Attenuation
- Silences the VC-switching and mic silence warnings.

I manage Discord declaratively via Nixcord, but because Discord stores Voice & Video settings in IndexedDB rather than a config file, they cannot be set declaratively. Instead of building a bloated, fragile settings-mapper, I made this plugin to enforce these settings on startup.