### PR TITLE
new plugin: StopAutoUnread

### DIFF
--- a/src/equicordplugins/stopAutoUnread/index.ts
+++ b/src/equicordplugins/stopAutoUnread/index.ts
@@ -9,7 +9,7 @@ import definePlugin from "@utils/types";
 
 export default definePlugin({
     name: "StopAutoUnread",
-    description: "Stops Discord from automatically bumping a channel's notification setting to \"All Messages\"",
+    description: 'Stops Discord from automatically bumping a channels notification setting to "All Messages"',
     authors: [EquicordDevs.SobakinTech],
 
     patches: [

--- a/src/equicordplugins/stopAutoUnread/index.ts
+++ b/src/equicordplugins/stopAutoUnread/index.ts
@@ -1,0 +1,24 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+
+export default definePlugin({
+    name: "StopAutoUnread",
+    description: "Stops Discord from automatically bumping a channel's notification setting to \"All Messages\"",
+    authors: [EquicordDevs.SobakinTech],
+
+    patches: [
+        {
+            find: "}maybeAutoUpgradeChannel(",
+            replacement: {
+                match: /maybeAutoUpgradeChannel\(\i\){/,
+                replace: "$&return !1;"
+            }
+        }
+    ]
+});

--- a/src/equicordplugins/stopAutoUnread/index.ts
+++ b/src/equicordplugins/stopAutoUnread/index.ts
@@ -11,7 +11,6 @@ export default definePlugin({
     name: "StopAutoUnread",
     description: 'Stops Discord from automatically bumping a channels notification setting to "All Messages"',
     authors: [EquicordDevs.SobakinTech],
-
     patches: [
         {
             find: "}maybeAutoUpgradeChannel(",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1346,6 +1346,10 @@ export const EquicordDevs = Object.freeze({
         name: "pandaptable",
         id: 97153209843335168n
     },
+    SobakinTech: {
+        name: "sobakintech",
+        id: 745203026335236178n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
<img width="1250" height="99" alt="16-59-25" src="https://github.com/user-attachments/assets/bf4139c4-e27b-4739-ad5f-d5e979faa59f" />

Added a new plugin which stops Discord from automatically setting a channel's notification setting to "All Messages". The plugin was originally submitted to the Vencord client in https://github.com/Vendicated/Vencord/pull/3055 but got rejected because the behaviour it was changing was still a partial experiment - it no longer is.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
