### PR TITLE
Adding a "Date" method in the "AnonymiseFileName" plugin

### DIFF
--- a/src/plugins/anonymiseFileNames/index.tsx
+++ b/src/plugins/anonymiseFileNames/index.tsx
@@ -172,8 +172,7 @@ export default definePlugin({
                         .replace(/ss/g, now.getSeconds().toString().padStart(2, "0"))
                         .replace(/SSS/g, now.getMilliseconds().toString().padStart(3, "0"));
 
-                    const finalName = format ? addSpoilerPrefix(format + ext) : addSpoilerPrefix(Date.now().toString() + ext);
-                    return addSpoilerPrefix(finalName);
+                    return format ? addSpoilerPrefix(format + ext) : addSpoilerPrefix(Date.now().toString() + ext);
             }
         })();
 

--- a/src/plugins/anonymiseFileNames/index.tsx
+++ b/src/plugins/anonymiseFileNames/index.tsx
@@ -32,6 +32,7 @@ const enum Methods {
     Random,
     Consistent,
     Timestamp,
+    Date
 }
 
 const ANONYMISE_UPLOAD_SYMBOL = Symbol("vcAnonymise");
@@ -55,6 +56,7 @@ const settings = definePluginSettings({
             { label: "Random Characters", value: Methods.Random, default: true },
             { label: "Consistent", value: Methods.Consistent },
             { label: "Timestamp", value: Methods.Timestamp },
+            { label: "Date", value: Methods.Date },
         ],
     },
     randomisedLength: {
@@ -67,13 +69,21 @@ const settings = definePluginSettings({
         type: OptionType.STRING,
         default: "image"
     },
+    dateFormat: {
+        description: "Date format",
+        type: OptionType.STRING,
+        default: "YYYY-MM-DD_HH-mm-ss-SSS"
+    }
 }, {
     randomisedLength: {
         disabled() { return this.store.method !== Methods.Random; },
     },
     consistent: {
         disabled() { return this.store.method !== Methods.Consistent; },
-    }
+    },
+    dateFormat: {
+        disabled() { return this.store.method !== Methods.Date; },
+    },
 });
 
 export default definePlugin({
@@ -151,6 +161,19 @@ export default definePlugin({
                     return addSpoilerPrefix(settings.store.consistent + ext);
                 case Methods.Timestamp:
                     return addSpoilerPrefix(Date.now().toString() + ext);
+                case Methods.Date:
+                    const now = new Date();
+                    const format = settings.store.dateFormat
+                        .replace(/YYYY/g, now.getFullYear().toString())
+                        .replace(/MM/g, (now.getMonth() + 1).toString().padStart(2, "0"))
+                        .replace(/DD/g, now.getDate().toString().padStart(2, "0"))
+                        .replace(/HH/g, now.getHours().toString().padStart(2, "0"))
+                        .replace(/mm/g, now.getMinutes().toString().padStart(2, "0"))
+                        .replace(/ss/g, now.getSeconds().toString().padStart(2, "0"))
+                        .replace(/SSS/g, now.getMilliseconds().toString().padStart(3, "0"));
+
+                    const finalName = format ? addSpoilerPrefix(format + ext) : addSpoilerPrefix(Date.now().toString() + ext);
+                    return addSpoilerPrefix(finalName);
             }
         })();
 

--- a/src/plugins/anonymiseFileNames/index.tsx
+++ b/src/plugins/anonymiseFileNames/index.tsx
@@ -70,7 +70,7 @@ const settings = definePluginSettings({
         default: "image"
     },
     dateFormat: {
-        description: "Date format",
+        description: "Date format (YYYY, MM, DD, HH, mm, ss, SSS are supported)",
         type: OptionType.STRING,
         default: "YYYY-MM-DD_HH-mm-ss-SSS"
     }


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes

I've added a new method in the "AnonymiseFileName" plugin called "Date"
<img width="648" height="269" alt="image" src="https://github.com/user-attachments/assets/464e2435-c12d-4e00-915a-a9ffeff3e074" />

We can change the format of the method
<img width="658" height="113" alt="image" src="https://github.com/user-attachments/assets/b1f3a110-666d-4d36-a4d8-217503d5eed2" />

<img width="560" height="113" alt="image" src="https://github.com/user-attachments/assets/f2dcecdf-1d5d-42e9-a580-541abeb1f813" />

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
