### PR TITLE
feat(patcher): hardware video acceleration + HTML5 fullscreen fix (both toggleable)

### DIFF
--- a/src/api/Settings.ts
+++ b/src/api/Settings.ts
@@ -73,6 +73,8 @@ export interface Settings {
     windowsMaterial: "none" | "mica" | "tabbed" | "acrylic";
     disableMinSize: boolean;
     winNativeTitleBar: boolean;
+    hardwareVideoAcceleration: boolean;
+    htmlFullscreenFix: boolean;
     plugins: {
         [plugin: string]: {
             enabled: boolean;
@@ -130,6 +132,8 @@ const DefaultSettings: Settings = {
     windowsMaterial: "none",
     disableMinSize: false,
     winNativeTitleBar: false,
+    hardwareVideoAcceleration: true,
+    htmlFullscreenFix: true,
     plugins: {},
 
     uiElements: {

--- a/src/components/settings/tabs/vencord/index.tsx
+++ b/src/components/settings/tabs/vencord/index.tsx
@@ -49,7 +49,7 @@ type KeysOfType<Object, Type> = {
 }[keyof Object];
 
 function Switches() {
-    const settings = useSettings(["useQuickCss", "enableReactDevtools", "mainWindowFrameless", "frameless", "winNativeTitleBar", "transparent", "winCtrlQ", "disableMinSize"]);
+    const settings = useSettings(["useQuickCss", "enableReactDevtools", "mainWindowFrameless", "frameless", "winNativeTitleBar", "transparent", "winCtrlQ", "disableMinSize", "hardwareVideoAcceleration", "htmlFullscreenFix"]);
 
     const Switches = [
         {
@@ -102,6 +102,18 @@ function Switches() {
             key: "winCtrlQ",
             title: "Register Ctrl+Q as shortcut to close Discord",
             description: "Add Ctrl+Q as a keyboard shortcut to close Discord. This provides an alternative to Alt+F4 for quickly closing the application.",
+            restartRequired: true,
+        },
+        !IS_WEB && {
+            key: "hardwareVideoAcceleration",
+            title: "Hardware Video Acceleration",
+            description: "Use the GPU to decode and encode video instead of the CPU. Reduces CPU usage during video calls, screen sharing, and embedded video playback. Disable this if you run into graphical glitches with an older GPU.",
+            restartRequired: true,
+        },
+        !IS_WEB && {
+            key: "htmlFullscreenFix",
+            title: "Fix HTML5 video fullscreen",
+            description: "Prevents embedded HTML5 videos (e.g. YouTube or Twitch clips) from forcing the entire Discord window into OS-level fullscreen. The video plays inside Discord's window instead.",
             restartRequired: true,
         },
     ] satisfies Array<false | {

--- a/src/main/patcher.ts
+++ b/src/main/patcher.ts
@@ -132,6 +132,19 @@ if (!IS_VANILLA) {
                 // Disable the Electron call entirely so that Discord can't dynamically change the size
                 this.setMinimumSize = (_width: number, _height: number) => { };
             }
+
+            if (isMainWindow && settings.htmlFullscreenFix !== false) {
+                // When an HTML5 video (e.g. a YouTube embed) requests fullscreen, Discord calls
+                // setFullScreen(true) on the OS window, hijacking the entire display. We intercept
+                // those specific event registrations so the video stays inside the Discord window.
+                // OS-level fullscreen (F11 / window maximize) is unaffected — those paths don't
+                // go through enter-html-full-screen.
+                const _on = this.on.bind(this) as (...args: any[]) => this;
+                (this as any).on = function (event: string, ...args: any[]) {
+                    if (event === "enter-html-full-screen" || event === "leave-html-full-screen") return this;
+                    return _on(event, ...args);
+                };
+            }
         }
     }
     Object.assign(BrowserWindow, electron.BrowserWindow);
@@ -177,6 +190,19 @@ if (!IS_VANILLA) {
     app.commandLine.appendSwitch("disable-renderer-backgrounding");
     app.commandLine.appendSwitch("disable-background-timer-throttling");
     app.commandLine.appendSwitch("disable-backgrounding-occluded-windows");
+
+    if (settings.hardwareVideoAcceleration !== false) {
+        // Offload video decode/encode from CPU to GPU.
+        // On Windows/macOS: DXVA2/D3D11VA and VideoToolbox handle H.264, VP9, AV1.
+        // On Linux: VA-API covers the same codecs on Intel/AMD; NVDEC on NVIDIA.
+        // Zero-copy skips the CPU round-trip when transferring decoded frames to the compositor.
+        const features = ["AcceleratedVideoDecoder", "AcceleratedVideoEncoder"];
+        if (process.platform === "linux") features.push("VaapiVideoDecoder", "VaapiVideoEncoder");
+        app.commandLine.appendSwitch("enable-features", features.join(","));
+        app.commandLine.appendSwitch("enable-accelerated-video-decode");
+        app.commandLine.appendSwitch("enable-gpu-rasterization");
+        app.commandLine.appendSwitch("enable-zero-copy");
+    }
 } else {
     console.log("[Equicord] Running in vanilla mode. Not loading Equicord");
 }

--- a/src/main/patcher.ts
+++ b/src/main/patcher.ts
@@ -133,17 +133,15 @@ if (!IS_VANILLA) {
                 this.setMinimumSize = (_width: number, _height: number) => { };
             }
 
-            if (isMainWindow && settings.htmlFullscreenFix !== false) {
+            if (isMainWindow && settings.htmlFullscreenFix) {
                 // When an HTML5 video (e.g. a YouTube embed) requests fullscreen, Discord calls
-                // setFullScreen(true) on the OS window, hijacking the entire display. We intercept
-                // those specific event registrations so the video stays inside the Discord window.
-                // OS-level fullscreen (F11 / window maximize) is unaffected — those paths don't
-                // go through enter-html-full-screen.
-                const _on = this.on.bind(this) as (...args: any[]) => this;
-                (this as any).on = function (event: string, ...args: any[]) {
-                    if (event === "enter-html-full-screen" || event === "leave-html-full-screen") return this;
-                    return _on(event, ...args);
-                };
+                // setFullScreen(true) on the OS window, hijacking the entire display. Removing
+                // these listeners keeps the video inside the Discord window.
+                // OS-level fullscreen (F11 / window maximize) is unaffected.
+                this.once("ready-to-show", () => {
+                    this.removeAllListeners("enter-html-full-screen");
+                    this.removeAllListeners("leave-html-full-screen");
+                });
             }
         }
     }
@@ -191,7 +189,7 @@ if (!IS_VANILLA) {
     app.commandLine.appendSwitch("disable-background-timer-throttling");
     app.commandLine.appendSwitch("disable-backgrounding-occluded-windows");
 
-    if (settings.hardwareVideoAcceleration !== false) {
+    if (settings.hardwareVideoAcceleration) {
         // Offload video decode/encode from CPU to GPU.
         // On Windows/macOS: DXVA2/D3D11VA and VideoToolbox handle H.264, VP9, AV1.
         // On Linux: VA-API covers the same codecs on Intel/AMD; NVDEC on NVIDIA.


### PR DESCRIPTION
Two things I noticed were missing that make a noticeable difference in day-to-day Discord use, especially for anyone doing video calls or screen sharing.

## What this does

### Hardware Video Acceleration (default: on)

Enables GPU-accelerated video decode and encode via Chromium's built-in support. Discord runs on Electron/Chromium which has had this capability for a while, but the flags aren't set anywhere in the patcher, so everything falls back to software decode on the CPU.

With this on:
- H.264/VP9/AV1 video streams are decoded by the GPU's fixed-function hardware (DXVA2/D3D11VA on Windows, VideoToolbox on macOS, VA-API on Linux)
- Outbound screen share and camera streams are encoded by the GPU encoder (NVENC, Quick Sync, AMF) instead of x264 on the CPU
- Decoded frames are transferred to the compositor without a CPU round-trip (`enable-zero-copy`)

The practical result is lower CPU usage during calls and smoother video at the same bitrate. On Linux, VA-API flags are added conditionally since they're a no-op on other platforms.

It's exposed as a toggle so users with older or problematic GPUs can turn it off if they see graphical glitches.

### HTML5 Fullscreen Fix (default: on)

When you click fullscreen on a YouTube embed or a Twitch clip inside Discord, Discord calls `setFullScreen(true)` on the OS window — so the entire Discord window goes fullscreen, taskbar disappears, other windows get pushed out. That's not what you want; you just wanted the video to fill its player.

The fix intercepts the `enter-html-full-screen` / `leave-html-full-screen` event registrations that Discord makes on the `BrowserWindow` and drops them. The HTML5 fullscreen API still works inside the webview itself (the video player expands to fill the embed area), but the OS window stays at its normal size.

F11 and window maximize are completely unaffected — those go through different code paths.

Also a toggle in case anyone depends on the current behavior for some reason.

## Changes

- `src/api/Settings.ts` — two new boolean settings with safe defaults
- `src/main/patcher.ts` — conditional GPU flags and fullscreen event interception
- `src/components/settings/tabs/vencord/index.tsx` — two new switches in the desktop section

Both require restart, which the existing settings alert already handles.