### PR TITLE
Fix RPCStats update interval cleanup

### DIFF
--- a/src/equicordplugins/rpcStats/index.tsx
+++ b/src/equicordplugins/rpcStats/index.tsx
@@ -127,6 +127,7 @@ interface IMessageCreate {
 }
 
 const Native = VencordNative.pluginHelpers.RPCStats as PluginNative<typeof import("./native")>;
+let updateInterval: ReturnType<typeof setInterval> | undefined;
 
 async function updateData() {
     switch (settings.store.statDisplay) {
@@ -174,19 +175,24 @@ export default definePlugin({
     description: "Displays stats about your activity as an rpc",
     tags: ["Utility"],
     authors: [Devs.Samwich],
-    async start() {
+async start() {
+    updateData();
+
+    updateInterval = setInterval(() => {
+        checkForNewDay();
         updateData();
+    }, 1000);
 
-        setInterval(() => {
-            checkForNewDay();
-            updateData();
-        }, 1000);
-
-    },
+},
     settings,
-    stop() {
-        setRpc(true);
-    },
+stop() {
+    if (updateInterval !== undefined) {
+        clearInterval(updateInterval);
+        updateInterval = undefined;
+    }
+
+    setRpc(true);
+},
     flux:
     {
         async MESSAGE_CREATE({ optimistic, type, message }: IMessageCreate) {


### PR DESCRIPTION
## Describe your Changes
- RPCStats now stores the update interval id.
- The interval is cleared when the plugin stops.
- This prevents updates from continuing after the plugin is disabled.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
