### PR TITLE
fix ShowAllMessageButtons quick reacts

### DIFF
--- a/src/plugins/ircColors/index.ts
+++ b/src/plugins/ircColors/index.ts
@@ -133,7 +133,7 @@ export default definePlugin({
                 const currentUserColor = Number(h64(currentUserId) % 360n);
                 const otherUserColor = Number(h64(userId) % 360n);
                 const colorDiff = Math.min(Math.abs(currentUserColor - otherUserColor), 360 - Math.abs(currentUserColor - otherUserColor));
-                if (colorDiff < 45) {
+                if (colorDiff < 70) {
                     const newColor = (otherUserColor + 180) % 360;
                     return `hsl(${newColor}, 100%, ${settings.store.lightness}%)`;
                 }

--- a/src/plugins/showAllMessageButtons/index.ts
+++ b/src/plugins/showAllMessageButtons/index.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import "./style.css";
+
 import { definePluginSettings } from "@api/Settings";
 import { Devs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
@@ -19,6 +21,12 @@ const settings = definePluginSettings({
         type: OptionType.BOOLEAN,
         description: "Remove requirement to hold shift for pinning a message.",
         default: true,
+    },
+    noQuickReacts: {
+        default: false,
+        restartNeeded: true,
+        type: OptionType.BOOLEAN,
+        description: "Hide quick reacts. By default, showing the full menu hides quick react buttons.",
     },
 });
 
@@ -36,6 +44,11 @@ export default definePlugin({
                 {
                     match: /isExpanded:\i&&(.+?),/,
                     replace: "isExpanded:$1,"
+                },
+                {
+                    predicate: () => !settings.store.noQuickReacts,
+                    match: /\i(\?null:\(0,\i\.jsxs\)\(\i\.Fragment,\{children:\[\(0,\i\.jsx\)\(\i,)/,
+                    replace: "false$1"
                 },
                 {
                     predicate: () => settings.store.noShiftDelete,

--- a/src/plugins/showAllMessageButtons/style.css
+++ b/src/plugins/showAllMessageButtons/style.css
@@ -1,8 +1,8 @@
 /* with emojis on + extended menu at the same time, the emotes just
    sort to the middle, this this puts the emojis back on the left */
 
-[class*='popover_'] {
+[class*='popover'] {
   /* regular buttons go >div >svg, but tbh idrk the best way to use the selector for speed */
   >span:has(>div >div) {order: -2;}
-  >[class*='separator_'] {order: -1;}
+  >[class*='separator'] {order: -1;}
 }

--- a/src/plugins/showAllMessageButtons/style.css
+++ b/src/plugins/showAllMessageButtons/style.css
@@ -1,0 +1,7 @@
+/* with emojis on + extended menu at the same time, the emotes just
+   sort to the middle, this this puts the emojis back on the left */
+
+[class*='popover_'] {
+  >span:has(>[class*='hoverBarButton_'] >[class*='icon_'] >.emoji) {order: -1;}
+  >[class*='separator_'] {display: none;} 
+}

--- a/src/plugins/showAllMessageButtons/style.css
+++ b/src/plugins/showAllMessageButtons/style.css
@@ -3,6 +3,6 @@
 
 [class*='popover_'] {
   /* regular buttons go >div >svg, but tbh idrk the best way to use the selector for speed */
-  >span:has(>div >div) {order: -1;}
-  >[class*='separator_'] {display: none;}
+  >span:has(>div >div) {order: -2;}
+  >[class*='separator_'] {order: -1;}
 }

--- a/src/plugins/showAllMessageButtons/style.css
+++ b/src/plugins/showAllMessageButtons/style.css
@@ -2,6 +2,7 @@
    sort to the middle, this this puts the emojis back on the left */
 
 [class*='popover_'] {
-  >span:has(>[class*='hoverBarButton_'] >[class*='icon_'] >.emoji) {order: -1;}
-  >[class*='separator_'] {display: none;} 
+  /* regular buttons go >div >svg, but tbh idrk the best way to use the selector for speed */
+  >span:has(>div >div) {order: -1;}
+  >[class*='separator_'] {display: none;}
 }


### PR DESCRIPTION
This plugin shows all message context menu buttons by "holding shift" for you. But by default, holding shift also hides the quick reacts, so this plugin does the same, it permanently disables quick reacts on message hover (the plugin description mentions nothing about this).

## Describe your Changes

This patch unremoves quickreacts. The CSS is needed because without it, the quick reacts are in the middle of the menu instead of the end. `extendedButtons > Emojis > basicButtons`
It also includes an option to still remove the emojis and keep the plugin's current behavior.

Current plugin (quick reacts are permanently hidden with this plugin):
<img width="600" height="175" alt="image" src="https://github.com/user-attachments/assets/3595227e-6a85-4e90-9e35-117d4bf5569e" />

My patch (***without*** CSS, quick reacts are in the middle):
<img width="649" height="132" alt="image" src="https://github.com/user-attachments/assets/5c5add6a-5617-4f9d-8ee1-e8ceb1a18dec" />

My patch (***with*** CSS, emojis are on the end as you expect):
<img width="646" height="158" alt="image" src="https://github.com/user-attachments/assets/18cfd0eb-ac56-4d25-8c92-414913b8fde6" />

also(2) idk if i can, but i put the adjustment to my [original irc colors plugin fix](https://github.com/Equicord/Equicord/pull/971) because vencord will neve accept the pr + id like to not have to keep running a devbuild for this smol thing that was already merged

## Checklist before submitting
- [hi] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [hi] This pull request was written by me, and not an AI agent
