### PR TITLE
fix(gifCollections): incorect treatment of all tenor url's as videos

### DIFF
--- a/src/equicordplugins/gifCollections/utils/getFormat.ts
+++ b/src/equicordplugins/gifCollections/utils/getFormat.ts
@@ -11,5 +11,5 @@ const videoExtensions = ["mp4", "ogg", "webm", "avi", "wmv", "flv", "mov", "mkv"
 
 export function getFormat(url: string) {
     const extension = getUrlExtension(url);
-    return url.startsWith("https://media.tenor") || extension == null || videoExtensions.includes(extension) ? Format.VIDEO : Format.IMAGE;
+    return extension != null && videoExtensions.includes(extension) ? Format.VIDEO : Format.IMAGE;
 }


### PR DESCRIPTION
So gifCollections was treating EVERY tenor url as video, when in fact they were not