### PR TITLE
FavouriteAnything: Message components V2 support

### DIFF
--- a/src/equicordplugins/favouriteAnything/components.tsx
+++ b/src/equicordplugins/favouriteAnything/components.tsx
@@ -279,25 +279,40 @@ export function AttachmentAccessory() {
 
     const props: FavoriteButtonProps | null = useMemo(() => {
         if (!attachment?.downloadUrl) return null;
-        const { originalItem, type, downloadUrl, width = 600, height = 400, srcIsAnimated } = attachment;
+        const { originalItem, uniqueId, type, downloadUrl, srcIsAnimated, spoiler } = attachment;
+        const width = attachment.width || 600, height = attachment.height || 400;
+
+        // Regular media attachments and cv2 media attachments are structured differently
+        const raw: MessageAttachment =
+            "media" in originalItem
+                ? {
+                    ...originalItem.media,
+                    id: uniqueId,
+                    size: 0,
+                    spoiler,
+                    filename: "UNKNOWN",
+                    content_type: originalItem.media.contentType,
+                    proxy_url: originalItem.media.proxyUrl,
+                }
+                : originalItem;
 
         // Do not render the custom accessory if the original attachment component already has a gif accessory
         const isAnimated = ImageUtils.isAnimated({
-            original: originalItem.url,
-            src: originalItem.proxy_url,
+            original: raw.url,
+            src: raw.proxy_url,
             animated: false,
             srcIsAnimated
         });
         if (isAnimated) return null;
 
         if (type in visualMediaFormats) {
-            return { format: visualMediaFormats[type]!, src: originalItem.proxy_url, url: downloadUrl, width, height };
+            return { format: visualMediaFormats[type]!, src: raw.proxy_url, url: downloadUrl, width, height };
         }
 
         // Non visual attachments have to be encoded to store metadata in the src property.
         // Note that this isn't a valid url yet, the full url (with a fallback image for vanilla client compat)
         // is generated via `getThumbnailUrl` once the user clicks the favourite button
-        const src = defs.encode(CustomItemFormat.ATTACHMENT, originalItem)?.toString();
+        const src = defs.encode(CustomItemFormat.ATTACHMENT, raw)?.toString();
         if (!src) return null;
 
         return { format: FavouriteItemFormat.NONE, src, url: downloadUrl, width, height };

--- a/src/equicordplugins/favouriteAnything/components.tsx
+++ b/src/equicordplugins/favouriteAnything/components.tsx
@@ -279,40 +279,26 @@ export function AttachmentAccessory() {
 
     const props: FavoriteButtonProps | null = useMemo(() => {
         if (!attachment?.downloadUrl) return null;
-        const { originalItem, uniqueId, type, downloadUrl, srcIsAnimated, spoiler } = attachment;
+        const { originalItem, type, downloadUrl, srcIsAnimated } = attachment;
         const width = attachment.width || 600, height = attachment.height || 400;
-
-        // Regular media attachments and cv2 media attachments are structured differently
-        const raw: MessageAttachment =
-            "media" in originalItem
-                ? {
-                    ...originalItem.media,
-                    id: uniqueId,
-                    size: 0,
-                    spoiler,
-                    filename: "UNKNOWN",
-                    content_type: originalItem.media.contentType,
-                    proxy_url: originalItem.media.proxyUrl,
-                }
-                : originalItem;
 
         // Do not render the custom accessory if the original attachment component already has a gif accessory
         const isAnimated = ImageUtils.isAnimated({
-            original: raw.url,
-            src: raw.proxy_url,
+            original: originalItem.url,
+            src: originalItem.proxy_url,
             animated: false,
             srcIsAnimated
         });
         if (isAnimated) return null;
 
         if (type in visualMediaFormats) {
-            return { format: visualMediaFormats[type]!, src: raw.proxy_url, url: downloadUrl, width, height };
+            return { format: visualMediaFormats[type]!, src: originalItem.proxy_url, url: downloadUrl, width, height };
         }
 
         // Non visual attachments have to be encoded to store metadata in the src property.
         // Note that this isn't a valid url yet, the full url (with a fallback image for vanilla client compat)
         // is generated via `getThumbnailUrl` once the user clicks the favourite button
-        const src = defs.encode(CustomItemFormat.ATTACHMENT, raw)?.toString();
+        const src = defs.encode(CustomItemFormat.ATTACHMENT, originalItem)?.toString();
         if (!src) return null;
 
         return { format: FavouriteItemFormat.NONE, src, url: downloadUrl, width, height };

--- a/src/equicordplugins/favouriteAnything/index.tsx
+++ b/src/equicordplugins/favouriteAnything/index.tsx
@@ -15,8 +15,8 @@ import { ComponentType, ReactNode } from "react";
 import { AttachmentAccessory, EmbedAccessory, FilePicker } from "./components";
 import { SignedUrlsStore } from "./stores";
 import managedStyle from "./style.css?managed";
-import { AttachmentItem, EmbedComponent, ExpressionPickerTabProps, ExpressionPickerView, FavouriteItem, FavouriteItemFormat } from "./types";
-import { getThumbnailUrl } from "./utils";
+import { AttachmentItem, CV2AttachmentItem, EmbedComponent, ExpressionPickerTabProps, ExpressionPickerView, FavouriteItem, FavouriteItemFormat } from "./types";
+import { getThumbnailUrl, transformAttachment } from "./utils";
 
 export const EmbedContext = proxyLazyWebpack(() => React.createContext<null | Embed>(null));
 export const EmbedMosaicContext = proxyLazyWebpack(() => React.createContext<null | number>(null));
@@ -69,6 +69,15 @@ export default definePlugin({
                     replace: "=[$self.renderAttachmentAccessory()];"
                 }
             ]
+        },
+        // COMPONENTSv2
+        {
+            // FILE message component
+            find: "#{intl::ATTACHMENT_FILENAME_UNKNOWN}",
+            replacement: {
+                match: /(?<=case \i\.\i\.FILE:)return(\(0,\i\.jsx\)\(\i,\{\.\.\.(\i)\},(\i)\))/,
+                replace: "return $self.renderCV2Attachment($1,$3,$2)"
+            }
         },
         // EXPRESSION PICKER
         {
@@ -135,6 +144,15 @@ export default definePlugin({
     },
     renderAttachment(children: ReactNode, props: { item: AttachmentItem; }) {
         return <AttachmentContext.Provider value={props.item}>{children}</AttachmentContext.Provider>;
+    },
+    renderCV2Attachment(children: ReactNode, key: React.Key, props: { id: string; size: number; name: string; spoiler: boolean; file: CV2AttachmentItem; }) {
+        const { id, size, name, spoiler, file: { width, height, contentType, proxyUrl, ...rest } } = props;
+        const raw = { ...rest, size, filename: name, id, spoiler, content_type: contentType, proxy_url: proxyUrl };
+
+        // width and height properties are incorrectly added to non media cv2 attachments
+        if (width && height) Object.assign(raw, { width, height });
+
+        return <AttachmentContext.Provider value={transformAttachment(raw)} key={key}>{children}</AttachmentContext.Provider>;
     },
     renderEmbed(this: EmbedComponent) {
         return <EmbedContext.Provider value={this.props.embed}>{this.__render()}</EmbedContext.Provider>;

--- a/src/equicordplugins/favouriteAnything/index.tsx
+++ b/src/equicordplugins/favouriteAnything/index.tsx
@@ -15,7 +15,7 @@ import { ComponentType, ReactNode } from "react";
 import { AttachmentAccessory, EmbedAccessory, FilePicker } from "./components";
 import { SignedUrlsStore } from "./stores";
 import managedStyle from "./style.css?managed";
-import { AttachmentItem, CV2AttachmentItem, EmbedComponent, ExpressionPickerTabProps, ExpressionPickerView, FavouriteItem, FavouriteItemFormat } from "./types";
+import { AttachmentItem, CV2Attachment, EmbedComponent, ExpressionPickerTabProps, ExpressionPickerView, FavouriteItem, FavouriteItemFormat } from "./types";
 import { getThumbnailUrl, transformAttachment } from "./utils";
 
 export const EmbedContext = proxyLazyWebpack(() => React.createContext<null | Embed>(null));
@@ -70,13 +70,12 @@ export default definePlugin({
                 }
             ]
         },
-        // COMPONENTSv2
+        // COMPONENTS V2
         {
-            // FILE message component
             find: "#{intl::ATTACHMENT_FILENAME_UNKNOWN}",
             replacement: {
                 match: /(?<=case \i\.\i\.FILE:)return(\(0,\i\.jsx\)\(\i,\{\.\.\.(\i)\},(\i)\))/,
-                replace: "return $self.renderCV2Attachment($1,$3,$2)"
+                replace: "return $self.renderCV2File($1,$3,$2)"
             }
         },
         // EXPRESSION PICKER
@@ -145,12 +144,9 @@ export default definePlugin({
     renderAttachment(children: ReactNode, props: { item: AttachmentItem; }) {
         return <AttachmentContext.Provider value={props.item}>{children}</AttachmentContext.Provider>;
     },
-    renderCV2Attachment(children: ReactNode, key: React.Key, props: { id: string; size: number; name: string; spoiler: boolean; file: CV2AttachmentItem; }) {
-        const { id, size, name, spoiler, file: { width, height, contentType, proxyUrl, ...rest } } = props;
-        const raw = { ...rest, size, filename: name, id, spoiler, content_type: contentType, proxy_url: proxyUrl };
-
-        // width and height properties are incorrectly added to non media cv2 attachments
-        if (width && height) Object.assign(raw, { width, height });
+    renderCV2File(children: ReactNode, key: React.Key, props: { id: string; size: number; name: string; spoiler: boolean; file: CV2Attachment; }) {
+        const { id, size, name, spoiler, file } = props;
+        const raw = { ...file, size, filename: name, id, spoiler, content_type: file.contentType, proxy_url: file.proxyUrl };
 
         return <AttachmentContext.Provider value={transformAttachment(raw)} key={key}>{children}</AttachmentContext.Provider>;
     },

--- a/src/equicordplugins/favouriteAnything/index.tsx
+++ b/src/equicordplugins/favouriteAnything/index.tsx
@@ -7,7 +7,7 @@
 import { Devs, EquicordDevs } from "@utils/constants";
 import { getIntlMessage } from "@utils/discord";
 import definePlugin from "@utils/types";
-import { Embed } from "@vencord/discord-types";
+import { Embed, MessageAttachment } from "@vencord/discord-types";
 import { proxyLazyWebpack } from "@webpack";
 import { React } from "@webpack/common";
 import { ComponentType, ReactNode } from "react";
@@ -141,8 +141,24 @@ export default definePlugin({
     renderFilePicker(activeView: ExpressionPickerView, onSelectGIF: (item: { url: string; }) => void) {
         return activeView === ExpressionPickerView.FILES ? <FilePicker onSelectItem={onSelectGIF} /> : null;
     },
-    renderAttachment(children: ReactNode, props: { item: AttachmentItem; }) {
-        return <AttachmentContext.Provider value={props.item}>{children}</AttachmentContext.Provider>;
+    renderAttachment(children: ReactNode, props: { item: AttachmentItem<MessageAttachment | { media: CV2Attachment; }>; }) {
+        const { item: { originalItem, ...rest } } = props;
+
+        // Regular media attachments and cv2 media attachments are structured differently
+        const raw: MessageAttachment =
+            "media" in originalItem
+                ? {
+                    ...originalItem.media,
+                    id: rest.uniqueId,
+                    size: 0,
+                    spoiler: rest.spoiler,
+                    filename: (rest.spoiler ? "SPOILER_" : "") + rest.uniqueId,
+                    content_type: originalItem.media.contentType,
+                    proxy_url: originalItem.media.proxyUrl,
+                }
+                : originalItem;
+
+        return <AttachmentContext.Provider value={{ originalItem: raw, ...rest }}>{children}</AttachmentContext.Provider>;
     },
     renderCV2File(children: ReactNode, key: React.Key, props: { id: string; size: number; name: string; spoiler: boolean; file: CV2Attachment; }) {
         const { id, size, name, spoiler, file } = props;

--- a/src/equicordplugins/favouriteAnything/types.ts
+++ b/src/equicordplugins/favouriteAnything/types.ts
@@ -76,7 +76,7 @@ export interface EmbedComponent extends Component<{ embed: Embed; }> {
     __render: () => ReactNode;
 }
 
-export interface AttachmentItem {
+export interface AttachmentItem<TOriginal = MessageAttachment> {
     contentType: string;
     type: "IMAGE" | "VIDEO" | "CLIP" | "AUDIO" | "VISUAL_PLACEHOLDER" | "PLAINTEXT_PREVIEW" | "OTHER" | "INVALID";
     width?: number;
@@ -85,7 +85,7 @@ export interface AttachmentItem {
     spoiler: boolean;
     srcIsAnimated: boolean;
     uniqueId: string;
-    originalItem: MessageAttachment | { media: CV2Attachment; };
+    originalItem: TOriginal;
 }
 
 export interface CV2Attachment {

--- a/src/equicordplugins/favouriteAnything/types.ts
+++ b/src/equicordplugins/favouriteAnything/types.ts
@@ -88,6 +88,16 @@ export interface AttachmentItem {
     originalItem: MessageAttachment;
 }
 
+export interface CV2AttachmentItem {
+    url: string;
+    proxyUrl: string;
+    width: number;
+    height: number;
+    placeholder?: string;
+    contentType: string;
+    flags: number;
+}
+
 export enum FavouriteItemFormat {
     NONE = 0,
     IMAGE = 1,
@@ -138,3 +148,5 @@ export type ResizeObserverHook = (
 export interface ImageUtils {
     isAnimated(image: { src: string; original?: string; animated: boolean; srcIsAnimated?: boolean; }): boolean;
 }
+
+export type AttachmentTransformer = (attachment: Partial<MessageAttachment>, inlineAttachmentMedia?: boolean) => AttachmentItem;

--- a/src/equicordplugins/favouriteAnything/types.ts
+++ b/src/equicordplugins/favouriteAnything/types.ts
@@ -85,10 +85,10 @@ export interface AttachmentItem {
     spoiler: boolean;
     srcIsAnimated: boolean;
     uniqueId: string;
-    originalItem: MessageAttachment;
+    originalItem: MessageAttachment | { media: CV2Attachment; };
 }
 
-export interface CV2AttachmentItem {
+export interface CV2Attachment {
     url: string;
     proxyUrl: string;
     width: number;
@@ -149,4 +149,4 @@ export interface ImageUtils {
     isAnimated(image: { src: string; original?: string; animated: boolean; srcIsAnimated?: boolean; }): boolean;
 }
 
-export type AttachmentTransformer = (attachment: Partial<MessageAttachment>, inlineAttachmentMedia?: boolean) => AttachmentItem;
+export type AttachmentTransformer = (attachment: MessageAttachment, inlineAttachmentMedia?: boolean) => AttachmentItem;

--- a/src/equicordplugins/favouriteAnything/utils.ts
+++ b/src/equicordplugins/favouriteAnything/utils.ts
@@ -18,7 +18,7 @@ import { Key } from "react";
 import { JsonValue } from "type-fest";
 
 import { base64ToUint8Array, uint8ArrayToBase64 } from "./polyfills";
-import { CustomItemDef, CustomItemFormat, FavouriteItem, FavouriteItemFormat, ImageUtils as ImageUtils_, ItemsDef, ResizeObserverHook, UnfurledEmbedsResponse } from "./types";
+import { AttachmentTransformer, CustomItemDef, CustomItemFormat, FavouriteItem, FavouriteItemFormat, ImageUtils as ImageUtils_, ItemsDef, ResizeObserverHook, UnfurledEmbedsResponse } from "./types";
 
 const Native = VencordNative.pluginHelpers.FavouriteAnything as PluginNative<typeof import("./native")>;
 
@@ -26,6 +26,7 @@ export const cl = classNameFactory("vc-favouriteAnything-");
 
 export const useResizeObserver: ResizeObserverHook = findByCodeLazy("borderBoxSize", "blockSize", "inlineSize");
 export const ImageUtils: ImageUtils_ = findByPropsLazy("isAnimated", "getFormatQuality");
+export const transformAttachment: AttachmentTransformer = findByCodeLazy("return{uniqueId", ".IS_ANIMATED");
 
 const defineItem = <const A, const B extends JsonValue>(item: CustomItemDef<A, B>) => item;
 function defineItems<T extends Record<CustomItemFormat, CustomItemDef>>(def: ItemsDef<T>) {


### PR DESCRIPTION
## Describe your Changes
What the title says. Adds support for files and media embedded within message components, which were previously broken.
<img width="614" height="410" alt="image" src="https://github.com/user-attachments/assets/79a1809e-7bdd-45a7-9ca9-0a5c589fb919" />


## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
