### PR TITLE
fix(declutter): update regex for billing settings replacement

### DIFF
--- a/src/equicordplugins/declutter/index.tsx
+++ b/src/equicordplugins/declutter/index.tsx
@@ -335,7 +335,7 @@ export default definePlugin({
             // Billing settings
             find: ".BILLING_SECTION,",
             replacement: {
-                match: /(?<=#{intl::BILLING}\),buildLayout:\(\)=>)\[.+?\]/,
+                match: /(?<=BILLING_SECTION[\s\S]{0,300}?\i:\(\)=>)\[.+?\]/,
                 replace: "[]",
             },
             predicate: () => settings.store.removeBillingSettings,


### PR DESCRIPTION
Fix the issue of not hiding billing section.

Bug found by nug

<img width="941" height="1045" alt="discord screenshot" src="https://github.com/user-attachments/assets/1e9e2ccf-4210-43a4-8347-3e547384f8ff" />
