### PR TITLE
fix(FrequentQuickSwitcher): prevent crash when frecency data is unavailable

### DIFF
--- a/src/equicordplugins/frequentQuickSwitcher/index.tsx
+++ b/src/equicordplugins/frequentQuickSwitcher/index.tsx
@@ -8,29 +8,34 @@ import { Devs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { ChannelStore, UserSettingsActionCreators } from "@webpack/common";
 
-function generateSearchResults(query) {
-    const frequentChannelsWithQuery = Object.entries(UserSettingsActionCreators.FrecencyUserSettingsActionCreators.getCurrentValue().guildAndChannelFrecency.guildAndChannels)
-        .map(([key, value]) => key)
-        .filter(id => ChannelStore.getChannel(id) != null)
-        .filter(id => ChannelStore.getChannel(id).name.includes(query))
-        .sort((id1, id2) => {
-            const channel1 = UserSettingsActionCreators.FrecencyUserSettingsActionCreators.getCurrentValue().guildAndChannelFrecency.guildAndChannels[id1];
-            const channel2 = UserSettingsActionCreators.FrecencyUserSettingsActionCreators.getCurrentValue().guildAndChannelFrecency.guildAndChannels[id2];
-            return channel2.totalUses - channel1.totalUses;
+function getGuildAndChannels(): Record<string, { totalUses: number; }> | null {
+    const { guildAndChannelFrecency } = UserSettingsActionCreators.FrecencyUserSettingsActionCreators.getCurrentValue() ?? {};
+    return guildAndChannelFrecency?.guildAndChannels ?? null;
+}
+
+function generateSearchResults(query: string) {
+    const guildAndChannels = getGuildAndChannels();
+    if (!guildAndChannels) return null;
+
+    const normalizedQuery = query.toLowerCase();
+
+    const frequentChannelsWithQuery = Object.keys(guildAndChannels)
+        .filter(id => {
+            const channel = ChannelStore.getChannel(id);
+            return channel != null && channel.name.toLowerCase().includes(normalizedQuery);
         })
+        .sort((id1, id2) => (guildAndChannels[id2]?.totalUses ?? 0) - (guildAndChannels[id1]?.totalUses ?? 0))
         .slice(0, 20);
 
     return frequentChannelsWithQuery.map(channelID => {
-        const channel = ChannelStore.getChannel(channelID);
-        return (
-            {
-                "type": "TEXT_CHANNEL",
-                "record": channel,
-                "score": 20,
-                "comparator": query,
-                "sortable": query
-            }
-        );
+        const channel = ChannelStore.getChannel(channelID)!;
+        return {
+            type: "TEXT_CHANNEL",
+            record: channel,
+            score: 20,
+            comparator: query,
+            sortable: query
+        };
     });
 }
 
@@ -39,13 +44,16 @@ export default definePlugin({
     description: "Rewrites and filters the quick switcher results to be your most frequent channels",
     tags: ["Shortcuts", "Servers"],
     authors: [Devs.Samwich],
-    generateSearchResults: generateSearchResults,
+    generateSearchResults,
+    start() {
+        UserSettingsActionCreators.FrecencyUserSettingsActionCreators.loadIfNecessary();
+    },
     patches: [
         {
             find: "#{intl::QUICKSWITCHER_PLACEHOLDER}",
             replacement: {
                 match: /let{selectedIndex:\i,results:\i}/,
-                replace: "this.props.results = $self.generateSearchResults(this.state.query);$&"
+                replace: "var _fqsResults=$self.generateSearchResults(this.state.query);if(_fqsResults!=null)this.props.results=_fqsResults;$&"
             },
         }
     ]


### PR DESCRIPTION
## Summary

Fixes a crash in **FrequentQuickSwitcher** when opening the quick switcher before Discord's frecency user settings have finished loading.

### Problem

Opening the quick switcher (Ctrl+K) with FrequentQuickSwitcher enabled could throw:

```
TypeError: Cannot read properties of undefined (reading 'guildAndChannels')
    at Object.generateSearchResults (index.tsx:12)
```

The plugin unconditionally accessed:

```ts
UserSettingsActionCreators.FrecencyUserSettingsActionCreators
  .getCurrentValue()
  .guildAndChannelFrecency
  .guildAndChannels
```

`guildAndChannelFrecency` is `undefined` until frecency settings are loaded from Discord. Because the patch always overwrote quick switcher results on every render, this crashed as soon as the quick switcher opened — even with an empty query.

### Solution

1. **Null-safe frecency access** — Added `getGuildAndChannels()` with optional chaining so missing data no longer throws.
2. **Graceful fallback** — `generateSearchResults()` returns `null` when frecency data is unavailable. The patch only overrides results when data is present, so Discord's default quick switcher behavior is preserved until settings load.
3. **Preload on start** — Calls `FrecencyUserSettingsActionCreators.loadIfNecessary()` in the plugin's `start()` hook so channel frecency data is fetched earlier.
4. **Minor improvements** — Case-insensitive channel name filtering, fewer repeated `getCurrentValue()` calls, and safe sorting when `totalUses` is missing.

### Changed files

- `src/equicordplugins/frequentQuickSwitcher/index.tsx`

## Test plan

- [ ] Enable **FrequentQuickSwitcher** in Equicord settings
- [ ] Open Discord immediately after launch (before frecency settings have loaded) and press **Ctrl+K** — quick switcher should open without crashing
- [ ] Type a channel name in the quick switcher — results should show your most frequently used matching channels
- [ ] Clear the search box — top frequent channels should still appear (empty query matches all channel names)
- [ ] Disable the plugin and confirm the default Discord quick switcher still works normally
