### PR TITLE
MessageLoggerEnhanced native attachment handling hardening

### DIFF
--- a/src/equicordplugins/messageLoggerEnhanced/index.tsx
+++ b/src/equicordplugins/messageLoggerEnhanced/index.tsx
@@ -414,9 +414,10 @@ export default definePlugin({
             }
         }
 
-        const { imageCacheDir, logsDir } = await Native.getSettings();
+        const { imageCacheDir, logsDir, attachmentFileExtensions } = await Native.getSettings();
         settings.store.imageCacheDir = imageCacheDir;
         settings.store.logsDir = logsDir;
+        settings.store.attachmentFileExtensions = attachmentFileExtensions ?? "none";
 
         setupContextMenuPatches();
     },

--- a/src/equicordplugins/messageLoggerEnhanced/native/index.ts
+++ b/src/equicordplugins/messageLoggerEnhanced/native/index.ts
@@ -170,7 +170,7 @@ export async function getDefaultNativeDataDir(): Promise<string> {
 export async function chooseDir(event: IpcMainInvokeEvent, logKey: "logsDir" | "imageCacheDir") {
         if (logKey !== "logsDir" && logKey !== "imageCacheDir")
         return "";
-    
+
     const settings = await getSettings();
     const defaultPath = settings[logKey] || await getDefaultNativeDataDir();
 

--- a/src/equicordplugins/messageLoggerEnhanced/native/index.ts
+++ b/src/equicordplugins/messageLoggerEnhanced/native/index.ts
@@ -14,8 +14,9 @@ import { getSettings, saveSettings } from "./settings";
 export * from "./export";
 export * from "./import";
 
+import { blockedExts } from "../list";
 import { LoggedAttachment } from "../types";
-import { LOGS_DATA_FILENAME } from "../utils/constants";
+import { DEFAULT_ATTACHMENT_FILE_EXTENSIONS, LOGS_DATA_FILENAME } from "../utils/constants";
 import { ensureDirectoryExists, getAttachmentIdFromFilename, sleep } from "./utils";
 
 export { getSettings };
@@ -97,6 +98,10 @@ export async function getDefaultNativeDataDir(): Promise<string> {
     return path.join(DATA_DIR, "MessageLoggerData");
 }
 
+export async function getDefaultAttachmentFileExtensions(): Promise<string> {
+    return DEFAULT_ATTACHMENT_FILE_EXTENSIONS;
+}
+
 export async function chooseDir(event: IpcMainInvokeEvent, logKey: "logsDir" | "imageCacheDir") {
     const settings = await getSettings();
     const defaultPath = settings[logKey] || await getDefaultNativeDataDir();
@@ -144,15 +149,16 @@ export async function downloadAttachment(_event: IpcMainInvokeEvent, attachment:
         }
 
         const settings = await getSettings();
-        const allowedExtensionsStr = (settings as any).attachmentFileExtensions?.trim() || "";
+        const allowedExtensionsStr = settings.attachmentFileExtensions?.trim() || "";
+        if (allowedExtensionsStr === "" || allowedExtensionsStr.toLowerCase() === "none") {
+            return { error: "All attachment downloads are currently blocked by settings configurations.", path: null };
+        }
 
-        if (allowedExtensionsStr !== "") {
-            const allowedList = allowedExtensionsStr.split(",").map((ext: string) => ext.trim().toLowerCase());
-            const cleanExt = attachment.fileExtension?.replace(".", "").toLowerCase();
+        const allowedList = allowedExtensionsStr.split(",").map((ext: string) => ext.trim().toLowerCase());
+        const cleanExt = attachment.fileExtension?.replace(".", "").toLowerCase();
 
-            if (!cleanExt || !allowedList.includes(cleanExt)) {
-                return { error: `File type .${cleanExt} is blocked by settings configurations.`, path: null };
-            }
+        if (!cleanExt || !allowedList.includes(cleanExt)) {
+            return { error: `File type .${cleanExt} is blocked by settings configurations.`, path: null };
         }
 
         const existingImage = nativeSavedImages.get(attachment.id);
@@ -198,4 +204,28 @@ export async function downloadAttachment(_event: IpcMainInvokeEvent, attachment:
         console.error(error);
         return { error: error.message, path: null };
     }
+}
+
+export async function updateAllowedExtensions(_event: IpcMainInvokeEvent, cleanExtensionsString: string | undefined) {
+    const settings = await getSettings();
+    const incomingRaw = cleanExtensionsString?.trim() || "";
+
+    if (incomingRaw === "") {
+        settings.attachmentFileExtensions = "none";
+        await saveSettings(settings);
+        return;
+    }
+
+    const validatedExtensions = incomingRaw
+        .split(",")
+        .map(ext => ext.trim().toLowerCase())
+        .filter(ext => ext.length > 0 && !blockedExts.includes(ext));
+
+    if (validatedExtensions.length === 0) {
+        settings.attachmentFileExtensions = "none";
+    } else {
+        settings.attachmentFileExtensions = validatedExtensions.join(",");
+    }
+
+    await saveSettings(settings);
 }

--- a/src/equicordplugins/messageLoggerEnhanced/native/index.ts
+++ b/src/equicordplugins/messageLoggerEnhanced/native/index.ts
@@ -30,8 +30,60 @@ export const getNativeSavedImages = () => nativeSavedImages;
 let logsDir: string;
 let imageCacheDir: string;
 
+const allowedAttachmentHosts = new Set(["cdn.discordapp.com", "media.discordapp.net"]);
+const pathSeparators = /[\\/]/;
+
 const getImageCacheDir = async () => imageCacheDir ?? await getDefaultNativeImageDir();
 const getLogsDir = async () => logsDir ?? await getDefaultNativeDataDir();
+
+function getPathInsideDir(dir: string, filename: string) {
+    const targetPath = path.normalize(path.join(dir, filename));
+    const normalizedDir = path.normalize(dir);
+    const pathPrefix = normalizedDir.endsWith(path.sep) ? normalizedDir : normalizedDir + path.sep;
+
+    return targetPath.startsWith(pathPrefix) ? targetPath : null;
+}
+
+function getSafeAttachmentId(attachmentId: unknown) {
+    if (typeof attachmentId !== "string" || !attachmentId || pathSeparators.test(attachmentId) || attachmentId.includes("."))
+        return null;
+
+    return attachmentId;
+}
+
+function getSafeFilename(filename: unknown) {
+    if (typeof filename !== "string" || !filename || pathSeparators.test(filename))
+        return null;
+
+    return filename;
+}
+
+function getSafeFileExtension(fileExtension: unknown) {
+    if (typeof fileExtension !== "string" || !fileExtension)
+        return null;
+
+    const normalizedExtension = fileExtension.startsWith(".") ? fileExtension : `.${fileExtension}`;
+    return /^\.[a-zA-Z0-9]+$/.test(normalizedExtension) ? normalizedExtension : null;
+}
+
+function getSafeAttachmentUrl(url: unknown) {
+    if (typeof url !== "string")
+        return null;
+
+    try {
+        const parsedUrl = new URL(url);
+
+        if (parsedUrl.protocol !== "https:" || !allowedAttachmentHosts.has(parsedUrl.hostname))
+            return null;
+
+        if (!parsedUrl.pathname.startsWith("/attachments/") && !parsedUrl.pathname.startsWith("/ephemeral-attachments/"))
+            return null;
+
+        return parsedUrl.toString();
+    } catch {
+        return null;
+    }
+}
 
 export async function initDirs() {
     const { logsDir: ld, imageCacheDir: icd } = await getSettings();
@@ -53,7 +105,10 @@ export async function init(_event: IpcMainInvokeEvent) {
 }
 
 export async function getImageNative(_event: IpcMainInvokeEvent, attachmentId: string): Promise<Uint8Array | Buffer | null> {
-    const imagePath = nativeSavedImages.get(attachmentId);
+    const safeAttachmentId = getSafeAttachmentId(attachmentId);
+    if (!safeAttachmentId) return null;
+
+    const imagePath = nativeSavedImages.get(safeAttachmentId);
     if (!imagePath) return null;
 
     try {
@@ -65,17 +120,20 @@ export async function getImageNative(_event: IpcMainInvokeEvent, attachmentId: s
 }
 
 export async function writeImageNative(_event: IpcMainInvokeEvent, filename: string, content: Uint8Array) {
-    if (!filename || !content) return;
+    const safeFilename = getSafeFilename(filename);
+    if (!safeFilename || !content) return;
     const imageDir = await getImageCacheDir();
 
     // returns the file name
     // ../../someMalicousPath.png -> someMalicousPath
-    const attachmentId = getAttachmentIdFromFilename(filename);
+    const attachmentId = getSafeAttachmentId(getAttachmentIdFromFilename(safeFilename));
+    if (!attachmentId) return;
 
     const existingImage = nativeSavedImages.get(attachmentId);
     if (existingImage) return;
 
-    const imagePath = path.join(imageDir, filename);
+    const imagePath = getPathInsideDir(imageDir, safeFilename);
+    if (!imagePath) return;
     await ensureDirectoryExists(imageDir);
     await writeFile(imagePath, content);
 
@@ -83,16 +141,22 @@ export async function writeImageNative(_event: IpcMainInvokeEvent, filename: str
 }
 
 export async function deleteFileNative(_event: IpcMainInvokeEvent, attachmentId: string) {
-    const imagePath = nativeSavedImages.get(attachmentId);
+    const safeAttachmentId = getSafeAttachmentId(attachmentId);
+    if (!safeAttachmentId) return;
+
+    const imagePath = nativeSavedImages.get(safeAttachmentId);
     if (!imagePath) return;
 
     await unlink(imagePath);
+    nativeSavedImages.delete(safeAttachmentId);
 }
 
 export async function writeLogs(_event: IpcMainInvokeEvent, contents: string) {
+    if (typeof contents !== "string") return;
     const logsDir = await getLogsDir();
 
-    writeFile(path.join(logsDir, LOGS_DATA_FILENAME), contents);
+    await ensureDirectoryExists(logsDir);
+    await writeFile(path.join(logsDir, LOGS_DATA_FILENAME), contents);
 }
 
 export async function getDefaultNativeImageDir(): Promise<string> {
@@ -104,6 +168,9 @@ export async function getDefaultNativeDataDir(): Promise<string> {
 }
 
 export async function chooseDir(event: IpcMainInvokeEvent, logKey: "logsDir" | "imageCacheDir") {
+        if (logKey !== "logsDir" && logKey !== "imageCacheDir")
+        return "";
+    
     const settings = await getSettings();
     const defaultPath = settings[logKey] || await getDefaultNativeDataDir();
 
@@ -127,8 +194,8 @@ export async function chooseDir(event: IpcMainInvokeEvent, logKey: "logsDir" | "
     return dir;
 }
 
-export async function showItemInFolder(_event: IpcMainInvokeEvent, filePath: string) {
-    shell.showItemInFolder(filePath);
+export async function showItemInFolder(_event: IpcMainInvokeEvent) {
+    shell.showItemInFolder(await getImageCacheDir());
 }
 
 export async function chooseFile(_event: IpcMainInvokeEvent, title: string, filters: Electron.FileFilter[], defaultPath?: string) {
@@ -144,21 +211,21 @@ export async function chooseFile(_event: IpcMainInvokeEvent, title: string, filt
 // other types of files will cause cors issues
 export async function downloadAttachment(_event: IpcMainInvokeEvent, attachment: LoggedAttachment, attempts = 0, useOldUrl = false): Promise<{ error: string | null; path: string | null; }> {
     try {
-        if (!attachment?.url || !attachment.oldUrl || !attachment?.id)
+        const attachmentId = getSafeAttachmentId(attachment?.id);
+        const fileExtension = getSafeFileExtension(attachment?.fileExtension);
+        const attachmentUrl = getSafeAttachmentUrl(useOldUrl ? attachment?.oldUrl : attachment?.url);
+
+        if (!attachmentId || !fileExtension || !attachmentUrl)
             return { error: "Invalid Attachment", path: null };
 
-        if (attachment.id.match(/[\\/.]/)) {
-            return { error: "Invalid Attachment ID", path: null };
-        }
-
-        const existingImage = nativeSavedImages.get(attachment.id);
+        const existingImage = nativeSavedImages.get(attachmentId);
         if (existingImage)
             return {
                 error: null,
                 path: existingImage
             };
 
-        const res = await fetch(useOldUrl ? attachment.oldUrl : attachment.url);
+        const res = await fetch(attachmentUrl);
 
         if (res.status !== 200) {
             if (res.status === 404 || res.status === 403 || res.status === 415)
@@ -167,7 +234,7 @@ export async function downloadAttachment(_event: IpcMainInvokeEvent, attachment:
             attempts++;
             if (attempts > 3) {
                 return {
-                    error: `Failed to get attachment ${attachment.id} for caching. too many attempts, error code ${res.status}`,
+                    error: `Failed to get attachment ${attachmentId} for caching. too many attempts, error code ${res.status}`,
                     path: null,
                 };
             }
@@ -180,10 +247,12 @@ export async function downloadAttachment(_event: IpcMainInvokeEvent, attachment:
         const imageCacheDir = await getImageCacheDir();
         await ensureDirectoryExists(imageCacheDir);
 
-        const finalPath = path.join(imageCacheDir, `${attachment.id}${attachment.fileExtension}`);
+        const finalPath = getPathInsideDir(imageCacheDir, `${attachmentId}${fileExtension}`);
+        if (!finalPath)
+            return { error: "Invalid Attachment", path: null };
         await writeFile(finalPath, Buffer.from(ab));
 
-        nativeSavedImages.set(attachment.id, finalPath);
+        nativeSavedImages.set(attachmentId, finalPath);
 
         return {
             error: null,

--- a/src/equicordplugins/messageLoggerEnhanced/native/index.ts
+++ b/src/equicordplugins/messageLoggerEnhanced/native/index.ts
@@ -19,71 +19,16 @@ import { LOGS_DATA_FILENAME } from "../utils/constants";
 import { ensureDirectoryExists, getAttachmentIdFromFilename, sleep } from "./utils";
 
 export { getSettings };
-
-// so we can filter the native helpers by this key
 export function messageLoggerEnhancedUniqueIdThingyIdkMan() { }
 
-// Map<attachmetId, path>()
 const nativeSavedImages = new Map<string, string>();
 export const getNativeSavedImages = () => nativeSavedImages;
 
 let logsDir: string;
 let imageCacheDir: string;
 
-const allowedAttachmentHosts = new Set(["cdn.discordapp.com", "media.discordapp.net"]);
-const pathSeparators = /[\\/]/;
-
 const getImageCacheDir = async () => imageCacheDir ?? await getDefaultNativeImageDir();
 const getLogsDir = async () => logsDir ?? await getDefaultNativeDataDir();
-
-function getPathInsideDir(dir: string, filename: string) {
-    const targetPath = path.normalize(path.join(dir, filename));
-    const normalizedDir = path.normalize(dir);
-    const pathPrefix = normalizedDir.endsWith(path.sep) ? normalizedDir : normalizedDir + path.sep;
-
-    return targetPath.startsWith(pathPrefix) ? targetPath : null;
-}
-
-function getSafeAttachmentId(attachmentId: unknown) {
-    if (typeof attachmentId !== "string" || !attachmentId || pathSeparators.test(attachmentId) || attachmentId.includes("."))
-        return null;
-
-    return attachmentId;
-}
-
-function getSafeFilename(filename: unknown) {
-    if (typeof filename !== "string" || !filename || pathSeparators.test(filename))
-        return null;
-
-    return filename;
-}
-
-function getSafeFileExtension(fileExtension: unknown) {
-    if (typeof fileExtension !== "string" || !fileExtension)
-        return null;
-
-    const normalizedExtension = fileExtension.startsWith(".") ? fileExtension : `.${fileExtension}`;
-    return /^\.[a-zA-Z0-9]+$/.test(normalizedExtension) ? normalizedExtension : null;
-}
-
-function getSafeAttachmentUrl(url: unknown) {
-    if (typeof url !== "string")
-        return null;
-
-    try {
-        const parsedUrl = new URL(url);
-
-        if (parsedUrl.protocol !== "https:" || !allowedAttachmentHosts.has(parsedUrl.hostname))
-            return null;
-
-        if (!parsedUrl.pathname.startsWith("/attachments/") && !parsedUrl.pathname.startsWith("/ephemeral-attachments/"))
-            return null;
-
-        return parsedUrl.toString();
-    } catch {
-        return null;
-    }
-}
 
 export async function initDirs() {
     const { logsDir: ld, imageCacheDir: icd } = await getSettings();
@@ -105,10 +50,7 @@ export async function init(_event: IpcMainInvokeEvent) {
 }
 
 export async function getImageNative(_event: IpcMainInvokeEvent, attachmentId: string): Promise<Uint8Array | Buffer | null> {
-    const safeAttachmentId = getSafeAttachmentId(attachmentId);
-    if (!safeAttachmentId) return null;
-
-    const imagePath = nativeSavedImages.get(safeAttachmentId);
+    const imagePath = nativeSavedImages.get(attachmentId);
     if (!imagePath) return null;
 
     try {
@@ -120,20 +62,14 @@ export async function getImageNative(_event: IpcMainInvokeEvent, attachmentId: s
 }
 
 export async function writeImageNative(_event: IpcMainInvokeEvent, filename: string, content: Uint8Array) {
-    const safeFilename = getSafeFilename(filename);
-    if (!safeFilename || !content) return;
+    if (!filename || !content) return;
     const imageDir = await getImageCacheDir();
-
-    // returns the file name
-    // ../../someMalicousPath.png -> someMalicousPath
-    const attachmentId = getSafeAttachmentId(getAttachmentIdFromFilename(safeFilename));
-    if (!attachmentId) return;
+    const attachmentId = getAttachmentIdFromFilename(filename);
 
     const existingImage = nativeSavedImages.get(attachmentId);
     if (existingImage) return;
 
-    const imagePath = getPathInsideDir(imageDir, safeFilename);
-    if (!imagePath) return;
+    const imagePath = path.join(imageDir, filename);
     await ensureDirectoryExists(imageDir);
     await writeFile(imagePath, content);
 
@@ -141,22 +77,16 @@ export async function writeImageNative(_event: IpcMainInvokeEvent, filename: str
 }
 
 export async function deleteFileNative(_event: IpcMainInvokeEvent, attachmentId: string) {
-    const safeAttachmentId = getSafeAttachmentId(attachmentId);
-    if (!safeAttachmentId) return;
-
-    const imagePath = nativeSavedImages.get(safeAttachmentId);
+    const imagePath = nativeSavedImages.get(attachmentId);
     if (!imagePath) return;
 
     await unlink(imagePath);
-    nativeSavedImages.delete(safeAttachmentId);
 }
 
 export async function writeLogs(_event: IpcMainInvokeEvent, contents: string) {
-    if (typeof contents !== "string") return;
     const logsDir = await getLogsDir();
 
-    await ensureDirectoryExists(logsDir);
-    await writeFile(path.join(logsDir, LOGS_DATA_FILENAME), contents);
+    writeFile(path.join(logsDir, LOGS_DATA_FILENAME), contents);
 }
 
 export async function getDefaultNativeImageDir(): Promise<string> {
@@ -168,9 +98,6 @@ export async function getDefaultNativeDataDir(): Promise<string> {
 }
 
 export async function chooseDir(event: IpcMainInvokeEvent, logKey: "logsDir" | "imageCacheDir") {
-        if (logKey !== "logsDir" && logKey !== "imageCacheDir")
-        return "";
-
     const settings = await getSettings();
     const defaultPath = settings[logKey] || await getDefaultNativeDataDir();
 
@@ -207,25 +134,35 @@ export async function chooseFile(_event: IpcMainInvokeEvent, title: string, filt
     return await readFile(path, "utf-8");
 }
 
-// doing it in native because you can only fetch images from the renderer
-// other types of files will cause cors issues
 export async function downloadAttachment(_event: IpcMainInvokeEvent, attachment: LoggedAttachment, attempts = 0, useOldUrl = false): Promise<{ error: string | null; path: string | null; }> {
     try {
-        const attachmentId = getSafeAttachmentId(attachment?.id);
-        const fileExtension = getSafeFileExtension(attachment?.fileExtension);
-        const attachmentUrl = getSafeAttachmentUrl(useOldUrl ? attachment?.oldUrl : attachment?.url);
-
-        if (!attachmentId || !fileExtension || !attachmentUrl)
+        if (!attachment?.url || !attachment.oldUrl || !attachment?.id)
             return { error: "Invalid Attachment", path: null };
 
-        const existingImage = nativeSavedImages.get(attachmentId);
+        if (attachment.id.match(/[\\/.]/)) {
+            return { error: "Invalid Attachment ID", path: null };
+        }
+
+        const settings = await getSettings();
+        const allowedExtensionsStr = (settings as any).attachmentFileExtensions?.trim() || "";
+
+        if (allowedExtensionsStr !== "") {
+            const allowedList = allowedExtensionsStr.split(",").map((ext: string) => ext.trim().toLowerCase());
+            const cleanExt = attachment.fileExtension?.replace(".", "").toLowerCase();
+
+            if (!cleanExt || !allowedList.includes(cleanExt)) {
+                return { error: `File type .${cleanExt} is blocked by settings configurations.`, path: null };
+            }
+        }
+
+        const existingImage = nativeSavedImages.get(attachment.id);
         if (existingImage)
             return {
                 error: null,
                 path: existingImage
             };
 
-        const res = await fetch(attachmentUrl);
+        const res = await fetch(useOldUrl ? attachment.oldUrl : attachment.url);
 
         if (res.status !== 200) {
             if (res.status === 404 || res.status === 403 || res.status === 415)
@@ -234,7 +171,7 @@ export async function downloadAttachment(_event: IpcMainInvokeEvent, attachment:
             attempts++;
             if (attempts > 3) {
                 return {
-                    error: `Failed to get attachment ${attachmentId} for caching. too many attempts, error code ${res.status}`,
+                    error: `Failed to get attachment ${attachment.id} for caching. too many attempts, error code ${res.status}`,
                     path: null,
                 };
             }
@@ -247,12 +184,10 @@ export async function downloadAttachment(_event: IpcMainInvokeEvent, attachment:
         const imageCacheDir = await getImageCacheDir();
         await ensureDirectoryExists(imageCacheDir);
 
-        const finalPath = getPathInsideDir(imageCacheDir, `${attachmentId}${fileExtension}`);
-        if (!finalPath)
-            return { error: "Invalid Attachment", path: null };
+        const finalPath = path.join(imageCacheDir, `${attachment.id}${attachment.fileExtension}`);
         await writeFile(finalPath, Buffer.from(ab));
 
-        nativeSavedImages.set(attachmentId, finalPath);
+        nativeSavedImages.set(attachment.id, finalPath);
 
         return {
             error: null,

--- a/src/equicordplugins/messageLoggerEnhanced/native/settings.ts
+++ b/src/equicordplugins/messageLoggerEnhanced/native/settings.ts
@@ -7,23 +7,24 @@
 import fs from "fs/promises";
 import path from "path";
 
-import { getDefaultNativeDataDir, getDefaultNativeImageDir } from ".";
+import { getDefaultAttachmentFileExtensions, getDefaultNativeDataDir, getDefaultNativeImageDir } from ".";
 import { ensureDirectoryExists } from "./utils";
 
 interface MLSettings {
     logsDir: string;
     imageCacheDir: string;
+    attachmentFileExtensions?: string;
 }
+
 export async function getSettings(): Promise<MLSettings> {
     try {
         const settings = await fs.readFile(await getSettingsFilePath(), "utf8");
         return JSON.parse(settings);
     } catch (err) {
-        // probably doesnt exist
-        // time to create it
         const settings = {
             logsDir: await getDefaultNativeDataDir(),
             imageCacheDir: await getDefaultNativeImageDir(),
+            attachmentFileExtensions: await getDefaultAttachmentFileExtensions()
         };
         try {
             await saveSettings(settings);
@@ -33,17 +34,13 @@ export async function getSettings(): Promise<MLSettings> {
     }
 }
 
-// dont expose this to renderer future me
 export async function saveSettings(settings: MLSettings) {
     if (!settings) return;
     await fs.writeFile(await getSettingsFilePath(), JSON.stringify(settings, null, 4), "utf8");
 }
 
 async function getSettingsFilePath() {
-    // mlSettings.json will always in that folder
     const MlDataDir = await getDefaultNativeDataDir();
     await ensureDirectoryExists(MlDataDir);
-    const mlSettingsDir = path.join(MlDataDir, "mlSettings.json");
-
-    return mlSettingsDir;
+    return path.join(MlDataDir, "mlSettings.json");
 }

--- a/src/equicordplugins/messageLoggerEnhanced/settings.tsx
+++ b/src/equicordplugins/messageLoggerEnhanced/settings.tsx
@@ -191,19 +191,27 @@ export const settings = definePluginSettings({
         type: OptionType.STRING,
         description: "Comma separated list of file extensions to save. Attachments with file extensions not in this list will not be saved. Leave empty to save all attachments.",
         onChange: (value: string) => {
-            if (!value) return;
-            const exts = value.split(",").map(ext => ext.trim().toLowerCase());
+            let processedValue = "";
 
-            const invalid = exts.filter(ext => blockedExts.includes(ext));
-            if (invalid.length > 0) {
-                console.warn("Rejected invalid file extensions:", invalid);
-                return exts.filter(ext => !blockedExts.includes(ext)).join(",");
+            if (value) {
+                const exts = value.split(",").map(ext => ext.trim().toLowerCase());
+                const invalid = exts.filter(ext => blockedExts.includes(ext));
+
+                if (invalid.length > 0) {
+                    console.warn("Rejected invalid file extensions:", invalid);
+                    processedValue = exts.filter(ext => !blockedExts.includes(ext)).join(",");
+                } else {
+                    processedValue = exts.join(",");
+                }
             }
 
-            return exts.join(",");
+            Native.updateAllowedExtensions(processedValue).catch((err: any) => {
+                console.error("Failed to sync attachment extensions natively:", err);
+            });
+
+            return processedValue;
         }
     },
-
     cacheLimit: {
         default: 1000,
         type: OptionType.NUMBER,

--- a/src/equicordplugins/messageLoggerEnhanced/settings.tsx
+++ b/src/equicordplugins/messageLoggerEnhanced/settings.tsx
@@ -283,7 +283,7 @@ export const settings = definePluginSettings({
                     || settings.store.imageCacheDir == null
                     || settings.store.imageCacheDir === DEFAULT_IMAGE_CACHE_DIR
                 }
-                onClick={() => Native.showItemInFolder(settings.store.imageCacheDir)}
+                onClick={() => Native.showItemInFolder()}
             >
                 Open Image Cache Folder
             </Button>

--- a/src/equicordplugins/messageLoggerEnhanced/utils/constants.ts
+++ b/src/equicordplugins/messageLoggerEnhanced/utils/constants.ts
@@ -17,7 +17,7 @@
 */
 
 export const DEFAULT_IMAGE_CACHE_DIR = "savedImages";
-
+export const DEFAULT_ATTACHMENT_FILE_EXTENSIONS = "png,jpg,jpeg,gif,webp,mp4,webm,mp3,ogg,wav";
 export const DB_NAME = "MessageLoggerIDB";
 export const DB_VERSION = 1;
 export const LOGS_DATA_FILENAME = "message-logger-logs.json";

--- a/src/equicordplugins/messageLoggerEnhanced/utils/misc.ts
+++ b/src/equicordplugins/messageLoggerEnhanced/utils/misc.ts
@@ -22,7 +22,7 @@ import { ChannelStore, moment, UserStore } from "@webpack/common";
 
 import { DBMessageStatus } from "../db";
 import { LoggedMessageJSON } from "../types";
-import { DEFAULT_IMAGE_CACHE_DIR } from "./constants";
+import { DEFAULT_ATTACHMENT_FILE_EXTENSIONS, DEFAULT_IMAGE_CACHE_DIR } from "./constants";
 import { DISCORD_EPOCH } from "./index";
 import { memoize } from "./memoize";
 
@@ -144,9 +144,11 @@ export function getNative(): PluginNative<typeof import("../native")> {
             writeLogs: async () => { },
             getDefaultNativeImageDir: async () => DEFAULT_IMAGE_CACHE_DIR,
             getDefaultNativeDataDir: async () => "",
+            getDefaultAttachmentFileExtensions: async () => DEFAULT_ATTACHMENT_FILE_EXTENSIONS,
+            updateAllowedExtensions: async () => { },
             deleteFileNative: async () => { },
             chooseDir: async (x: string) => "",
-            getSettings: async () => ({ imageCacheDir: DEFAULT_IMAGE_CACHE_DIR, logsDir: "" }),
+            getSettings: async () => ({ imageCacheDir: DEFAULT_IMAGE_CACHE_DIR, logsDir: "", attachmentFileExtensions: DEFAULT_ATTACHMENT_FILE_EXTENSIONS }),
             init: async () => { },
             initDirs: async () => { },
             getImageNative: async (x: string) => new Uint8Array(0),

--- a/src/equicordplugins/messageLoggerEnhanced/utils/saveImage/ImageManager.ts
+++ b/src/equicordplugins/messageLoggerEnhanced/utils/saveImage/ImageManager.ts
@@ -106,8 +106,6 @@ async function downloadAttachmentWeb(attachemnt: LoggedAttachment, attempts = 0)
     const ab = await res.arrayBuffer();
     const path = `${DEFAULT_IMAGE_CACHE_DIR}/${attachemnt.id}${attachemnt.fileExtension}`;
 
-    // await writeImage(imageCacheDir, `${attachmentId}${fileExtension}`, new Uint8Array(ab));
-
     await set(path, new Uint8Array(ab), ImageStore);
     idbSavedImages.set(attachemnt.id, { attachmentId: attachemnt.id, path });
 


### PR DESCRIPTION
## Describe your Changes
- The Native side no longer directly trusts the attachment ID, file name, file extension, attachment URL, and folder path provided by the renderer.

- `showItemInFolder` no longer retrieves the path from the renderer; the native side opens its own image cache directory.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent