### PR TITLE
feat(plugin): add randomGary

### DIFF
--- a/src/equicordplugins/randomGary/index.tsx
+++ b/src/equicordplugins/randomGary/index.tsx
@@ -59,7 +59,6 @@ const GARY_SETTINGS_KEYS = ["randomGaryImageSource"] as const;
 
 async function sendGaryLink(channelId: string, link: string) {
     const reply = PendingReplyStore.getPendingReply(channelId);
-    if (reply) FluxDispatcher.dispatch({ type: "DELETE_PENDING_REPLY", channelId });
     try {
         if (getSlowmodeCooldownGuess(channelId) === 0) {
             const channel = ChannelStore.getChannel(channelId);
@@ -68,7 +67,7 @@ async function sendGaryLink(channelId: string, link: string) {
                 return;
             }
 
-
+            if (reply) FluxDispatcher.dispatch({ type: "DELETE_PENDING_REPLY", channelId });
             sendMessage(channelId, {
                 content: link
             }, true, {
@@ -85,7 +84,6 @@ async function sendGaryLink(channelId: string, link: string) {
 
 async function uploadGaryImage(url: string, channelId: string) {
     const reply = PendingReplyStore.getPendingReply(channelId);
-    if (reply) FluxDispatcher.dispatch({ type: "DELETE_PENDING_REPLY", channelId });
     try {
         if (getSlowmodeCooldownGuess(channelId) === 0) {
             const channel = ChannelStore.getChannel(channelId);
@@ -107,7 +105,7 @@ async function uploadGaryImage(url: string, channelId: string) {
             }, channelId, false, 0);
 
             upload.on("complete", () => {
-
+                if (reply) FluxDispatcher.dispatch({ type: "DELETE_PENDING_REPLY", channelId });
                 sendMessage(channelId, {
                     content: "",
                 }, true, {

--- a/src/equicordplugins/randomGary/index.tsx
+++ b/src/equicordplugins/randomGary/index.tsx
@@ -97,6 +97,7 @@ async function uploadGaryImage(url: string, channelId: string) {
 
             showToast("Uploading image, this may take a few seconds.", Toasts.Type.MESSAGE);
             const buffer = await Native.getImageBuffer(url);
+            if (!buffer) { showToast("Failed to fetch image", Toasts.Type.FAILURE); return; }
             const blob = new Blob([buffer], { type: "image/jpeg" });
             const file = new File([blob], "gary.jpg", { type: "image/jpeg" });
             const upload = new CloudUpload({

--- a/src/equicordplugins/randomGary/index.tsx
+++ b/src/equicordplugins/randomGary/index.tsx
@@ -1,0 +1,282 @@
+import "./styles.css";
+
+import { ChatBarButton } from "@api/ChatButtons";
+import { definePluginSettings } from "@api/Settings";
+import { classNameFactory } from "@utils/css";
+import { classes } from "@utils/misc";
+import { IconComponent } from "@utils/types";
+import definePlugin, { OptionType, PluginNative } from "@utils/types";
+import { sendMessage } from "@utils/discord";
+import { findByPropsLazy, findLazy, findStoreLazy } from "@webpack";
+import { ChannelStore, FluxDispatcher, MessageActions, PermissionsBits, PermissionStore, SearchableSelect, SelectedChannelStore, Modal, openModal, showToast, Toasts, useState } from "@webpack/common";
+import { Heading } from "@components/Heading";
+import type { RenderModalProps } from "@vencord/discord-types";
+import { EquicordDevs } from "@utils/constants";
+
+const cl = classNameFactory("vc-gary-");
+const CloudUpload = findLazy(m => m.prototype?.trackUploadFinished);
+const PendingReplyStore = findStoreLazy("PendingReplyStore");
+const { getSlowmodeCooldownGuess } = findByPropsLazy("getSlowmodeCooldownGuess");
+const Native = VencordNative.pluginHelpers.RandomGary as PluginNative<typeof import("./native")>;
+
+
+export const GaryIcon: IconComponent = ({ height = 20, width = 20, className }) => {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox="0 0 24 24" className={classes(className, cl("icon"))}>
+            <path
+                fill="currentColor"
+                d="M11.75 6.406c-1.48 0-1.628.157-2.394.157C8.718 6.563 6.802 5 5.845 5c-.958 0-2.075.563-2.075 2.188v1.875c.002.492.18 2 .88 1.597-.827.978-.91 2.119-.899 3.223-.223.064-.45.137-.671.212-.684.234-1.41.532-1.737.744a.75.75 0 0 0 .814 1.26c.156-.101.721-.35 1.408-.585l.228-.075c.046.433.161.83.332 1.19l-.024.013c-.41.216-.79.465-1.032.623l-.113.074a.75.75 0 1 0 .814 1.26l.131-.086c.245-.16.559-.365.901-.545.08-.043.157-.081.231-.116C6.763 19.475 9.87 20 11.75 20s4.987-.525 6.717-2.148c.074.035.15.073.231.116.342.18.656.385.901.545l.131.086a.75.75 0 0 0 .814-1.26l-.113-.074a13.008 13.008 0 0 0-1.032-.623l-.024-.013c.171-.36.286-.757.332-1.19l.228.075c.687.235 1.252.484 1.409.585a.75.75 0 0 0 .813-1.26c-.327-.212-1.053-.51-1.736-.744-.221-.075-.449-.148-.672-.213.012-1.104-.072-2.244-.9-3.222.7.403.88-1.105.881-1.598V7.188C19.73 5.563 18.613 5 17.655 5c-.957 0-2.873 1.563-3.51 1.563-.767 0-.915-.157-2.395-.157Zm-.675 9.194c.202-.069.441-.1.675-.1.234 0 .473.031.676.1.1.034.22.088.328.174a.619.619 0 0 1 .246.476c0 .23-.139.39-.246.476-.107.086-.229.14-.328.174-.203.069-.442.1-.676.1-.234 0-.473-.031-.675-.1a1.078 1.078 0 0 1-.329-.174.619.619 0 0 1-.246-.476c0-.23.139-.39.246-.476.107-.086.23-.14.329-.174Zm2.845-3.1c.137-.228.406-.5.81-.5s.674.272.81.5c.142.239.21.527.21.813 0 .285-.068.573-.21.811-.136.229-.406.501-.81.501s-.673-.272-.81-.5a1.596 1.596 0 0 1-.21-.813c0-.285.068-.573.21-.811Zm-5.96 0c.137-.228.406-.5.81-.5s.674.272.81.5c.142.239.21.527.21.813 0 .285-.068.573-.21.811-.136.229-.406.501-.81.501s-.673-.272-.81-.5a1.596 1.596 0 0 1-.21-.813c0-.285.068-.573.21-.811Z"
+            />
+        </svg>
+    );
+};
+
+const settings = definePluginSettings({
+    randomGarySendMethod: {
+        description: "Choose the buttons behavior.",
+        type: OptionType.SELECT,
+        options: [
+            { label: "Left Click: Send as a link, Right Click: Send as an attachment", value: "link", default: true },
+            { label: "Left Click: Send as an attachment, Right Click: Send as a link", value: "attachment" }
+        ],
+    },
+    randomGaryImageSource: {
+        description: "Choose the source of the image",
+        type: OptionType.SELECT,
+        options: [
+            { label: "Gary API", value: "gary", default: true },
+            { label: "Cat API", value: "catapi" },
+            { label: "Minker API (attachment only)", value: "minker" },
+            { label: "Goober API", value: "goober" },
+            { label: "Gully API", value: "gully" }
+        ],
+    },
+});
+
+async function sendGaryLink(channelId: string, link: string) {
+    const reply = PendingReplyStore.getPendingReply(channelId);
+    if (reply) FluxDispatcher.dispatch({ type: "DELETE_PENDING_REPLY", channelId });
+    try {
+        if (getSlowmodeCooldownGuess(channelId) === 0) {
+            const channel = ChannelStore.getChannel(channelId);
+            if (channel.guild_id && !PermissionStore.can(PermissionsBits.EMBED_LINKS, channel)) {
+                showToast("Missing required permissions to embed links", Toasts.Type.FAILURE);
+                return;
+            }
+
+
+            sendMessage(channelId, {
+                content: link
+            }, true, {
+                messageReference: reply ? MessageActions.getSendMessageOptionsForReply(reply)?.messageReference : null,
+            });
+
+        }
+    } catch (error) {
+        console.error("Failed to send Gary link:", error);
+        showToast("Failed to send Gary image", Toasts.Type.FAILURE);
+    }
+}
+
+async function uploadGaryImage(url: string, channelId: string) {
+    const reply = PendingReplyStore.getPendingReply(channelId);
+    if (reply) FluxDispatcher.dispatch({ type: "DELETE_PENDING_REPLY", channelId });
+    try {
+        if (getSlowmodeCooldownGuess(channelId) === 0) {
+            const channel = ChannelStore.getChannel(channelId);
+
+            if (channel.guild_id && !PermissionStore.can(PermissionsBits.ATTACH_FILES, channel)) {
+                showToast("Missing required permissions to upload files", Toasts.Type.FAILURE);
+                return;
+            }
+
+            showToast("Uploading image, this may take a few seconds.", Toasts.Type.MESSAGE);
+            const buffer = await Native.getImageBuffer(url);
+            const blob = new Blob([buffer], { type: "image/jpeg" });
+            const file = new File([blob], "gary.jpg", { type: "image/jpeg" });
+            const upload = new CloudUpload({
+                file,
+                isThumbnail: false,
+                platform: 1,
+            }, channelId, false, 0);
+
+            upload.on("complete", () => {
+
+                sendMessage(channelId, {
+                    content: "",
+                }, true, {
+                    messageReference: reply ? MessageActions.getSendMessageOptionsForReply(reply)?.messageReference : null,
+                    attachmentsToUpload: [upload]
+                });
+            });
+
+            upload.on("error", () => showToast("Failed to upload Gary image", Toasts.Type.FAILURE));
+            upload.upload();
+        }
+    } catch (error) {
+        console.error("Failed to upload Gary image:", error);
+        MessageActions.sendMessage(channelId, { content: "Failed to upload Gary image :(" });
+    }
+}
+
+
+function GaryModal({ rootProps }: { rootProps: RenderModalProps; }) {
+    const options = [
+        { value: "gary", label: "Gary API" },
+        { value: "catapi", label: "Cat API" },
+        { value: "minker", label: "Minker API (attachment only)" },
+        { value: "goober", label: "Goober API" },
+        { value: "gully", label: "Gully API" }
+    ];
+    const currentValue = settings.use(["randomGaryImageSource"]).randomGaryImageSource;
+
+    return (
+        <Modal
+            {...rootProps}
+            title="Button Settings"
+        >
+            <Heading tag="h3">
+                {"Image Source"}
+            </Heading>
+
+            <SearchableSelect
+                options={options}
+                value={options.find(o => o.value === currentValue)?.value}
+                placeholder={"Select a source"}
+                maxVisibleItems={5}
+                closeOnSelect={true}
+                onChange={v => settings.store.randomGaryImageSource = v}
+            />
+        </Modal>
+    );
+}
+//@ts-ignore
+export const GaryChatBarIcon: ChatBarButton = ({ isMainChat }) => {
+    const [isAnimating, setIsAnimating] = useState(false);
+    const currentChannelId = SelectedChannelStore.getChannelId();
+
+    const handleClick = async (e: React.MouseEvent) => {
+        if (e.shiftKey) {
+            handleShiftClick();
+            return;
+        }
+
+        setIsAnimating(true);
+        setTimeout(() => setIsAnimating(false), 1000);
+
+        if (currentChannelId) {
+            const link = await getUrl();
+            if (settings.store.randomGarySendMethod === "link" && settings.store.randomGaryImageSource !== "minker") {
+                await sendGaryLink(currentChannelId, link);
+            } else {
+                await uploadGaryImage(link, currentChannelId);
+            }
+        }
+    };
+
+    const handleRightClick = async () => {
+        setIsAnimating(true);
+        setTimeout(() => setIsAnimating(false), 1000);
+
+        if (currentChannelId) {
+            const link = await getUrl();
+            if (settings.store.randomGarySendMethod === "attachment" && settings.store.randomGaryImageSource !== "minker") {
+                await sendGaryLink(currentChannelId, link);
+            } else {
+                await uploadGaryImage(link, currentChannelId);
+            }
+        }
+    };
+
+    const handleShiftClick = async () => {
+
+        openModal(props => (
+            <GaryModal rootProps={props} />
+        ));
+    };
+
+    if (!isMainChat) return null;
+
+    let buttonTooltip;
+    switch (settings.use(["randomGaryImageSource"]).randomGaryImageSource) {
+        case "gary":
+            buttonTooltip = "Click for Gary";
+            break;
+        case "catapi":
+            buttonTooltip = "Click for Cat";
+            break;
+        case "minker":
+            buttonTooltip = "Click for Minky";
+            break;
+        case "goober":
+            buttonTooltip = "Click for Goober";
+            break;
+        case "gully":
+            buttonTooltip = "Click for Gully";
+            break;
+    }
+
+    return (
+        <ChatBarButton
+            tooltip={buttonTooltip}
+            onClick={handleClick}
+            onContextMenu={handleRightClick}
+            buttonProps={{
+                "aria-label": "Gary Button",
+                "data-vc-gary": "true",
+                "data-vc-gary-animating": String(isAnimating)
+            } as any}
+        >
+            <GaryIcon />
+        </ChatBarButton>
+    );
+};
+
+export default definePlugin({
+    name: "RandomGary",
+    description: "Adds a button to send a random Gary picture!",
+    authors: [EquicordDevs.zach],
+    tags: ["Fun", "Media"],
+    settings,
+    start() {
+        VencordNative.csp.requestAddOverride("https://api.garythe.cat", ["img-src", "connect-src"], "RandomGary");
+        VencordNative.csp.requestAddOverride("api.garythe.cat", ["img-src", "connect-src"], "RandomGary");
+        VencordNative.csp.requestAddOverride("https://api.thecatapi.com", ["img-src", "connect-src"], "RandomGary");
+        VencordNative.csp.requestAddOverride("api.thecatapi.com", ["img-src", "connect-src"], "RandomGary");
+        VencordNative.csp.requestAddOverride("https://minky.materii.dev", ["img-src", "connect-src"], "RandomGary");
+        VencordNative.csp.requestAddOverride("minky.materii.dev", ["img-src", "connect-src"], "RandomGary");
+    },
+    stop() {
+    },
+    chatBarButton: {
+        icon: GaryIcon,
+        render: GaryChatBarIcon
+    }
+});
+
+export async function getUrl() {
+    switch (settings.store.randomGaryImageSource) {
+        case "gary":
+            const response = await fetch("https://api.garythe.cat/gary");
+            const json = await response.json();
+            return json.url;
+        case "goober":
+            const gooberResponse = await fetch("https://api.garythe.cat/goober");
+            const gooberJson = await gooberResponse.json();
+            return gooberJson.url;
+        case "catapi":
+            const catResponse = await fetch("https://api.thecatapi.com/v1/images/search");
+            const catJson = await catResponse.json();
+            return catJson[0].url;
+        case "minker":
+            return "https://minky.materii.dev/";
+        case "gully":
+            const gullyResponse = await fetch("https://api.garythe.cat/gully");
+            const gullyJson = await gullyResponse.json();
+            return gullyJson.url;
+        default:
+            throw new Error("Invalid randomGaryImageSource value");
+    }
+}
+
+

--- a/src/equicordplugins/randomGary/index.tsx
+++ b/src/equicordplugins/randomGary/index.tsx
@@ -206,10 +206,12 @@ export const GaryChatBarIcon: ChatBarButton = ({ isMainChat }) => {
         ));
     };
 
+    const { randomGaryImageSource } = settings.use(GARY_SETTINGS_KEYS);
+
     if (!isMainChat) return null;
 
     let buttonTooltip;
-    switch (settings.use(GARY_SETTINGS_KEYS).randomGaryImageSource) {
+    switch (randomGaryImageSource) {
         case "gary":
             buttonTooltip = "Click for Gary";
             break;

--- a/src/equicordplugins/randomGary/index.tsx
+++ b/src/equicordplugins/randomGary/index.tsx
@@ -1,3 +1,9 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import "./styles.css";
 
 import { ChatBarButton } from "@api/ChatButtons";
@@ -8,14 +14,13 @@ import { IconComponent } from "@utils/types";
 import definePlugin, { OptionType, PluginNative } from "@utils/types";
 import { sendMessage } from "@utils/discord";
 import { findByPropsLazy, findLazy, findStoreLazy } from "@webpack";
-import { ChannelStore, FluxDispatcher, MessageActions, PermissionsBits, PermissionStore, SearchableSelect, SelectedChannelStore, Modal, openModal, showToast, Toasts, useState } from "@webpack/common";
+import { ChannelStore, FluxDispatcher, MessageActions, PendingReplyStore, PermissionsBits, PermissionStore, SearchableSelect, SelectedChannelStore, Modal, openModal, showToast, Toasts, useState } from "@webpack/common";
 import { Heading } from "@components/Heading";
 import type { RenderModalProps } from "@vencord/discord-types";
 import { EquicordDevs } from "@utils/constants";
 
 const cl = classNameFactory("vc-gary-");
 const CloudUpload = findLazy(m => m.prototype?.trackUploadFinished);
-const PendingReplyStore = findStoreLazy("PendingReplyStore");
 const { getSlowmodeCooldownGuess } = findByPropsLazy("getSlowmodeCooldownGuess");
 const Native = VencordNative.pluginHelpers.RandomGary as PluginNative<typeof import("./native")>;
 
@@ -32,13 +37,10 @@ export const GaryIcon: IconComponent = ({ height = 20, width = 20, className }) 
 };
 
 const settings = definePluginSettings({
-    randomGarySendMethod: {
-        description: "Choose the buttons behavior.",
-        type: OptionType.SELECT,
-        options: [
-            { label: "Left Click: Send as a link, Right Click: Send as an attachment", value: "link", default: true },
-            { label: "Left Click: Send as an attachment, Right Click: Send as a link", value: "attachment" }
-        ],
+    randomGaryInvertBehavior: {
+        description: "Invert click behavior: left click sends as attachment, right click sends as link.",
+        type: OptionType.BOOLEAN,
+        default: false,
     },
     randomGaryImageSource: {
         description: "Choose the source of the image",
@@ -52,6 +54,8 @@ const settings = definePluginSettings({
         ],
     },
 });
+
+const GARY_SETTINGS_KEYS = ["randomGaryImageSource"] as const;
 
 async function sendGaryLink(channelId: string, link: string) {
     const reply = PendingReplyStore.getPendingReply(channelId);
@@ -71,9 +75,10 @@ async function sendGaryLink(channelId: string, link: string) {
                 messageReference: reply ? MessageActions.getSendMessageOptionsForReply(reply)?.messageReference : null,
             });
 
+        } else {
+            showToast("You are on cooldown, please wait before sending another image.", Toasts.Type.FAILURE);
         }
     } catch (error) {
-        console.error("Failed to send Gary link:", error);
         showToast("Failed to send Gary image", Toasts.Type.FAILURE);
     }
 }
@@ -112,10 +117,11 @@ async function uploadGaryImage(url: string, channelId: string) {
 
             upload.on("error", () => showToast("Failed to upload Gary image", Toasts.Type.FAILURE));
             upload.upload();
+        } else {
+            showToast("You are on cooldown, please wait before sending another image.", Toasts.Type.FAILURE);
         }
     } catch (error) {
-        console.error("Failed to upload Gary image:", error);
-        MessageActions.sendMessage(channelId, { content: "Failed to upload Gary image :(" });
+        showToast("Failed to upload Gary image", Toasts.Type.FAILURE);
     }
 }
 
@@ -128,7 +134,7 @@ function GaryModal({ rootProps }: { rootProps: RenderModalProps; }) {
         { value: "goober", label: "Goober API" },
         { value: "gully", label: "Gully API" }
     ];
-    const currentValue = settings.use(["randomGaryImageSource"]).randomGaryImageSource;
+    const currentValue = settings.use(GARY_SETTINGS_KEYS).randomGaryImageSource;
 
     return (
         <Modal
@@ -150,7 +156,7 @@ function GaryModal({ rootProps }: { rootProps: RenderModalProps; }) {
         </Modal>
     );
 }
-//@ts-ignore
+// @ts-expect-error ChatBarButton type doesn't include all props provided by the framework
 export const GaryChatBarIcon: ChatBarButton = ({ isMainChat }) => {
     const [isAnimating, setIsAnimating] = useState(false);
     const currentChannelId = SelectedChannelStore.getChannelId();
@@ -166,7 +172,9 @@ export const GaryChatBarIcon: ChatBarButton = ({ isMainChat }) => {
 
         if (currentChannelId) {
             const link = await getUrl();
-            if (settings.store.randomGarySendMethod === "link" && settings.store.randomGaryImageSource !== "minker") {
+            const isMinker = settings.store.randomGaryImageSource === "minker";
+            const invert = !!settings.store.randomGaryInvertBehavior;
+            if (!invert && !isMinker) {
                 await sendGaryLink(currentChannelId, link);
             } else {
                 await uploadGaryImage(link, currentChannelId);
@@ -180,7 +188,9 @@ export const GaryChatBarIcon: ChatBarButton = ({ isMainChat }) => {
 
         if (currentChannelId) {
             const link = await getUrl();
-            if (settings.store.randomGarySendMethod === "attachment" && settings.store.randomGaryImageSource !== "minker") {
+            const isMinker = settings.store.randomGaryImageSource === "minker";
+            const invert = !!settings.store.randomGaryInvertBehavior;
+            if (invert && !isMinker) {
                 await sendGaryLink(currentChannelId, link);
             } else {
                 await uploadGaryImage(link, currentChannelId);
@@ -198,7 +208,7 @@ export const GaryChatBarIcon: ChatBarButton = ({ isMainChat }) => {
     if (!isMainChat) return null;
 
     let buttonTooltip;
-    switch (settings.use(["randomGaryImageSource"]).randomGaryImageSource) {
+    switch (settings.use(GARY_SETTINGS_KEYS).randomGaryImageSource) {
         case "gary":
             buttonTooltip = "Click for Gary";
             break;

--- a/src/equicordplugins/randomGary/index.tsx
+++ b/src/equicordplugins/randomGary/index.tsx
@@ -172,13 +172,21 @@ export const GaryChatBarIcon: ChatBarButton = ({ isMainChat }) => {
         setTimeout(() => setIsAnimating(false), 1000);
 
         if (currentChannelId) {
-            const link = await getUrl();
-            const isMinker = settings.store.randomGaryImageSource === "minker";
-            const invert = !!settings.store.randomGaryInvertBehavior;
-            if (!invert && !isMinker) {
-                await sendGaryLink(currentChannelId, link);
-            } else {
-                await uploadGaryImage(link, currentChannelId);
+            try {
+                const link = await getUrl();
+                if (!link) {
+                    showToast("Failed to fetch image URL.", Toasts.Type.FAILURE);
+                    return;
+                }
+                const isMinker = settings.store.randomGaryImageSource === "minker";
+                const invert = !!settings.store.randomGaryInvertBehavior;
+                if (!invert && !isMinker) {
+                    await sendGaryLink(currentChannelId, link);
+                } else {
+                    await uploadGaryImage(link, currentChannelId);
+                }
+            } catch (err) {
+                showToast("Failed to fetch image. Check your connection.", Toasts.Type.FAILURE);
             }
         }
     };
@@ -188,13 +196,21 @@ export const GaryChatBarIcon: ChatBarButton = ({ isMainChat }) => {
         setTimeout(() => setIsAnimating(false), 1000);
 
         if (currentChannelId) {
-            const link = await getUrl();
-            const isMinker = settings.store.randomGaryImageSource === "minker";
-            const invert = !!settings.store.randomGaryInvertBehavior;
-            if (invert && !isMinker) {
-                await sendGaryLink(currentChannelId, link);
-            } else {
-                await uploadGaryImage(link, currentChannelId);
+            try {
+                const link = await getUrl();
+                if (!link) {
+                    showToast("Failed to fetch image URL.", Toasts.Type.FAILURE);
+                    return;
+                }
+                const isMinker = settings.store.randomGaryImageSource === "minker";
+                const invert = !!settings.store.randomGaryInvertBehavior;
+                if (invert && !isMinker) {
+                    await sendGaryLink(currentChannelId, link);
+                } else {
+                    await uploadGaryImage(link, currentChannelId);
+                }
+            } catch (err) {
+                showToast("Failed to fetch image. Check your connection.", Toasts.Type.FAILURE);
             }
         }
     };
@@ -267,24 +283,32 @@ export default definePlugin({
 
 export async function getUrl() {
     switch (settings.store.randomGaryImageSource) {
-        case "gary":
+        case "gary": {
             const response = await fetch("https://api.garythe.cat/gary");
+            if (!response.ok) throw new Error("Gary API error: " + response.status);
             const json = await response.json();
             return json.url;
-        case "goober":
+        }
+        case "goober": {
             const gooberResponse = await fetch("https://api.garythe.cat/goober");
+            if (!gooberResponse.ok) throw new Error("Goober API error: " + gooberResponse.status);
             const gooberJson = await gooberResponse.json();
             return gooberJson.url;
-        case "catapi":
+        }
+        case "catapi": {
             const catResponse = await fetch("https://api.thecatapi.com/v1/images/search");
+            if (!catResponse.ok) throw new Error("Cat API error: " + catResponse.status);
             const catJson = await catResponse.json();
-            return catJson[0].url;
+            return catJson[0]?.url;
+        }
         case "minker":
             return "https://minky.materii.dev/";
-        case "gully":
+        case "gully": {
             const gullyResponse = await fetch("https://api.garythe.cat/gully");
+            if (!gullyResponse.ok) throw new Error("Gully API error: " + gullyResponse.status);
             const gullyJson = await gullyResponse.json();
             return gullyJson.url;
+        }
         default:
             throw new Error("Invalid randomGaryImageSource value");
     }

--- a/src/equicordplugins/randomGary/native.ts
+++ b/src/equicordplugins/randomGary/native.ts
@@ -1,0 +1,7 @@
+export async function getImageBuffer(_, url: string) {
+    const response = await fetch(url);
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+
+}
+

--- a/src/equicordplugins/randomGary/native.ts
+++ b/src/equicordplugins/randomGary/native.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-const allowedDomains = ["api.garythe.cat", "minky.materii.dev", "api.thecatapi.com"];
+const allowedDomains = ["api.garythe.cat", "cdn.garythe.cat", "minky.materii.dev", "api.thecatapi.com"];
 
 export async function getImageBuffer(_, url: string): Promise<Buffer | null> {
     try {

--- a/src/equicordplugins/randomGary/native.ts
+++ b/src/equicordplugins/randomGary/native.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-const allowedDomains = ["api.garythe.cat", "cdn.garythe.cat", "minky.materii.dev", "api.thecatapi.com"];
+const allowedDomains = ["api.garythe.cat", "cdn.garythe.cat", "minky.materii.dev", "api.thecatapi.com", "cdn2.thecatapi.com"];
 
 export async function getImageBuffer(_, url: string): Promise<Buffer | null> {
     try {

--- a/src/equicordplugins/randomGary/native.ts
+++ b/src/equicordplugins/randomGary/native.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-const allowedDomains = ["api.garybot.dev", "minky.materii.dev", "api.thecatapi.com"];
+const allowedDomains = ["api.garythe.cat", "minky.materii.dev", "api.thecatapi.com"];
 
 export async function getImageBuffer(_, url: string): Promise<Buffer | null> {
     try {

--- a/src/equicordplugins/randomGary/native.ts
+++ b/src/equicordplugins/randomGary/native.ts
@@ -1,7 +1,29 @@
-export async function getImageBuffer(_, url: string) {
-    const response = await fetch(url);
-    const arrayBuffer = await response.arrayBuffer();
-    return Buffer.from(arrayBuffer);
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
 
+const allowedDomains = ["api.garybot.dev", "minky.materii.dev", "api.thecatapi.com"];
+
+export async function getImageBuffer(_, url: string): Promise<Buffer | null> {
+    try {
+        const parsedUrl = new URL(url);
+
+        if (!allowedDomains.includes(parsedUrl.hostname)) {
+            return null;
+        }
+
+        const response = await fetch(parsedUrl.href);
+
+        if (!response.ok) {
+            return null;
+        }
+
+        const arrayBuffer = await response.arrayBuffer();
+        return Buffer.from(arrayBuffer);
+
+    } catch (error) {
+        return null;
+    }
 }
-

--- a/src/equicordplugins/randomGary/styles.css
+++ b/src/equicordplugins/randomGary/styles.css
@@ -1,3 +1,10 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+
 .vc-gary-icon {
     transform-origin: center;
     display: inline-block;

--- a/src/equicordplugins/randomGary/styles.css
+++ b/src/equicordplugins/randomGary/styles.css
@@ -1,0 +1,74 @@
+.vc-gary-icon {
+    transform-origin: center;
+    display: inline-block;
+    transition: transform 0.3s ease-in-out;
+    width: 24px;
+    height: 24px;
+}
+
+
+@keyframes gary-bounce-rotate {
+
+    0%,
+    100% {
+        transform: translateY(0) rotate(0deg);
+    }
+
+    15% {
+        transform: translateY(-10px) rotate(20deg);
+    }
+
+    30% {
+        transform: translateY(5px) rotate(-10deg);
+    }
+
+    45% {
+        transform: translateY(-5px) rotate(5deg);
+    }
+
+    60% {
+        transform: translateY(2px) rotate(-2deg);
+    }
+
+    75% {
+        transform: translateY(-1px) rotate(1deg);
+    }
+
+    90% {
+        transform: translateY(0) rotate(0deg);
+    }
+}
+
+.vc-chatbar-button [data-vc-gary][data-vc-gary-animating="true"] .vc-gary-icon {
+    animation: gary-bounce-rotate 1s ease-in-out;
+}
+
+.vc-chatbar-button [data-vc-gary]:hover .vc-gary-icon {
+    animation: gary-hover 0.5s ease-in-out;
+}
+
+.vc-chatbar-button [data-vc-gary][data-vc-gary-animating="true"]:hover .vc-gary-icon {
+    animation: gary-bounce-rotate 1s ease-in-out;
+}
+
+@keyframes gary-hover {
+
+    0%,
+    100% {
+        transform: rotate(0deg);
+    }
+
+    25% {
+        transform: rotate(5deg);
+    }
+
+    75% {
+        transform: rotate(-5deg);
+    }
+}
+
+.vc-gary-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1337,6 +1337,10 @@ export const EquicordDevs = Object.freeze({
         name: "qdnx",
         id: 1374803023506702508n
     },
+    zach: {
+        name: "zach",
+        id: 435847641041993759n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
Adds a button to send random Gary, Goober, Gully, Minky, or random cat pictures in your Discord chats!

## Features
- Chat bar button for quick Gary/Goober/Gully/Minky/random cat picture sharing
- Multiple image sources: Gary API, Goober API, Gully API, Cat API, or Minker API
- Send as links or attachments
- Settings accessible via Shift + Click

## Usage
- Click: Send picture as link
- Right-click: Send picture as attachment
- Shift + Click: Open settings

## Settings
- Choose your image source
- Invert the click/right click behavior of the button
- Note: Minker API is attachment-only