### PR TITLE
fix(ProfileSets): restore banner apply when loading presets

### DIFF
--- a/src/equicordplugins/profileSets/utils/actions.ts
+++ b/src/equicordplugins/profileSets/utils/actions.ts
@@ -19,26 +19,41 @@ function isImageInput(value: unknown): value is string | { imageUri: string; } {
     return typeof value === "object" && isNonNullish(value) && "imageUri" in value && typeof (value as { imageUri: unknown }).imageUri === "string";
 }
 
-function getFreshPendingAvatar(section: PresetSection, guildId?: string): string | null {
+function getFreshPendingImage(
+    section: PresetSection,
+    guildId: string | undefined,
+    keys: string[]
+): string | null {
     const pending = (section === "server" && guildId
         ? UserProfileSettingsStore.getPendingChanges?.(guildId)
         : UserProfileSettingsStore.getPendingChanges?.()) ?? {};
     const pendingObj = pending as Record<string, unknown>;
-    const selected = [pendingObj.pendingAvatar].find(isImageInput);
+    const selected = keys.map(k => pendingObj[k]).find(isImageInput);
     if (!selected) return null;
     return typeof selected === "string" ? selected : selected.imageUri;
+}
+
+function getFreshPendingAvatar(section: PresetSection, guildId?: string): string | null {
+    return getFreshPendingImage(section, guildId, ["pendingAvatar"]);
+}
+
+function getFreshPendingBanner(section: PresetSection, guildId?: string): string | null {
+    return getFreshPendingImage(section, guildId, ["pendingBanner", "banner"]);
 }
 
 export async function savePreset(name: string, section: PresetSection, guildId?: string) {
     const profile = await getCurrentProfile(guildId, { isGuildProfile: section === "server" });
     const freshPendingAvatar = getFreshPendingAvatar(section, guildId);
+    const freshPendingBanner = getFreshPendingBanner(section, guildId);
     const effectiveAvatar = freshPendingAvatar ?? profile.avatarDataUrl ?? null;
+    const effectiveBanner = freshPendingBanner ?? profile.bannerDataUrl ?? null;
 
     const newPreset: ProfilePresetEx = {
         name,
         timestamp: Date.now(),
         ...profile,
         avatarDataUrl: effectiveAvatar,
+        bannerDataUrl: effectiveBanner,
     };
     addPreset(newPreset);
     await savePresetsData(section);

--- a/src/equicordplugins/profileSets/utils/profile.ts
+++ b/src/equicordplugins/profileSets/utils/profile.ts
@@ -62,16 +62,12 @@ function setPendingBanner(banner: ImageInput, guildId?: string) {
     dispatch("USER_PROFILE_SETTINGS_SET_PENDING_BANNER", guildId ? { guildId, banner } : { banner });
 }
 
-function openProfileCustomizationPreviewModal(payload: Record<string, unknown>) {
-    dispatch("PROFILE_CUSTOMIZATION_OPEN_PREVIEW_MODAL", payload);
-}
-
 function openProfileImagePreview(
     uploadType: "AVATAR" | "BANNER",
     image: { imageUri: string; [key: string]: unknown; },
     guildId?: string
 ) {
-    openProfileCustomizationPreviewModal({
+    dispatch("PROFILE_CUSTOMIZATION_OPEN_PREVIEW_MODAL", {
         image,
         file: {},
         uploadType,
@@ -348,13 +344,6 @@ function resolvePendingAvatar(pendingChanges: PendingChanges | null): ImageInput
     return hasImageInput(pendingChanges.pendingAvatar) ? pendingChanges.pendingAvatar : null;
 }
 
-function resolvePendingBanner(pendingChanges: PendingChanges | null): ImageInput {
-    if (!pendingChanges) return null;
-
-    const pending = pendingChanges.pendingBanner ?? (pendingChanges as { banner?: ImageInput; }).banner;
-    return hasImageInput(pending) ? pending : null;
-}
-
 function normalizeImageValue(value: unknown): string | null {
     if (typeof value === "string") return value;
     if (value && typeof value === "object" && "imageUri" in value) {
@@ -415,18 +404,10 @@ export async function loadPresetAsPending(preset: ProfilePreset, guildId?: strin
 
         if ("bannerDataUrl" in preset && preset.bannerDataUrl !== current.bannerDataUrl) {
             const bannerPayload = toBannerPayload(preset.bannerDataUrl, preset.name);
-            const bannerImageUri = normalizeImageValue(bannerPayload);
             const effectiveGuildId = isGuild ? guildId : undefined;
 
-            if (isNonEmptyString(bannerImageUri)) {
-                // Data-URL banners must go through the profile customization preview modal to apply.
-                openProfileImagePreview(
-                    "BANNER",
-                    typeof bannerPayload === "object" && bannerPayload != null && "imageUri" in bannerPayload
-                        ? { ...bannerPayload, imageUri: bannerImageUri }
-                        : { imageUri: bannerImageUri },
-                    effectiveGuildId
-                );
+            if (typeof bannerPayload === "object" && bannerPayload !== null) {
+                openProfileImagePreview("BANNER", bannerPayload, effectiveGuildId);
             } else if (bannerPayload != null) {
                 setPending({ pendingBanner: bannerPayload });
                 setPendingBanner(bannerPayload, effectiveGuildId);

--- a/src/equicordplugins/profileSets/utils/profile.ts
+++ b/src/equicordplugins/profileSets/utils/profile.ts
@@ -57,6 +57,45 @@ function setPendingChanges(payload: Record<string, unknown>, guildId?: string) {
     dispatch("USER_PROFILE_SETTINGS_SET_PENDING_CHANGES", guildId ? { guildId, ...payload } : payload);
 }
 
+function setPendingBanner(banner: ImageInput, guildId?: string) {
+    if (banner === undefined) return;
+    dispatch("USER_PROFILE_SETTINGS_SET_PENDING_BANNER", guildId ? { guildId, banner } : { banner });
+}
+
+function openProfileCustomizationPreviewModal(payload: Record<string, unknown>) {
+    dispatch("PROFILE_CUSTOMIZATION_OPEN_PREVIEW_MODAL", payload);
+}
+
+function openProfileImagePreview(
+    uploadType: "AVATAR" | "BANNER",
+    image: { imageUri: string; [key: string]: unknown; },
+    guildId?: string
+) {
+    openProfileCustomizationPreviewModal({
+        image,
+        file: {},
+        uploadType,
+        guildId,
+        analyticsSource: guildId ? "user settings guild profile" : "user settings user profile",
+        isTryItOut: false
+    });
+}
+
+function buildNewAssetPayload(dataUrl: string, presetName?: string): { assetOrigin: "NEW_ASSET"; imageUri: string; description: string; } {
+    return {
+        assetOrigin: "NEW_ASSET",
+        imageUri: dataUrl,
+        description: `profilesets-${presetName ?? "preset"}`
+    };
+}
+
+function toBannerPayload(bannerValue: ImageInput, presetName?: string): ImageInput {
+    if (typeof bannerValue === "string" && bannerValue.startsWith("data:")) {
+        return buildNewAssetPayload(bannerValue, presetName);
+    }
+    return bannerValue;
+}
+
 function isNonEmptyString(value: unknown): value is string {
     return typeof value === "string" && value.length > 0;
 }
@@ -121,6 +160,28 @@ async function processImage(imageData: ImageInput, userId: string, type: "avatar
         }
 
         const isAnimated = imageData.startsWith("a_");
+
+        if (type === "banner") {
+            const bannerUrl = useGuildPath && guildId
+                ? IconUtils.getGuildMemberBannerURL?.({
+                    id: userId,
+                    guildId,
+                    banner: imageData,
+                    canAnimate: isAnimated,
+                    size: 1024
+                })
+                : IconUtils.getUserBannerURL?.({
+                    id: userId,
+                    banner: imageData,
+                    canAnimate: isAnimated,
+                    size: 1024
+                });
+            if (bannerUrl) {
+                const fromUtils = await imageUrlToBase64(bannerUrl);
+                if (fromUtils) return fromUtils;
+            }
+        }
+
         const size = type === "banner" ? 1024 : 512;
         const urlPath = type === "banner" ? "banners" : "avatars";
         const guildPath = guildId ? `guilds/${guildId}/users/${userId}/${type === "banner" ? "banners" : "avatars"}` : urlPath;
@@ -237,10 +298,12 @@ export async function getCurrentProfile(guildId?: string, options: CurrentProfil
     const avatarDataUrl = await processImage(avatarInput, currentUser.id, "avatar", effectiveGuildId, useGuildAvatar);
     const resolvedAvatarDataUrl = avatarDataUrl ?? IconUtils.getDefaultAvatarURL(currentUser.id);
 
-    const { pendingBanner } = pendingChanges;
+    const pendingBanner = pendingChanges.pendingBanner ?? (pendingChanges as { banner?: ImageInput; }).banner;
     const bannerToUse: ImageInput = hasImageInput(pendingBanner)
         ? pendingBanner
-        : (isGuildProfile ? (guildProfile?.banner ?? baseProfile?.banner) : baseProfile?.banner);
+        : (isGuildProfile
+            ? (guildProfile?.banner ?? baseProfile?.banner)
+            : (baseProfile?.banner ?? currentUser.banner ?? null));
     const useGuildBanner = !!(effectiveGuildId && isGuildProfile && guildProfile?.banner && bannerToUse === guildProfile?.banner);
 
     const bannerDataUrl = await processImage(bannerToUse, currentUser.id, "banner", effectiveGuildId, useGuildBanner);
@@ -283,6 +346,13 @@ function resolvePendingAvatar(pendingChanges: PendingChanges | null): ImageInput
     if (!pendingChanges) return null;
 
     return hasImageInput(pendingChanges.pendingAvatar) ? pendingChanges.pendingAvatar : null;
+}
+
+function resolvePendingBanner(pendingChanges: PendingChanges | null): ImageInput {
+    if (!pendingChanges) return null;
+
+    const pending = pendingChanges.pendingBanner ?? (pendingChanges as { banner?: ImageInput; }).banner;
+    return hasImageInput(pending) ? pending : null;
 }
 
 function normalizeImageValue(value: unknown): string | null {
@@ -344,14 +414,26 @@ export async function loadPresetAsPending(preset: ProfilePreset, guildId?: strin
         }
 
         if ("bannerDataUrl" in preset && preset.bannerDataUrl !== current.bannerDataUrl) {
-            const bannerPayload = preset.bannerDataUrl?.startsWith?.("data:")
-                ? {
-                    assetOrigin: "NEW_ASSET",
-                    imageUri: preset.bannerDataUrl,
-                    description: `profilesets-${preset.name ?? "preset"}`
-                }
-                : preset.bannerDataUrl;
-            setPending({ pendingBanner: bannerPayload });
+            const bannerPayload = toBannerPayload(preset.bannerDataUrl, preset.name);
+            const bannerImageUri = normalizeImageValue(bannerPayload);
+            const effectiveGuildId = isGuild ? guildId : undefined;
+
+            if (isNonEmptyString(bannerImageUri)) {
+                // Data-URL banners must go through the profile customization preview modal to apply.
+                openProfileImagePreview(
+                    "BANNER",
+                    typeof bannerPayload === "object" && bannerPayload != null && "imageUri" in bannerPayload
+                        ? { ...bannerPayload, imageUri: bannerImageUri }
+                        : { imageUri: bannerImageUri },
+                    effectiveGuildId
+                );
+            } else if (bannerPayload != null) {
+                setPending({ pendingBanner: bannerPayload });
+                setPendingBanner(bannerPayload, effectiveGuildId);
+            } else {
+                setPending({ pendingBanner: null });
+                setPendingBanner(null, effectiveGuildId);
+            }
         }
 
         if (!options.skipBio && preset?.bio !== current?.bio) {


### PR DESCRIPTION
Fixes #1129

## Summary

- Restores `openProfileImagePreview("BANNER", …)` / `PROFILE_CUSTOMIZATION_OPEN_PREVIEW_MODAL` when loading a preset whose banner is a data URL (`NEW_ASSET`). This matches the approach used in PR #936 before patch 3/3 removed it.
- Keeps fallbacks: `pendingBanner` via `SET_PENDING_CHANGES` and `USER_PROFILE_SETTINGS_SET_PENDING_BANNER` for non–data-URL banners and clearing banners.
- Save path: read fresh pending banner when saving presets, fall back to `currentUser.banner`, and resolve banner hashes via `IconUtils` where available.

## Test plan

- [x] Build with `pnpm buildStandalone` and test locally on Discord stable
- [x] Save preset with banner → export JSON includes `bannerDataUrl`
- [x] Load preset → banner preview modal opens; **Apply** updates profile editor banner
- [x] Avatar and other preset fields still apply as before

## Notes

Loading a preset with a data-URL banner opens Discord’s normal banner crop/preview UI (same as manual upload). User taps **Apply** once — expected Discord behavior, not a regression.