### PR TITLE
Handle zero in threshold in SilentTyping plugin

### DIFF
--- a/src/plugins/silentTyping/index.tsx
+++ b/src/plugins/silentTyping/index.tsx
@@ -288,17 +288,19 @@ function isImplicitlyAllowed(channel: string | Channel): number {
         return 1;
     }
 
+    const addedThreshold = !guildID
+        ? settings.store.temporaryEnableThresholdDirectMessages
+        : settings.store.temporaryEnableThresholdServers;
+
+    if (addedThreshold === 0) {
+        return 0;
+    }
+
     const lastMessage = MessageStore.getLastEditableMessage(resolvedChannel.id);
     const messageTimestamp = lastMessage?.timestamp?.getTime?.();
 
-    if (messageTimestamp) {
-        const addedThreshold = !guildID
-            ? settings.store.temporaryEnableThresholdDirectMessages
-            : settings.store.temporaryEnableThresholdServers;
-
-        if (Date.now() < messageTimestamp + (addedThreshold * 1000)) {
-            return 2;
-        }
+    if (messageTimestamp && Date.now() < messageTimestamp + (addedThreshold * 1000)) {
+        return 2;
     }
 
     return 0;


### PR DESCRIPTION
## Describe your Changes
Now it handles default's 0 in the `Temporary Enable Threshold ...` settings in SilentTyping, just `return`-ing out of function instead of going that "temporary active" route. 
Was already adressed in the Discord server in [bug-report channel](https://discord.com/channels/1173279886065029291/1512304896345510119), and by me in the support chat

## Checklist before submitting
- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [X] This pull request was written by me, and not an AI agent
