### PR TITLE
feat: add PluginDiagnostics plugin

### DIFF
--- a/src/equicordplugins/pluginDiagnostics/DiagnosticsModal.tsx
+++ b/src/equicordplugins/pluginDiagnostics/DiagnosticsModal.tsx
@@ -1,0 +1,125 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// ─── Layer 3: UI (render ONLY — no scanning, no scoring) ─────────────────────
+
+import "./styles.css";
+
+import { saveFile } from "@utils/web";
+import { Modal, React, useState } from "@webpack/common";
+
+import type { ScoredPlugin } from "./scoring";
+
+type SortKey = "name" | "hooks" | "listeners" | "patches" | "uiInjects" | "risk";
+
+const COLUMNS: { key: SortKey; label: string; tip: string; num: boolean; }[] = [
+    { key: "name", label: "Plugin", tip: "Plugin name", num: false },
+    { key: "hooks", label: "Hooks", tip: "Registered slash commands", num: true },
+    { key: "listeners", label: "Listeners", tip: "Flux/Dispatcher subscriptions", num: true },
+    { key: "patches", label: "Patches", tip: "Webpack code patches", num: true },
+    { key: "uiInjects", label: "UI Injects", tip: "Context menus + UI render surfaces", num: true },
+    { key: "risk", label: "Risk", tip: "(patches×2) + (listeners×3) + (uiInjects×1.5)", num: true },
+];
+
+function exportJson(rows: ScoredPlugin[], heapMB: number | null) {
+    const payload = {
+        type: "plugin-diagnostics",
+        version: 1,
+        takenAt: new Date().toISOString(),
+        heapMB,
+        plugins: rows,
+    };
+    const date = new Date().toISOString().slice(0, 10);
+    saveFile(new File([JSON.stringify(payload, null, 2)], `plugin-diagnostics-${date}.json`, { type: "application/json" }));
+}
+
+export function DiagnosticsModal({ modalProps, initial, heapMB, rescan }: {
+    modalProps: any;
+    initial: ScoredPlugin[];
+    heapMB: number | null;
+    rescan: () => ScoredPlugin[];
+}) {
+    const [rows, setRows] = useState<ScoredPlugin[]>(initial);
+    const [search, setSearch] = useState("");
+    const [sortKey, setSortKey] = useState<SortKey>("risk");
+    const [asc, setAsc] = useState(false);
+
+    function sortBy(key: SortKey) {
+        if (key === sortKey) setAsc(!asc);
+        else { setSortKey(key); setAsc(key === "name"); }
+    }
+
+    const q = search.trim().toLowerCase();
+    const view = rows
+        .filter(r => !q || r.name.toLowerCase().includes(q))
+        .sort((a, b) => {
+            const av = a[sortKey], bv = b[sortKey];
+            const cmp = typeof av === "string"
+                ? (av as string).localeCompare(bv as string)
+                : (av as number) - (bv as number);
+            return asc ? cmp : -cmp;
+        });
+
+    return (
+        <Modal {...modalProps} size="lg" title="Plugin Diagnostics">
+            <div className="vc-diag">
+                <div className="vc-diag-sub">One-time plugin resource snapshot</div>
+
+                <div className="vc-diag-toolbar">
+                    <input
+                        className="vc-diag-search"
+                        type="text"
+                        placeholder="Search..."
+                        value={search}
+                        onChange={e => setSearch((e.target as HTMLInputElement).value)}
+                    />
+                    <div className="vc-diag-actions">
+                        {heapMB != null && (
+                            <span className="vc-diag-heap" title="Current JS heap">Heap: {heapMB} MB</span>
+                        )}
+                        <button className="vc-diag-btn" onClick={() => setRows(rescan())}>Re-scan</button>
+                        <button className="vc-diag-btn" onClick={() => exportJson(view, heapMB)}>Export JSON</button>
+                    </div>
+                </div>
+
+                <div className="vc-diag-tablewrap">
+                    <table className="vc-diag-table">
+                        <thead>
+                            <tr>
+                                {COLUMNS.map(c => (
+                                    <th
+                                        key={c.key}
+                                        title={c.tip}
+                                        className={c.num ? "num" : ""}
+                                        onClick={() => sortBy(c.key)}
+                                    >
+                                        {c.label}{sortKey === c.key ? (asc ? " ▲" : " ▼") : ""}
+                                    </th>
+                                ))}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {view.length === 0 ? (
+                                <tr><td colSpan={6} className="vc-diag-empty">No results</td></tr>
+                            ) : view.map(r => (
+                                <tr key={r.name} className={`vc-diag-row lvl-${r.level}`}>
+                                    <td>{r.name}</td>
+                                    <td className="num">{r.hooks}</td>
+                                    <td className="num">{r.listeners}</td>
+                                    <td className="num">{r.patches}</td>
+                                    <td className="num">{r.uiInjects}</td>
+                                    <td className="num"><span className={`vc-diag-badge ${r.level}`}>{r.risk}</span></td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+
+                <div className="vc-diag-foot">{view.length} / {rows.length} plugins</div>
+            </div>
+        </Modal>
+    );
+}

--- a/src/equicordplugins/pluginDiagnostics/index.tsx
+++ b/src/equicordplugins/pluginDiagnostics/index.tsx
@@ -1,0 +1,47 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { Button, openModal } from "@webpack/common";
+
+import { DiagnosticsModal } from "./DiagnosticsModal";
+import { sampleHeapMB, scanPlugins } from "./scanner";
+import { processSnapshot } from "./scoring";
+
+// Scanner (layer 1) → Processing (layer 2). One synchronous pass, on demand.
+function runScan() {
+    return processSnapshot(scanPlugins());
+}
+
+function openDiagnostics() {
+    const initial = runScan();          // single pass at click time
+    const heapMB = sampleHeapMB();
+    openModal(props => (
+        <ErrorBoundary>
+            <DiagnosticsModal modalProps={props} initial={initial} heapMB={heapMB} rescan={runScan} />
+        </ErrorBoundary>
+    ));
+    // `initial` is referenced only by the modal closure; released for GC when the modal unmounts.
+}
+
+const settings = definePluginSettings({
+    open: {
+        type: OptionType.COMPONENT,
+        component: () => (
+            <Button onClick={openDiagnostics}>Scan Diagnostics</Button>
+        ),
+    },
+});
+
+export default definePlugin({
+    name: "PluginDiagnostics",
+    description: "On-demand, one-shot snapshot of each enabled plugin's footprint (patches, listeners, UI injects) with a computed risk score. Zero cost when idle.",
+    authors: [EquicordDevs.LOSTSTR],
+    settings,
+});

--- a/src/equicordplugins/pluginDiagnostics/scanner.ts
+++ b/src/equicordplugins/pluginDiagnostics/scanner.ts
@@ -1,0 +1,72 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// ─── Layer 1: Scanner (data extraction ONLY — no scoring, no rendering) ──────
+// One synchronous pass over the live plugin registry. Reads existing in-memory
+// structures only. No loops, no listeners, no persistent allocations.
+
+import { isPluginEnabled } from "@api/PluginManager";
+
+export interface RawPluginStat {
+    name: string;
+    patches: number;     // webpack code patches
+    listeners: number;   // Flux/Dispatcher subscriptions
+    uiInjects: number;   // context menus + UI render surfaces
+    hooks: number;       // slash commands
+}
+
+// UI render factories a plugin can expose — each present one = a UI injection.
+const UI_RENDER_PROPS = [
+    "renderChatBarButton",
+    "renderMessageAccessory",
+    "renderMessagePopoverButton",
+    "renderMemberListDecorator",
+    "renderNicknameIcon",
+    "renderMessageDecoration",
+] as const;
+
+// Read the registry lazily at call time (avoids any static circular import).
+function getRegistry(): Record<string, any> {
+    return (window as any).Vencord?.Plugins?.plugins ?? {};
+}
+
+/** Single synchronous snapshot of every enabled plugin's footprint. */
+export function scanPlugins(): RawPluginStat[] {
+    const registry = getRegistry();
+    const out: RawPluginStat[] = [];
+
+    for (const name of Object.keys(registry)) {
+        let enabled = false;
+        try { enabled = isPluginEnabled(name); } catch { enabled = false; }
+        if (!enabled) continue;
+
+        const p = registry[name];
+        if (!p) continue;
+
+        try {
+            const patches = Array.isArray(p.patches) ? p.patches.length : 0;
+            const listeners = p.flux ? Object.keys(p.flux).length : 0;
+            let uiInjects = p.contextMenus ? Object.keys(p.contextMenus).length : 0;
+            for (const key of UI_RENDER_PROPS) if (typeof p[key] === "function") uiInjects++;
+            const hooks = Array.isArray(p.commands) ? p.commands.length : 0;
+            out.push({ name, patches, listeners, uiInjects, hooks });
+        } catch {
+            // a plugin with an unexpected shape must never break the whole scan
+            out.push({ name, patches: 0, listeners: 0, uiInjects: 0, hooks: 0 });
+        }
+    }
+    return out;
+}
+
+/** Optional single heap sample in MB. Returns null if the API is unavailable. */
+export function sampleHeapMB(): number | null {
+    try {
+        const used = (performance as any).memory?.usedJSHeapSize;
+        return typeof used === "number" ? Math.round(used / 1048576) : null;
+    } catch {
+        return null;
+    }
+}

--- a/src/equicordplugins/pluginDiagnostics/scoring.ts
+++ b/src/equicordplugins/pluginDiagnostics/scoring.ts
@@ -1,0 +1,28 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// ─── Layer 2: Processing (risk scoring + aggregation — pure, no I/O) ─────────
+
+import type { RawPluginStat } from "./scanner";
+
+export type RiskLevel = "low" | "medium" | "high";
+
+export interface ScoredPlugin extends RawPluginStat {
+    risk: number;
+    level: RiskLevel;
+}
+
+/** riskScore = (patches*2) + (listeners*3) + (uiInjects*1.5) */
+export function scorePlugin(s: RawPluginStat): ScoredPlugin {
+    const risk = (s.patches * 2) + (s.listeners * 3) + (s.uiInjects * 1.5);
+    const level: RiskLevel = risk <= 10 ? "low" : risk <= 25 ? "medium" : "high";
+    return { ...s, risk: Math.round(risk * 10) / 10, level };
+}
+
+/** Score every row and pre-sort by risk (descending). */
+export function processSnapshot(raw: RawPluginStat[]): ScoredPlugin[] {
+    return raw.map(scorePlugin).sort((a, b) => b.risk - a.risk);
+}

--- a/src/equicordplugins/pluginDiagnostics/styles.css
+++ b/src/equicordplugins/pluginDiagnostics/styles.css
@@ -1,0 +1,173 @@
+/* PluginDiagnostics — premium, dark, glassmorphism panel */
+
+.vc-diag {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px 4px;
+}
+
+.vc-diag-sub {
+    font-size: 13px;
+    color: var(--text-muted);
+    margin-top: -6px;
+}
+
+.vc-diag-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.vc-diag-search {
+    flex: 1;
+    min-width: 160px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: var(--background-secondary);
+    border: 1.5px solid var(--background-modifier-accent);
+    color: var(--text-normal);
+    font-size: 14px;
+    outline: none;
+    transition: border-color 0.15s ease;
+}
+
+.vc-diag-search:focus {
+    border-color: var(--brand-experiment);
+}
+
+.vc-diag-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.vc-diag-heap {
+    font-family: monospace;
+    font-size: 12px;
+    color: var(--text-muted);
+    padding: 4px 8px;
+    border-radius: 6px;
+    background: var(--background-secondary);
+}
+
+.vc-diag-btn {
+    padding: 6px 12px;
+    border-radius: 7px;
+    border: 1.5px solid var(--background-modifier-accent);
+    background: var(--background-secondary);
+    color: var(--text-normal);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.vc-diag-btn:hover {
+    background: var(--background-modifier-hover);
+    border-color: var(--brand-experiment);
+}
+
+.vc-diag-tablewrap {
+    max-height: 440px;
+    overflow: auto;
+    border-radius: 10px;
+    border: 1px solid var(--background-modifier-accent);
+    background: linear-gradient(180deg, rgb(255 255 255 / 3%), rgb(255 255 255 / 0%));
+    backdrop-filter: blur(6px);
+}
+
+.vc-diag-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.vc-diag-table thead th {
+    position: sticky;
+    top: 0;
+    background: var(--background-secondary-alt, var(--background-secondary));
+    color: var(--header-secondary);
+    text-align: start;
+    padding: 9px 12px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+.vc-diag-table th.num,
+.vc-diag-table td.num {
+    text-align: end;
+    font-variant-numeric: tabular-nums;
+}
+
+.vc-diag-table td.num {
+    font-family: monospace;
+    color: var(--text-normal);
+}
+
+.vc-diag-row {
+    border-top: 1px solid var(--background-modifier-accent);
+    transition: background 0.12s ease;
+}
+
+.vc-diag-row td {
+    padding: 8px 12px;
+    color: var(--text-normal);
+}
+
+.vc-diag-row:hover {
+    background: var(--background-modifier-hover);
+}
+
+.vc-diag-row.lvl-low {
+    background: linear-gradient(90deg, rgb(59 165 92 / 7%), transparent);
+}
+
+.vc-diag-row.lvl-medium {
+    background: linear-gradient(90deg, rgb(250 168 26 / 8%), transparent);
+}
+
+.vc-diag-row.lvl-high {
+    background: linear-gradient(90deg, rgb(237 66 69 / 10%), transparent);
+}
+
+.vc-diag-badge {
+    font-family: monospace;
+    font-weight: 700;
+    font-size: 12px;
+    padding: 2px 9px;
+    border-radius: 11px;
+}
+
+.vc-diag-badge.low {
+    background: rgb(59 165 92 / 20%);
+    color: #3ba55c;
+}
+
+.vc-diag-badge.medium {
+    background: rgb(250 168 26 / 20%);
+    color: #faa81a;
+}
+
+.vc-diag-badge.high {
+    background: rgb(237 66 69 / 20%);
+    color: var(--text-danger, #ed4245);
+}
+
+.vc-diag-empty {
+    text-align: center;
+    padding: 28px;
+    color: var(--text-muted);
+}
+
+.vc-diag-foot {
+    font-size: 12px;
+    color: var(--text-muted);
+    text-align: end;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -664,6 +664,10 @@ export const EquicordDevs = Object.freeze({
         name: "nobody",
         id: 0n
     },
+    LOSTSTR: {
+        name: "LOSTSTR",
+        id: 681465758127226900n
+    },
     thororen: {
         name: "thororen",
         id: 848339671629299742n


### PR DESCRIPTION
## What

Adds **PluginDiagnostics** — a developer-grade panel that takes a one-shot snapshot of every enabled plugin's runtime footprint and ranks them by a computed risk score.

## Why

Equicord lets you enable/disable plugins but gives no visibility into each plugin's runtime cost. When users report lag or high memory, there's no built-in way to see which plugin registers the most patches/listeners/UI injections. This adds that visibility — with zero background cost.

## How it works

- **Strictly on-demand** — runs only when the user clicks **Scan Diagnostics**. No intervals, no polling, no background loops, no continuous memory tracking.
- A **single synchronous pass** over the plugin registry reads existing in-memory structures only: webpack patches, Flux subscriptions, context menus + UI render factories, and commands. No network, no external dependencies.
- **Risk score** = `(patches × 2) + (listeners × 3) + (uiInjects × 1.5)`, classified Low / Medium / High.
- **Three-layer separation**: `scanner.ts` (extraction) → `scoring.ts` (pure scoring) → `DiagnosticsModal.tsx` (render only).
- Results are **transient** (component state only) and released for GC when the modal closes.
- Optional one-time heap sample via `performance.memory` (feature-detected).
- UI: sortable table, local search, manual re-scan, export-snapshot-as-JSON (local download), per-column tooltips.

## Performance & safety

- **Zero cost when idle** — nothing runs until the button is clicked.
- A scan is `O(#plugins)` and completes in a few ms.
- No leaks (no listeners beyond the modal), no unbounded growth (bounded by plugin count), no Discord behavior modification (read-only).

## Notes

- Also registers `LOSTSTR` in `EquicordDevs`.
- I couldn't run the full Equicord CI locally — happy to address any lint/tsc feedback.
