### PR TITLE
fix(dragify): pass message.author instead of author to onUserDragStart

### DIFF
--- a/src/equicordplugins/dragify/index.tsx
+++ b/src/equicordplugins/dragify/index.tsx
@@ -216,7 +216,7 @@ export default definePlugin({
             find: ']="BADGES"',
             replacement: {
                 match: /(?="data-username-has-gradient")/,
-                replace: "draggable:!0,onDragStart:e=>$self.onUserDragStart(e,arguments[0].author),\"data-dragify-user\":!0,\"data-user-id\":arguments[0].author.id,"
+                replace: "draggable:!0,onDragStart:e=>$self.onUserDragStart(e,arguments[0].message.author),\"data-dragify-user\":!0,\"data-user-id\":arguments[0].message.author.id,"
             }
         },
         // Call avatars (DM/group call tiles)
@@ -382,10 +382,10 @@ export default definePlugin({
         if (inspection.hasAttachment) return;
 
         const rawUserId =
-            inspection.authorId
-            ?? user?.id
+            user?.id
             ?? user?.userId
             ?? user?.user?.id
+            ?? inspection.authorId
             ?? inspection.userId
             ?? null;
         const userId = rawUserId?.trim();

--- a/src/equicordplugins/dragify/index.tsx
+++ b/src/equicordplugins/dragify/index.tsx
@@ -216,7 +216,7 @@ export default definePlugin({
             find: ']="BADGES"',
             replacement: {
                 match: /(?="data-username-has-gradient")/,
-                replace: "draggable:!0,onDragStart:e=>$self.onUserDragStart(e,arguments[0].message.author),\"data-dragify-user\":!0,\"data-user-id\":arguments[0].message.author.id,"
+                replace: "draggable:!0,onDragStart:e=>$self.onUserDragStart(e,arguments[0].message?.author),\"data-dragify-user\":!0,\"data-user-id\":arguments[0].message?.author?.id,"
             }
         },
         // Call avatars (DM/group call tiles)


### PR DESCRIPTION
The patch passed arguments[0].author which is a nickname display object with no .id. The full user object is at arguments[0].message.author.

Also changed onUserDragStart priority so user?.id checks before DOM inspection