### PR TITLE
A two letter change that makes all the diffrence

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Linux
 - [AUR](https://aur.archlinux.org/packages?O=0&K=equicord)
 
 ```shell
-sh -c "$(curl -sS https://raw.githubusercontent.com/Equicord/Equicord/refs/heads/main/misc/install.sh)"
+bash -c "$(curl -sS https://raw.githubusercontent.com/Equicord/Equicord/refs/heads/main/misc/install.sh)"
 ```
 
 ## Installing Equicord Devbuild


### PR DESCRIPTION
<!-- if you are reading this... why? -->

## Describe your Changes
Edited the README as executing the script using `sh` causes it to error as the `(foo bar)` syntax is not posix compliant (see https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19 for the posix standard)
This change could also be emulated by removing the brackets around the `PRIVILEGE_CMDS` variable definition in [Install Script](./misc/install.sh)

Thanks for your time and for making equicord a good experience

## Checklist before submitting
- [x] This pull request was written by me, and not an AI agent
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
