### PR TITLE
feat(StreamResize): add plugin for configurable PIP stream size

### DIFF
--- a/src/equicordplugins/streamResize/README.md
+++ b/src/equicordplugins/streamResize/README.md
@@ -1,0 +1,44 @@
+# StreamResize
+
+Extend the min/max resize limits of Discord's Picture-in-Picture (PIP) stream window.
+
+When a stream is not in focus (you scrolled away or opened another channel), Discord
+shows it as a floating, draggable PIP window that can only be resized within a fixed
+range. This plugin makes that range configurable via two sliders, while keeping the
+window at 16:9.
+
+## Settings
+
+- **Minimum PIP size (% of screen)** — lower bound, as a percentage of the Discord
+  window. Default `20`.
+- **Maximum PIP size (% of screen)** — upper bound. Default `90`.
+
+Both are live: moving a slider affects the next drag, no reload needed. If min > max
+they are swapped automatically.
+
+## How it works
+
+- `bounds.ts` — a pure helper. `computeBounds(screenW, screenH, minPct, maxPct)`
+  returns `{ min, max }` sizes. It keeps 16:9 and uses a "fit" rule (the smaller axis
+  wins) so the PIP never overflows the window on either axis.
+- `index.tsx` — the plugin. Two `OptionType.SLIDER` settings plus a `getBounds()`
+  method that feeds the current window size and slider values into `computeBounds`.
+- The patch targets Discord's resizable PIP container (the module that uniquely
+  contains `Draggable`). It rewrites two width clamps to use `$self.getBounds()`:
+  the live drag constraint and the on-release clamp. Height is derived from width at
+  16:9 by Discord itself, so only width needs patching.
+
+## Tests
+
+The pure helper has unit tests (Node's built-in test runner, run via `tsx`):
+
+```sh
+npx tsx --test src/equicordplugins/streamResize/bounds.test.ts
+```
+
+## Maintenance
+
+The patch matches obfuscated Discord code and may break after a Discord update. If the
+PIP stops resizing and the console shows `failed to apply patch StreamResize`,
+re-discover the module (search webpack for `Draggable`) and re-derive the two regex
+matches in `index.tsx`.

--- a/src/equicordplugins/streamResize/bounds.test.ts
+++ b/src/equicordplugins/streamResize/bounds.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { ASPECT_RATIO, computeBounds, sizeForPct } from "./bounds";
+
+test("sizeForPct keeps 16:9 ratio", () => {
+    const s = sizeForPct(1920, 1080, 50);
+    assert.ok(Math.abs(s.w / s.h - ASPECT_RATIO) < 1e-6);
+});
+
+test("sizeForPct is width-limited on a square screen", () => {
+    // 1000x1000: wByWidth=1000, wByHeight=1000*16/9≈1778 -> width wins
+    const s = sizeForPct(1000, 1000, 100);
+    assert.ok(Math.abs(s.w - 1000) < 1e-6);
+});
+
+test("sizeForPct is height-limited on an ultrawide screen", () => {
+    // 3440x1440: wByWidth=3440, wByHeight=1440*16/9=2560 -> height wins
+    const s = sizeForPct(3440, 1440, 100);
+    assert.ok(Math.abs(s.w - 2560) < 1e-6);
+    assert.ok(Math.abs(s.h - 1440) < 1e-6);
+});
+
+test("computeBounds maps minPct/maxPct to min/max sizes", () => {
+    const b = computeBounds(1920, 1080, 20, 90);
+    assert.ok(b.min.w < b.max.w);
+    assert.ok(Math.abs(b.min.w / b.min.h - ASPECT_RATIO) < 1e-6);
+    assert.ok(Math.abs(b.max.w / b.max.h - ASPECT_RATIO) < 1e-6);
+});
+
+test("computeBounds swaps when minPct > maxPct", () => {
+    const swapped = computeBounds(1920, 1080, 90, 20);
+    const ordered = computeBounds(1920, 1080, 20, 90);
+    assert.ok(Math.abs(swapped.min.w - ordered.min.w) < 1e-6);
+    assert.ok(Math.abs(swapped.max.w - ordered.max.w) < 1e-6);
+});
+
+test("computeBounds falls back when a screen dimension is 0", () => {
+    const b = computeBounds(0, 1080, 20, 90);
+    assert.equal(b.min.w, 320);
+    assert.equal(b.max.w, 1280);
+});

--- a/src/equicordplugins/streamResize/bounds.ts
+++ b/src/equicordplugins/streamResize/bounds.ts
@@ -6,19 +6,29 @@
 
 export const ASPECT_RATIO = 16 / 9;
 
-export interface Size { w: number; h: number; }
-export interface Bounds { min: Size; max: Size; }
+export interface Size {
+    w: number;
+    h: number;
+}
+export interface Bounds {
+    min: Size;
+    max: Size;
+}
 
 const FALLBACK: Bounds = {
     min: { w: 320, h: 180 },
     max: { w: 1280, h: 720 },
 };
 
-export function sizeForPct(screenW: number, screenH: number, pct: number): Size {
+export function sizeForPct(
+    screenW: number,
+    screenH: number,
+    pct: number,
+): Size {
     const p = pct / 100;
-    const wByWidth = screenW * p; // width-limited width
-    const wByHeight = screenH * p * ASPECT_RATIO; // height-limited -> width
-    const w = Math.min(wByWidth, wByHeight); // FIT: smaller axis wins
+    const wByWidth = screenW * p;
+    const wByHeight = screenH * p * ASPECT_RATIO;
+    const w = Math.min(wByWidth, wByHeight);
     return { w, h: w / ASPECT_RATIO };
 }
 

--- a/src/equicordplugins/streamResize/bounds.ts
+++ b/src/equicordplugins/streamResize/bounds.ts
@@ -1,0 +1,38 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export const ASPECT_RATIO = 16 / 9;
+
+export interface Size { w: number; h: number; }
+export interface Bounds { min: Size; max: Size; }
+
+const FALLBACK: Bounds = {
+    min: { w: 320, h: 180 },
+    max: { w: 1280, h: 720 },
+};
+
+export function sizeForPct(screenW: number, screenH: number, pct: number): Size {
+    const p = pct / 100;
+    const wByWidth = screenW * p; // width-limited width
+    const wByHeight = screenH * p * ASPECT_RATIO; // height-limited -> width
+    const w = Math.min(wByWidth, wByHeight); // FIT: smaller axis wins
+    return { w, h: w / ASPECT_RATIO };
+}
+
+export function computeBounds(
+    screenW: number,
+    screenH: number,
+    minPct: number,
+    maxPct: number,
+): Bounds {
+    if (!screenW || !screenH) return FALLBACK;
+    const lo = Math.min(minPct, maxPct);
+    const hi = Math.max(minPct, maxPct);
+    return {
+        min: sizeForPct(screenW, screenH, lo),
+        max: sizeForPct(screenW, screenH, hi),
+    };
+}

--- a/src/equicordplugins/streamResize/index.tsx
+++ b/src/equicordplugins/streamResize/index.tsx
@@ -1,6 +1,6 @@
 /*
  * Vencord, a Discord client mod
- * Copyright (c) 2024 Vendicated and contributors
+ * Copyright (c) 2026 Vendicated and contributors
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 

--- a/src/equicordplugins/streamResize/index.tsx
+++ b/src/equicordplugins/streamResize/index.tsx
@@ -1,0 +1,65 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin, { makeRange, OptionType } from "@utils/types";
+
+import { Bounds, computeBounds } from "./bounds";
+
+export const settings = definePluginSettings({
+    minPct: {
+        description: "Minimum PIP size (% of screen)",
+        type: OptionType.SLIDER,
+        markers: makeRange(10, 90, 5),
+        default: 20,
+        stickToMarkers: false,
+    },
+    maxPct: {
+        description: "Maximum PIP size (% of the screen)",
+        type: OptionType.SLIDER,
+        markers: makeRange(20, 100, 5),
+        default: 90,
+        stickToMarkers: false,
+    },
+});
+
+export default definePlugin({
+    name: "StreamResize",
+    description:
+        "Extend the min/max resize limits of the PIP stream window (keep 16:9)",
+    authors: [EquicordDevs.Skaikru0518],
+    settings,
+
+    getBounds(): Bounds {
+        return computeBounds(
+            window.innerWidth,
+            window.innerHeight,
+            settings.store.minPct,
+            settings.store.maxPct,
+        );
+    },
+
+    patches: [
+        {
+            find: "40*Math.round(",
+            replacement: [
+                {
+                    // clamp on resize end (final width)
+                    match: /(=40\*Math\.round\(\i\/40\);return\(0,\i\.clamp\)\(\i,)\i\.minWidth,\i\.maxWidth\)/,
+                    replace:
+                        "$1$self.getBounds().min.w,$self.getBounds().max.w)",
+                },
+                {
+                    // live drag constraint (hard limit while dragging)
+                    match: /minDimension:\i\.minWidth,maxDimension:\i\.maxWidth\+20/,
+                    replace:
+                        "minDimension:$self.getBounds().min.w,maxDimension:$self.getBounds().max.w",
+                },
+            ],
+        },
+    ],
+});

--- a/src/equicordplugins/streamResize/index.tsx
+++ b/src/equicordplugins/streamResize/index.tsx
@@ -30,7 +30,7 @@ export const settings = definePluginSettings({
 export default definePlugin({
     name: "StreamResize",
     description:
-        "Extend the min/max resize limits of the PIP stream window (keep 16:9)",
+        "Extend the min/max resize limits of the PIP stream window (keep 16:9).",
     authors: [EquicordDevs.Skaikru0518],
     settings,
 

--- a/src/equicordplugins/streamResize/index.tsx
+++ b/src/equicordplugins/streamResize/index.tsx
@@ -49,13 +49,11 @@ export default definePlugin({
             group: true,
             replacement: [
                 {
-                    // clamp on resize end (final width)
                     match: /(=40\*Math\.round\(\i\/40\);return\(0,\i\.clamp\)\(\i,)\i\.minWidth,\i\.maxWidth\)/,
                     replace:
                         "$1$self.getBounds().min.w,$self.getBounds().max.w)",
                 },
                 {
-                    // live drag constraint (hard limit while dragging)
                     match: /minDimension:\i\.minWidth,maxDimension:\i\.maxWidth\+20/,
                     replace:
                         "minDimension:$self.getBounds().min.w,maxDimension:$self.getBounds().max.w",

--- a/src/equicordplugins/streamResize/index.tsx
+++ b/src/equicordplugins/streamResize/index.tsx
@@ -46,6 +46,7 @@ export default definePlugin({
     patches: [
         {
             find: "40*Math.round(",
+            group: true,
             replacement: [
                 {
                     // clamp on resize end (final width)

--- a/src/equicordplugins/streamResize/index.tsx
+++ b/src/equicordplugins/streamResize/index.tsx
@@ -12,14 +12,14 @@ import { Bounds, computeBounds } from "./bounds";
 
 export const settings = definePluginSettings({
     minPct: {
-        description: "Minimum PIP size (% of screen)",
+        description: "Minimum PIP size (% of screen).",
         type: OptionType.SLIDER,
         markers: makeRange(10, 90, 5),
         default: 20,
         stickToMarkers: false,
     },
     maxPct: {
-        description: "Maximum PIP size (% of the screen)",
+        description: "Maximum PIP size (% of the screen).",
         type: OptionType.SLIDER,
         markers: makeRange(20, 100, 5),
         default: 90,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1354,6 +1354,10 @@ export const EquicordDevs = Object.freeze({
         name: "sobakintech",
         id: 745203026335236178n
     },
+    Skaikru0518: {
+        name: "Skaikru0518",
+        id: 276069113791643648n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
 ## StreamResize

  Extends the min/max resize limits of the PIP stream popout — the floating,
  draggable stream window shown when the stream isn't focused. Discord caps how
  far you can resize it; this plugin makes the range configurable.

  ### Features
  - Two sliders: minimum and maximum size, as a percentage of the Discord window.
  - Keeps the window at 16:9; uses a "fit" rule so it never overflows either axis.
  - Live: moving a slider affects the next drag, no reload needed.

  ### How it works
  Patches the resizable PIP module (the one that uniquely contains `Draggable`),
  rewriting the two width clamps — the live drag constraint and the on-release
  clamp — to use computed bounds. Height is derived from width at 16:9 by Discord,
  so only width is patched. Size math is a pure helper (`bounds.ts`) with unit tests.

  ### Rules compliance
  - Patch + React, no raw DOM (rule 3)
  - Adds functionality, not just UI hiding/redesign (rule 6)
  - No new dependencies (rule 11)

  ### Plugin request
  Approved in the plugin requests tracker.

  ### Testing
  - Pure helper: `npx tsx --test src/equicordplugins/streamResize/bounds.test.ts`
  - Manual: stream → PIP → drag corner; respects sliders, live, 16:9 preserved.