### PR TITLE
feat(aiTranslate): add outgoing AI translator

### DIFF
--- a/src/equicordplugins/aiTranslate.desktop/helpers.ts
+++ b/src/equicordplugins/aiTranslate.desktop/helpers.ts
@@ -1,0 +1,274 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface ChatCompletionMessage {
+    role: "system" | "user";
+    content: string;
+}
+
+export interface ChatCompletionRequest {
+    model: string;
+    messages: ChatCompletionMessage[];
+    temperature?: number;
+    reasoning_effort?: "none";
+}
+
+export interface TranslationResponseResult {
+    translatedText: string;
+}
+
+export interface ContentCacheKeySettings {
+    model: string;
+    targetLanguage: string;
+    systemPrompt?: string;
+}
+
+export type TranslationStatus = "translating" | "sent" | "failed" | "rateLimited";
+
+export const DEFAULT_OPENCODE_ZEN_MODEL = "big-pickle";
+export const OPENCODE_ZEN_CHAT_COMPLETIONS_ENDPOINT = "https://opencode.ai/zen/v1/chat/completions";
+export const OPENCODE_ZEN_MODELS_ENDPOINT = "https://opencode.ai/zen/v1/models";
+export const DEFAULT_SYSTEM_PROMPT = "You rewrite outgoing Discord messages in {{target_language}} so they sound like something a real person would send. Keep the meaning, tone, energy, slang, emojis, mentions, URLs, code, and line breaks. If the message is casual, keep it casual. If it is blunt, keep it blunt. Use natural phrasing for that language, not textbook wording. Output only the rewritten message.";
+const GENERATION_CONTROLS = {
+    temperature: 1,
+    reasoning_effort: "none",
+} as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function applyTargetLanguage(systemPrompt: string, targetLanguage: string): string {
+    return systemPrompt.replace(/{{target_language}}/g, targetLanguage);
+}
+
+function normalizeCacheContent(content: string): string {
+    return content.trim().replace(/\s+/g, " ");
+}
+
+function normalizeScriptLanguage(language: string): string {
+    const normalized = language.toLowerCase();
+    if (normalized.includes("chinese")) return "Chinese";
+    if (normalized.includes("japanese")) return "Japanese";
+    if (normalized.includes("korean")) return "Korean";
+    if (normalized.includes("cyrillic") || normalized.includes("russian") || normalized.includes("ukrainian") || normalized.includes("bulgarian") || normalized.includes("serbian")) return "Cyrillic";
+    if (normalized.includes("arabic") || normalized.includes("persian") || normalized.includes("urdu")) return "Arabic";
+    if (normalized.includes("hebrew")) return "Hebrew";
+    if (normalized.includes("thai")) return "Thai";
+    if (normalized.includes("devanagari") || normalized.includes("hindi")) return "Devanagari";
+    if (normalized.includes("bengali")) return "Bengali";
+    if (normalized.includes("greek")) return "Greek";
+
+    return "Unknown";
+}
+
+function detectLanguageScript(content: string): string {
+    if (/\p{Script=Hiragana}|\p{Script=Katakana}/u.test(content)) return "Japanese";
+    if (/\p{Script=Hangul}/u.test(content)) return "Korean";
+    if (/\p{Script=Han}/u.test(content)) return "Chinese";
+    if (/\p{Script=Cyrillic}/u.test(content)) return "Cyrillic";
+    if (/\p{Script=Arabic}/u.test(content)) return "Arabic";
+    if (/\p{Script=Hebrew}/u.test(content)) return "Hebrew";
+    if (/\p{Script=Thai}/u.test(content)) return "Thai";
+    if (/\p{Script=Devanagari}/u.test(content)) return "Devanagari";
+    if (/\p{Script=Bengali}/u.test(content)) return "Bengali";
+    if (/\p{Script=Greek}/u.test(content)) return "Greek";
+
+    return "Unknown";
+}
+
+function getResponseDetail(responseBody: string): string {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(responseBody);
+    } catch {
+        return responseBody;
+    }
+
+    if (!isRecord(parsed)) return responseBody;
+    if (!isRecord(parsed.error)) return JSON.stringify(parsed);
+
+    const detail: string[] = [];
+    for (const value of Object.values(parsed.error)) {
+        if (typeof value === "string") detail.push(value);
+    }
+
+    return detail.join(" ");
+}
+
+export function isOpenCodeFreeModel(model: string): boolean {
+    const normalized = model.trim().toLowerCase();
+    return normalized === DEFAULT_OPENCODE_ZEN_MODEL || normalized.includes("free");
+}
+
+export function parseOpenCodeFreeModelsResponse(responseBody: string): string[] {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(responseBody);
+    } catch {
+        return [DEFAULT_OPENCODE_ZEN_MODEL];
+    }
+
+    const rawModels = isRecord(parsed) && Array.isArray(parsed.data) ? parsed.data : [];
+    const models = new Set<string>([DEFAULT_OPENCODE_ZEN_MODEL]);
+
+    for (const model of rawModels) {
+        const id = isRecord(model) && typeof model.id === "string" ? model.id.trim() : "";
+        if (id && isOpenCodeFreeModel(id)) models.add(id);
+    }
+
+    return [...models].sort((a: string, b: string) => {
+        if (a === DEFAULT_OPENCODE_ZEN_MODEL) return -1;
+        if (b === DEFAULT_OPENCODE_ZEN_MODEL) return 1;
+        return a.localeCompare(b);
+    });
+}
+
+export function hasTranslatableContent(content: string): boolean {
+    const text = content
+        .replace(/<a?:[A-Za-z0-9_]+:\d+>/g, " ")
+        .replace(/<(?:@!?|@&|#)\d+>/g, " ")
+        .replace(/<t:\d+(?::[tTdDfFR])?>/g, " ")
+        .replace(/<\/[^:>]+:\d+>/g, " ")
+        .replace(/\b(?:https?:\/\/|discord:\/\/|(?:cdn|media)\.discordapp\.(?:com|net)\/)\S+/gi, " ")
+        .replace(/\p{Extended_Pictographic}/gu, " ")
+        .replace(/\p{Regional_Indicator}/gu, " ")
+        .replace(/\p{Emoji_Modifier}/gu, " ")
+        .replace(/\u200D/g, " ")
+        .replace(/\u20E3/g, " ")
+        .replace(/[\uFE0E\uFE0F]/g, " ")
+        .replace(/[`*_~|>#[\](){}.,!?;:'"\\/@$%^&+=…—–-]/g, " ")
+        .trim();
+
+    return /\p{L}/u.test(text);
+}
+
+export function shouldTranslateOutgoingContent(content: string, targetLanguage: string, enabled = true): boolean {
+    if (!enabled || !hasTranslatableContent(content)) return false;
+
+    const targetScript = normalizeScriptLanguage(targetLanguage);
+    if (targetScript === "Unknown") return true;
+
+    return detectLanguageScript(content) !== targetScript;
+}
+
+export function buildJsonHeaders(): Record<string, string> {
+    return { "Content-Type": "application/json" };
+}
+
+export function getAutoTranslateToggleLabel(enabled: boolean): string {
+    return enabled ? "AI outgoing translate is on." : "AI outgoing translate is off.";
+}
+
+export function getTranslationStatusMessage(status: TranslationStatus, retryMs = 0): string {
+    if (status === "translating") return "Translating your message.";
+    if (status === "sent") return "Translated message sent.";
+    if (status === "failed") return "Translation failed, so the message was not sent.";
+
+    return `AI Translate is cooling down. Try again in ${Math.ceil(retryMs / 1000)} seconds.`;
+}
+
+export function getContentCacheKey(content: string, settings: ContentCacheKeySettings): string {
+    return JSON.stringify([
+        "ai-translate-outgoing-v1",
+        normalizeCacheContent(content),
+        settings.model.trim(),
+        settings.targetLanguage.trim(),
+        settings.systemPrompt ?? "",
+    ]);
+}
+
+export function buildTranslationRequest(
+    text: string,
+    targetLanguage: string,
+    model: string,
+    systemPrompt = DEFAULT_SYSTEM_PROMPT,
+    useGenerationControls = true
+): ChatCompletionRequest {
+    const prompt = applyTargetLanguage(systemPrompt, targetLanguage);
+    const userPrompt = `Message to rewrite in ${targetLanguage}:\n${text}`;
+    const request: ChatCompletionRequest = {
+        model,
+        messages: [
+            { role: "system", content: prompt },
+            { role: "user", content: userPrompt },
+        ],
+    };
+
+    return {
+        ...request,
+        ...(useGenerationControls ? GENERATION_CONTROLS : {}),
+    };
+}
+
+export function getGenerationControlsRetryPayload(responseBody: string, payload: string): string | null {
+    const detail = getResponseDetail(responseBody).toLowerCase();
+    const mentionsControl = detail.includes("temperature")
+        || detail.includes("reasoning_effort")
+        || detail.includes("extra_body")
+        || detail.includes("thinking_config")
+        || detail.includes("thinking_budget")
+        || detail.includes("include_thoughts");
+    const rejectsControl = detail.includes("unsupported")
+        || detail.includes("not supported")
+        || detail.includes("unknown")
+        || detail.includes("unrecognized")
+        || detail.includes("invalid parameter")
+        || detail.includes("extra fields");
+
+    if (!mentionsControl || !rejectsControl) return null;
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(payload);
+    } catch {
+        return null;
+    }
+
+    if (!isRecord(parsed)) return null;
+    if (!("temperature" in parsed) && !("reasoning_effort" in parsed) && !("extra_body" in parsed)) return null;
+
+    const retryPayload: Record<string, unknown> = { ...parsed };
+    delete retryPayload.temperature;
+    delete retryPayload.reasoning_effort;
+    delete retryPayload.extra_body;
+
+    return JSON.stringify(retryPayload);
+}
+
+export function stripReasoningText(text: string): string {
+    return text
+        .replace(/^\s*<(thought|thinking|think|analysis)>[\s\S]*?<\/\1>\s*/i, "")
+        .replace(/^\s*<(thought|thinking|think|analysis)>[\s\S]*?$/i, "")
+        .trim();
+}
+
+export function parseTranslationResponse(responseBody: string): TranslationResponseResult | null {
+    if (!responseBody) return null;
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(responseBody);
+    } catch {
+        return null;
+    }
+
+    if (!isRecord(parsed) || isRecord(parsed.error)) return null;
+
+    const { choices } = parsed;
+    if (!Array.isArray(choices) || choices.length === 0) return null;
+
+    const firstChoice = choices[0];
+    if (!isRecord(firstChoice) || !isRecord(firstChoice.message)) return null;
+
+    const { content } = firstChoice.message;
+    if (typeof content !== "string") return null;
+
+    const translatedText = stripReasoningText(content);
+    if (!translatedText) return null;
+
+    return { translatedText };
+}

--- a/src/equicordplugins/aiTranslate.desktop/index.tsx
+++ b/src/equicordplugins/aiTranslate.desktop/index.tsx
@@ -1,0 +1,108 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { ChatBarButton, type ChatBarButtonFactory } from "@api/ChatButtons";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { EquicordDevs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
+import definePlugin, { type IconComponent } from "@utils/types";
+import { showToast, Toasts } from "@webpack/common";
+
+import { getAutoTranslateToggleLabel, getTranslationStatusMessage, shouldTranslateOutgoingContent } from "./helpers";
+import { settings } from "./settings";
+import { abortActiveTranslations, clearContentTranslationCache, getTranslationRateLimitMs, translateText } from "./utils";
+
+const cl = classNameFactory("vc-aitrans-");
+const AUTO_TRANSLATE_KEYS: Array<"autoTranslate"> = ["autoTranslate"];
+let lastRateLimitToast = 0;
+
+const AITranslateIcon: IconComponent = ({ height = 20, width = 20, className }) => (
+    <svg
+        viewBox="0 0 24 24"
+        height={height}
+        width={width}
+        className={className}
+    >
+        <path fill="currentColor" d="M4 4h7v2H8.8c.4 1.5 1.1 2.8 2.1 4 .4-.6.8-1.2 1.1-2h2.1c-.5 1.4-1.1 2.6-2 3.7l1.9 1.9-1.4 1.4-1.8-1.8c-1.2 1.1-2.7 2-4.5 2.8l-.8-1.8c1.5-.7 2.8-1.5 3.8-2.5-1.2-1.4-2-3.3-2.5-5.7H4V4Zm12.5 5h2L22 20h-2.1l-.7-2.2h-3.5L15 20h-2l3.5-11Zm-.2 7h2.3l-1.1-3.7h-.1L16.3 16Z" />
+    </svg>
+);
+
+function showRateLimitToast(rateLimitMs: number) {
+    const now = Date.now();
+    if (now - lastRateLimitToast < 5_000) return;
+
+    lastRateLimitToast = now;
+    showToast(getTranslationStatusMessage("rateLimited", rateLimitMs), Toasts.Type.FAILURE);
+}
+
+const AITranslateChatButtonComponent: ChatBarButtonFactory = ({ isMainChat }) => {
+    const { autoTranslate } = settings.use(AUTO_TRANSLATE_KEYS);
+    if (!isMainChat) return null;
+
+    function toggle() {
+        settings.store.autoTranslate = !autoTranslate;
+        showToast(
+            getAutoTranslateToggleLabel(settings.store.autoTranslate),
+            settings.store.autoTranslate ? Toasts.Type.SUCCESS : Toasts.Type.MESSAGE
+        );
+    }
+
+    return (
+        <ChatBarButton
+            tooltip={autoTranslate ? "Turn off AI outgoing translate" : "Turn on AI outgoing translate"}
+            onClick={toggle}
+            onContextMenu={toggle}
+        >
+            <AITranslateIcon className={cl({ enabled: autoTranslate })} />
+        </ChatBarButton>
+    );
+};
+
+const WrappedAITranslateChatButton = ErrorBoundary.wrap(AITranslateChatButtonComponent, { noop: true });
+const AITranslateChatButton: ChatBarButtonFactory = props => <WrappedAITranslateChatButton {...props} />;
+
+export default definePlugin({
+    name: "AITranslate",
+    description: "Translate your messages with free OpenCode Zen AI models before Discord sends them.",
+    tags: ["Chat", "Utility"],
+    authors: [EquicordDevs.MasuRii],
+    settings,
+    chatBarButton: {
+        icon: AITranslateIcon,
+        render: AITranslateChatButton,
+    },
+
+    async onBeforeMessageSend(_, message) {
+        const { autoTranslate, targetLanguage } = settings.store;
+        if (!shouldTranslateOutgoingContent(message.content, targetLanguage, autoTranslate)) return;
+
+        let rateLimitMs = getTranslationRateLimitMs(targetLanguage);
+        if (rateLimitMs > 0) {
+            showRateLimitToast(rateLimitMs);
+            return { cancel: true };
+        }
+
+        showToast(getTranslationStatusMessage("translating"), Toasts.Type.CLOCK);
+        const translation = await translateText(message.content, targetLanguage);
+        if (translation) {
+            message.content = translation.translated;
+            showToast(getTranslationStatusMessage("sent"), Toasts.Type.SUCCESS);
+            return;
+        }
+
+        rateLimitMs = getTranslationRateLimitMs(targetLanguage);
+        if (rateLimitMs > 0) showRateLimitToast(rateLimitMs);
+        else showToast(getTranslationStatusMessage("failed"), Toasts.Type.FAILURE);
+        return { cancel: true };
+    },
+
+    stop() {
+        abortActiveTranslations();
+        clearContentTranslationCache();
+    },
+});

--- a/src/equicordplugins/aiTranslate.desktop/native.ts
+++ b/src/equicordplugins/aiTranslate.desktop/native.ts
@@ -1,0 +1,110 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import type { IpcMainInvokeEvent } from "electron";
+
+import { buildJsonHeaders, OPENCODE_ZEN_CHAT_COMPLETIONS_ENDPOINT, OPENCODE_ZEN_MODELS_ENDPOINT } from "./helpers";
+
+export interface OpenCodeZenResult {
+    ok: boolean;
+    status: number;
+    body: string;
+    error?: string;
+}
+
+const MAX_PAYLOAD_BYTES = 256_000;
+const MAX_RESPONSE_BYTES = 1_000_000;
+const REQUEST_TIMEOUT_MS = 30_000;
+const OPENCODE_ZEN_ALLOWED_ORIGIN = "https://opencode.ai";
+
+async function readCappedResponse(response: Response): Promise<string> {
+    const reader = response.body?.getReader();
+    if (!reader) return await response.text();
+
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+
+    for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value) continue;
+
+        received += value.byteLength;
+        if (received > MAX_RESPONSE_BYTES) {
+            await reader.cancel();
+            throw new Error("Response too large.");
+        }
+
+        chunks.push(value);
+    }
+
+    const body = new Uint8Array(received);
+    let offset = 0;
+    for (const chunk of chunks) {
+        body.set(chunk, offset);
+        offset += chunk.byteLength;
+    }
+
+    return new TextDecoder().decode(body);
+}
+
+function scrubFetchError(error: unknown): string {
+    if (error instanceof Error && error.name === "AbortError") return "Request timed out.";
+    if (error instanceof Error && error.message === "Response too large.") return error.message;
+
+    return "Request failed.";
+}
+
+function getAllowedOpenCodeUrl(url: string): string | null {
+    try {
+        const parsedUrl = new URL(url);
+        if (parsedUrl.origin === OPENCODE_ZEN_ALLOWED_ORIGIN) return parsedUrl.toString();
+    } catch {
+        return null;
+    }
+
+    return null;
+}
+
+async function makeOpenCodeRequest(url: string, init: RequestInit): Promise<OpenCodeZenResult> {
+    const requestUrl = getAllowedOpenCodeUrl(url);
+    if (!requestUrl) return { ok: false, status: 0, body: "", error: "Invalid endpoint." };
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+        const response = await fetch(requestUrl, {
+            ...init,
+            redirect: "error",
+            signal: controller.signal,
+        });
+
+        const body = await readCappedResponse(response);
+        return { ok: response.ok, status: response.status, body };
+    } catch (error) {
+        return { ok: false, status: 0, body: "", error: scrubFetchError(error) };
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+export async function makeModelsRequest(_: IpcMainInvokeEvent): Promise<OpenCodeZenResult> {
+    return await makeOpenCodeRequest(OPENCODE_ZEN_MODELS_ENDPOINT, { method: "GET" });
+}
+
+export async function makeTranslateRequest(_: IpcMainInvokeEvent, payload: string): Promise<OpenCodeZenResult> {
+    if (typeof payload !== "string") return { ok: false, status: 0, body: "", error: "Invalid request." };
+    if (!payload || new TextEncoder().encode(payload).byteLength > MAX_PAYLOAD_BYTES) {
+        return { ok: false, status: 0, body: "", error: "Request body is too large." };
+    }
+
+    return await makeOpenCodeRequest(OPENCODE_ZEN_CHAT_COMPLETIONS_ENDPOINT, {
+        method: "POST",
+        headers: buildJsonHeaders(),
+        body: payload,
+    });
+}

--- a/src/equicordplugins/aiTranslate.desktop/settings.ts
+++ b/src/equicordplugins/aiTranslate.desktop/settings.ts
@@ -1,0 +1,208 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings, SettingsStore } from "@api/Settings";
+import { Logger } from "@utils/Logger";
+import { classes } from "@utils/misc";
+import { OptionType, type PluginNative, type PluginSettingComponentProps } from "@utils/types";
+import { React, Select, useEffect, useState } from "@webpack/common";
+
+import { DEFAULT_OPENCODE_ZEN_MODEL, DEFAULT_SYSTEM_PROMPT, isOpenCodeFreeModel, parseOpenCodeFreeModelsResponse } from "./helpers";
+
+const DEFAULT_TARGET_LANGUAGE = "Chinese (Simplified)";
+const MODEL_KEYS: Array<"model"> = ["model"];
+const logger = new Logger("AITranslate");
+const Native = VencordNative.pluginHelpers.AITranslate as PluginNative<typeof import("./native")>;
+const removedSettings = ["endpoint", "apiKey", "modelDiscovery", "endpointTest"] as const;
+
+type ModelDiscoveryState = "loading" | "success" | "failure";
+
+interface ModelSelectorState {
+    type: ModelDiscoveryState;
+    message: string;
+    models: string[];
+}
+
+function getSettingsResultClassName(type: ModelDiscoveryState) {
+    return classes(
+        "vc-aitrans-settings-result",
+        type === "success" ? "vc-aitrans-settings-success" : undefined,
+        type === "failure" ? "vc-aitrans-settings-failure" : undefined
+    );
+}
+
+const LANGUAGE_VALUES = [
+    "English",
+    "Chinese (Simplified)",
+    "Chinese (Traditional)",
+    "Japanese",
+    "Korean",
+    "Spanish",
+    "French",
+    "German",
+    "Portuguese",
+    "Portuguese (Brazil)",
+    "Russian",
+    "Arabic",
+    "Hindi",
+    "Bengali",
+    "Indonesian",
+    "Vietnamese",
+    "Thai",
+    "Filipino",
+    "Malay",
+    "Italian",
+    "Dutch",
+    "Turkish",
+    "Polish",
+    "Ukrainian",
+    "Czech",
+    "Swedish",
+    "Norwegian",
+    "Danish",
+    "Finnish",
+    "Greek",
+    "Hebrew",
+    "Romanian",
+    "Hungarian",
+    "Bulgarian",
+    "Serbian",
+    "Croatian",
+    "Slovenian",
+    "Slovak",
+    "Lithuanian",
+    "Latvian",
+    "Estonian",
+    "Persian",
+    "Urdu",
+] as const;
+
+function makeLanguageOptions(defaultValue: string) {
+    return LANGUAGE_VALUES.map(value => ({
+        label: value,
+        value,
+        default: value === defaultValue,
+    }));
+}
+
+async function fetchOpenCodeFreeModels(): Promise<string[]> {
+    const response = await Native.makeModelsRequest();
+    if (!response.ok) throw new Error(response.error ?? `Request failed with status ${response.status}.`);
+
+    return parseOpenCodeFreeModelsResponse(response.body);
+}
+
+function OpenCodeModelSelector({ setValue }: PluginSettingComponentProps) {
+    const { model } = settings.use(MODEL_KEYS);
+    const selectedModel = typeof model === "string" && isOpenCodeFreeModel(model)
+        ? model
+        : DEFAULT_OPENCODE_ZEN_MODEL;
+    const [state, setState] = useState<ModelSelectorState>({
+        type: "loading",
+        message: "Fetching free OpenCode Zen models.",
+        models: [DEFAULT_OPENCODE_ZEN_MODEL],
+    });
+
+    useEffect(() => {
+        let mounted = true;
+
+        fetchOpenCodeFreeModels()
+            .then((models: string[]) => {
+                if (!mounted) return;
+
+                setState({
+                    type: "success",
+                    message: `Found ${models.length} free OpenCode Zen models.`,
+                    models,
+                });
+
+                const currentModel = settings.store.model;
+                if (typeof currentModel !== "string" || !models.includes(currentModel)) setValue(DEFAULT_OPENCODE_ZEN_MODEL);
+            })
+            .catch((error: unknown) => {
+                if (!mounted) return;
+
+                logger.warn("OpenCode Zen model discovery failed.", error);
+                setState({
+                    type: "failure",
+                    message: "Could not fetch free models. Big Pickle is still selected.",
+                    models: [DEFAULT_OPENCODE_ZEN_MODEL],
+                });
+
+                if (settings.store.model !== DEFAULT_OPENCODE_ZEN_MODEL) setValue(DEFAULT_OPENCODE_ZEN_MODEL);
+            });
+
+        return () => { mounted = false; };
+    }, [setValue]);
+
+    return React.createElement(
+        "div",
+        { className: "vc-aitrans-model-select" },
+        React.createElement(
+            "div",
+            { className: "vc-aitrans-settings-label" },
+            React.createElement("div", { className: "vc-aitrans-settings-title" }, "OpenCode Zen model"),
+            React.createElement("div", { className: "vc-aitrans-settings-description" }, "Automatically fetches free OpenCode Zen models. Messages are sent to OpenCode Zen for translation.")
+        ),
+        React.createElement(Select, {
+            placeholder: "Select a free model",
+            options: state.models.map((freeModel: string) => ({ label: freeModel, value: freeModel })),
+            maxVisibleItems: 5,
+            closeOnSelect: true,
+            select: (value: string) => setValue(value),
+            isSelected: (value: string) => value === selectedModel,
+            serialize: (value: string) => value,
+        }),
+        state.message && React.createElement(
+            "div",
+            { "aria-live": "polite", className: getSettingsResultClassName(state.type) },
+            state.message
+        )
+    );
+}
+
+const pluginSettings = SettingsStore.plain.plugins.AITranslate;
+if (pluginSettings) {
+    let changed = false;
+
+    for (const setting of removedSettings) {
+        if (Object.hasOwn(pluginSettings, setting)) {
+            delete pluginSettings[setting];
+            changed = true;
+        }
+    }
+
+    if (typeof pluginSettings.model !== "string" || !isOpenCodeFreeModel(pluginSettings.model)) {
+        pluginSettings.model = DEFAULT_OPENCODE_ZEN_MODEL;
+        changed = true;
+    }
+
+    if (changed) SettingsStore.markAsChanged();
+}
+
+export const settings = definePluginSettings({
+    model: {
+        type: OptionType.COMPONENT,
+        component: OpenCodeModelSelector,
+        default: DEFAULT_OPENCODE_ZEN_MODEL,
+    },
+    autoTranslate: {
+        type: OptionType.BOOLEAN,
+        description: "Translate your messages before Discord sends them.",
+        default: false,
+    },
+    targetLanguage: {
+        type: OptionType.SELECT,
+        description: "Language your messages are translated to before Discord sends them.",
+        options: makeLanguageOptions(DEFAULT_TARGET_LANGUAGE),
+    },
+    systemPrompt: {
+        type: OptionType.STRING,
+        description: "System prompt. Use {{target_language}} where the target language should appear.",
+        default: DEFAULT_SYSTEM_PROMPT,
+        multiline: true,
+    },
+});

--- a/src/equicordplugins/aiTranslate.desktop/style.css
+++ b/src/equicordplugins/aiTranslate.desktop/style.css
@@ -1,0 +1,39 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+.vc-aitrans-enabled {
+    color: var(--green-360);
+}
+
+.vc-aitrans-model-select {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.vc-aitrans-settings-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.vc-aitrans-settings-title {
+    color: var(--header-primary);
+    font-weight: 500;
+}
+
+.vc-aitrans-settings-description,
+.vc-aitrans-settings-result {
+    color: var(--text-muted);
+}
+
+.vc-aitrans-settings-success {
+    color: var(--green-360);
+}
+
+.vc-aitrans-settings-failure {
+    color: var(--text-danger);
+}

--- a/src/equicordplugins/aiTranslate.desktop/utils.ts
+++ b/src/equicordplugins/aiTranslate.desktop/utils.ts
@@ -1,0 +1,245 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Logger } from "@utils/Logger";
+import type { PluginNative } from "@utils/types";
+
+import {
+    buildTranslationRequest,
+    DEFAULT_OPENCODE_ZEN_MODEL,
+    getContentCacheKey,
+    getGenerationControlsRetryPayload,
+    isOpenCodeFreeModel,
+    parseTranslationResponse,
+} from "./helpers";
+import type { OpenCodeZenResult } from "./native";
+import { settings } from "./settings";
+
+interface AITranslation {
+    translated: string;
+}
+
+interface TranslationRequestConfig {
+    model: string;
+    targetLanguage: string;
+    systemPrompt?: string;
+}
+
+interface QueuedRequest {
+    reject(error: Error): void;
+    run(): void;
+}
+
+type TranslateRequestResult = OpenCodeZenResult;
+
+const Native = VencordNative.pluginHelpers.AITranslate as PluginNative<typeof import("./native")>;
+const logger = new Logger("AITranslate");
+const contentTranslationCache = new Map<string, AITranslation>();
+const contentInProgress = new Map<string, Promise<AITranslation | null>>();
+const generationControlsUnsupported = new Set<string>();
+const rateLimitedUntil = new Map<string, number>();
+const lastFailureLog = new Map<string, number>();
+const queuedRequests: QueuedRequest[] = [];
+const MAX_CONCURRENT_TRANSLATION_REQUESTS = 1;
+const RATE_LIMIT_COOLDOWN_MS = 60_000;
+const FAILURE_LOG_COOLDOWN_MS = 30_000;
+let activeRequestCount = 0;
+let contentCacheGeneration = 0;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getApiErrorMessage(body: string, status: number): string {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(body);
+    } catch {
+        parsed = null;
+    }
+
+    if (isRecord(parsed) && isRecord(parsed.error)) {
+        const { message, param, status: errorStatus } = parsed.error;
+        if (typeof message === "string" && typeof param === "string") return `${message}. ${param}`;
+        if (typeof message === "string" && typeof errorStatus === "string") return `${message}. ${errorStatus}`;
+        if (typeof message === "string") return message;
+    }
+
+    return status > 0 ? `Request failed with status ${status}.` : "Request failed.";
+}
+
+function getRequestConfigKey(config: TranslationRequestConfig): string {
+    return JSON.stringify([config.model]);
+}
+
+function drainQueuedRequests() {
+    while (activeRequestCount < MAX_CONCURRENT_TRANSLATION_REQUESTS) {
+        const queued = queuedRequests.shift();
+        if (!queued) return;
+
+        activeRequestCount++;
+        queued.run();
+    }
+}
+
+function enqueueTranslationRequest<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+        queuedRequests.push({
+            reject,
+            run() {
+                task().then(resolve, reject).finally(() => {
+                    activeRequestCount--;
+                    drainQueuedRequests();
+                });
+            },
+        });
+        drainQueuedRequests();
+    });
+}
+
+function getRateLimitedResponse(config: TranslationRequestConfig): TranslateRequestResult | null {
+    const retryAt = rateLimitedUntil.get(getRequestConfigKey(config));
+    if (retryAt === undefined || Date.now() >= retryAt) return null;
+
+    return { ok: false, status: 429, body: "", error: "Rate limited. Waiting before retrying." };
+}
+
+export function getTranslationRateLimitMs(targetLanguage = settings.store.targetLanguage): number {
+    const config = getTranslationConfig(targetLanguage, false);
+    if (!config) return 0;
+
+    const retryAt = rateLimitedUntil.get(getRequestConfigKey(config));
+    return retryAt === undefined ? 0 : Math.max(0, retryAt - Date.now());
+}
+
+function rememberRateLimit(config: TranslationRequestConfig, response: TranslateRequestResult) {
+    if (response.status !== 429) return;
+    rateLimitedUntil.set(getRequestConfigKey(config), Date.now() + RATE_LIMIT_COOLDOWN_MS);
+}
+
+async function makeTranslateRequest(payload: string): Promise<TranslateRequestResult> {
+    return await Native.makeTranslateRequest(payload);
+}
+
+export function abortActiveTranslations() {
+    for (const queued of queuedRequests.splice(0)) queued.reject(new Error("Request cancelled."));
+}
+
+export function clearContentTranslationCache() {
+    contentCacheGeneration++;
+    contentTranslationCache.clear();
+    contentInProgress.clear();
+    rateLimitedUntil.clear();
+    lastFailureLog.clear();
+}
+
+function getConfiguredModel(): string {
+    const { model } = settings.store;
+    if (typeof model === "string" && isOpenCodeFreeModel(model)) return model.trim();
+
+    return DEFAULT_OPENCODE_ZEN_MODEL;
+}
+
+function getTranslationConfig(targetLanguage: string, logFailure = true): TranslationRequestConfig | null {
+    const model = getConfiguredModel();
+    const normalizedTargetLanguage = targetLanguage.trim();
+
+    if (!model || !normalizedTargetLanguage) {
+        if (logFailure) logger.warn("Model and target language are required.");
+        return null;
+    }
+
+    return {
+        model,
+        targetLanguage: normalizedTargetLanguage,
+        systemPrompt: settings.store.systemPrompt,
+    };
+}
+
+function showTranslationRequestFailure(response: TranslateRequestResult): null {
+    const message = response.error ?? getApiErrorMessage(response.body, response.status);
+    const now = Date.now();
+    const last = lastFailureLog.get(message) ?? 0;
+    if (now - last > FAILURE_LOG_COOLDOWN_MS) {
+        lastFailureLog.set(message, now);
+        logger.warn(`Translation request failed. ${message}`);
+    }
+    return null;
+}
+
+function showMissingTranslationFailure(): null {
+    logger.warn("Translation response did not include translated text.");
+    return null;
+}
+
+async function makeTranslateRequestWithRetry(
+    config: TranslationRequestConfig,
+    buildPayload: (requestConfig: TranslationRequestConfig, useGenerationControls: boolean) => string
+): Promise<{ response: TranslateRequestResult; config: TranslationRequestConfig; }> {
+    try {
+        return await enqueueTranslationRequest(async () => {
+            const configKey = getRequestConfigKey(config);
+            const controlsUnsupported = generationControlsUnsupported.has(configKey);
+            const useGenerationControls = !controlsUnsupported;
+            const payload = buildPayload(config, useGenerationControls);
+            let response = getRateLimitedResponse(config) ?? await makeTranslateRequest(payload);
+            rememberRateLimit(config, response);
+            if (response.ok) return { response, config };
+
+            const retryPayload = getGenerationControlsRetryPayload(response.body, payload);
+            if (!retryPayload) return { response, config };
+
+            generationControlsUnsupported.add(configKey);
+            logger.warn("Retrying translation request without generation controls.");
+            response = getRateLimitedResponse(config) ?? await makeTranslateRequest(retryPayload);
+            rememberRateLimit(config, response);
+
+            return { response, config };
+        });
+    } catch {
+        return { response: { ok: false, status: 0, body: "", error: "Request cancelled." }, config };
+    }
+}
+
+async function requestTranslation(text: string, config: TranslationRequestConfig): Promise<AITranslation | null> {
+    const { response } = await makeTranslateRequestWithRetry(config, (requestConfig: TranslationRequestConfig, useGenerationControls: boolean) => JSON.stringify(buildTranslationRequest(
+        text,
+        requestConfig.targetLanguage,
+        requestConfig.model,
+        requestConfig.systemPrompt,
+        useGenerationControls
+    )));
+    if (!response.ok) return showTranslationRequestFailure(response);
+
+    const parsed = parseTranslationResponse(response.body);
+    if (!parsed) return showMissingTranslationFailure();
+
+    return { translated: parsed.translatedText };
+}
+
+export async function translateText(text: string, targetLanguage = settings.store.targetLanguage): Promise<AITranslation | null> {
+    const config = getTranslationConfig(targetLanguage);
+    if (!config) return null;
+
+    const cacheKey = getContentCacheKey(text, config);
+    const cached = contentTranslationCache.get(cacheKey);
+    if (cached) return cached;
+
+    const active = contentInProgress.get(cacheKey);
+    if (active) return await active;
+
+    const generation = contentCacheGeneration;
+    const promise = requestTranslation(text, config);
+    contentInProgress.set(cacheKey, promise);
+
+    try {
+        const translation = await promise;
+        if (translation && generation === contentCacheGeneration) contentTranslationCache.set(cacheKey, translation);
+        return translation;
+    } finally {
+        if (contentInProgress.get(cacheKey) === promise) contentInProgress.delete(cacheKey);
+    }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1009,6 +1009,10 @@ export const EquicordDevs = Object.freeze({
         name: "creations",
         id: 209830981060788225n
     },
+    MasuRii: {
+        name: "masurii",
+        id: 397885875184467968n
+    },
     Leko: {
         name: "Leko",
         id: 108153734541942784n


### PR DESCRIPTION
## Describe your Changes
First time contributor, anyway added a plugin that should translate your own input message only using AI using the legit and reputable free models (big pickle will always be free, so technically unlimited) from opencode (https://github.com/sst/opencode). Information about the models are here (https://opencode.ai/docs/models/).  Hopefully this will get added, as many complains from other foreign countries as using translation using google translate sound robotic, AI translation helps with that.

Features are:
1. Translates outgoing messages before Discord sends them (Auto-translate is disabled by default and can be toggled from the chat bar).
2. Settings for target language, model selection, and system prompt.
3. Fetches available free OpenCode Zen models

Commands run:
- `pnpm eslint src/equicordplugins/aiTranslate.desktop src/utils/constants.ts`
- `pnpm stylelint "src/equicordplugins/aiTranslate.desktop/**/*.css"`
- `pnpm testTsc`
- `pnpm build`

Screenshots:
<img width="753" height="876" alt="image" src="https://github.com/user-attachments/assets/e8408b53-2dce-4cf5-91f6-c1c23f3e9200" />

See the little button there for toggling auto translate in the chat bar:
<img width="1510" height="127" alt="image" src="https://github.com/user-attachments/assets/d7e769b5-a23a-4c82-8b45-cc4b1260278b" />


## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
