### PR TITLE
DiscordDevBanner: fix invalid variable name in default format

### DIFF
--- a/src/equicordplugins/discordDevBanner/components/consts.ts
+++ b/src/equicordplugins/discordDevBanner/components/consts.ts
@@ -13,7 +13,7 @@ export const settings = definePluginSettings({
     format: {
         component: ({ setValue }) => FormatSetting(setValue),
         type: OptionType.COMPONENT,
-        default: "{buildChannel} {buildNumber} ({buildHash}) | {clientName} {equicordVersion} ({equicordHash})",
+        default: "{equicordIcon} Equicord {equicordVersion} ({equicordHash})",
         restartNeeded: true
     }
 });

--- a/src/equicordplugins/discordDevBanner/components/consts.ts
+++ b/src/equicordplugins/discordDevBanner/components/consts.ts
@@ -13,7 +13,7 @@ export const settings = definePluginSettings({
     format: {
         component: ({ setValue }) => FormatSetting(setValue),
         type: OptionType.COMPONENT,
-        default: "{buildChannel} {buildNumber} ({buildHash}) | {equicordName} {equicordVersion} ({equicordHash})",
+        default: "{buildChannel} {buildNumber} ({buildHash}) | {clientName} {equicordVersion} ({equicordHash})",
         restartNeeded: true
     }
 });


### PR DESCRIPTION
"equicordName" should be "clientName"