### PR TITLE
feat(plugins): add VideoThemeEngine

### DIFF
--- a/src/equicordplugins/videoThemeEngine/components/VideoLayer.tsx
+++ b/src/equicordplugins/videoThemeEngine/components/VideoLayer.tsx
@@ -4,14 +4,17 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import { Logger } from "@utils/Logger";
 import { React, useEffect, useState } from "@webpack/common";
 
 import { settings } from "../settings";
 import { CONTAINER_ID, VIDEO_ID } from "../utils/constants";
 import { getVideoSource } from "../utils/video";
 
+const logger = new Logger("VideoThemeEngine");
+
 export function VideoLayer() {
-    const { localVideoPath } = settings.use(["localVideoPath"]);
+    const { localVideoPath, videoReloadToken } = settings.use(["localVideoPath", "videoReloadToken"]);
     const [src, setSrc] = useState<string | null>(null);
 
     useEffect(() => {
@@ -20,7 +23,7 @@ export function VideoLayer() {
             if (!cancelled) setSrc(source);
         });
         return () => { cancelled = true; };
-    }, [localVideoPath]);
+    }, [localVideoPath, videoReloadToken]);
 
     if (!src) return null;
 
@@ -37,7 +40,7 @@ export function VideoLayer() {
                 preload="auto"
                 onLoadedData={e => {
                     void (e.currentTarget as HTMLVideoElement).play()
-                        .catch(err => console.error("[VideoThemeEngine] play() failed:", err));
+                        .catch(err => logger.warn("Video autoplay failed.", err));
                 }}
             />
         </div>

--- a/src/equicordplugins/videoThemeEngine/components/VideoLayer.tsx
+++ b/src/equicordplugins/videoThemeEngine/components/VideoLayer.tsx
@@ -1,0 +1,45 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { React, useEffect, useState } from "@webpack/common";
+
+import { settings } from "../settings";
+import { CONTAINER_ID, VIDEO_ID } from "../utils/constants";
+import { getVideoSource } from "../utils/video";
+
+export function VideoLayer() {
+    const { localVideoPath } = settings.use(["localVideoPath"]);
+    const [src, setSrc] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        void getVideoSource().then(source => {
+            if (!cancelled) setSrc(source);
+        });
+        return () => { cancelled = true; };
+    }, [localVideoPath]);
+
+    if (!src) return null;
+
+    return (
+        <div id={CONTAINER_ID} className="vc-videothemeengine-container">
+            <video
+                id={VIDEO_ID}
+                className="vc-videothemeengine-video"
+                src={src}
+                muted
+                loop
+                autoPlay
+                playsInline
+                preload="auto"
+                onLoadedData={e => {
+                    void (e.currentTarget as HTMLVideoElement).play()
+                        .catch(err => console.error("[VideoThemeEngine] play() failed:", err));
+                }}
+            />
+        </div>
+    );
+}

--- a/src/equicordplugins/videoThemeEngine/components/panels.tsx
+++ b/src/equicordplugins/videoThemeEngine/components/panels.tsx
@@ -27,7 +27,7 @@ import {
     snapSliderValue,
     type UiSettings,
 } from "../utils/constants";
-import { basename, getVideoSource, loadStoredVideo, pickLocalVideo } from "../utils/video";
+import { basename, bumpVideoReloadToken, getVideoSource, pickLocalVideo, revokeActiveObjectUrl } from "../utils/video";
 
 export function applyThemePreset(presetId: string): void {
     const meta = PRESET_LABELS[presetId as keyof typeof PRESET_LABELS];
@@ -348,15 +348,15 @@ export function VideoSizePanel() {
 }
 
 export function VideoPickerPanel() {
-    const { localVideoPath } = settings.use(["localVideoPath"]);
+    const { localVideoPath, videoReloadToken } = settings.use(["localVideoPath", "videoReloadToken"]);
     const [previewError, setPreviewError] = useState(false);
     const [previewSrc, setPreviewSrc] = useState("");
 
     useEffect(() => {
         let cancelled = false;
-        void loadStoredVideo().then(s => { if (!cancelled) setPreviewSrc(s ?? ""); });
+        void getVideoSource().then(s => { if (!cancelled) setPreviewSrc(s ?? ""); });
         return () => { cancelled = true; };
-    }, [localVideoPath]);
+    }, [localVideoPath, videoReloadToken]);
 
     const reloadVideo = async () => {
         const source = await getVideoSource();
@@ -366,7 +366,15 @@ export function VideoPickerPanel() {
                 type: Toasts.Type.FAILURE,
                 id: Toasts.genId(),
             });
+            return;
         }
+        revokeActiveObjectUrl();
+        bumpVideoReloadToken();
+        Toasts.show({
+            message: "Video reloaded.",
+            type: Toasts.Type.SUCCESS,
+            id: Toasts.genId(),
+        });
     };
 
     return (

--- a/src/equicordplugins/videoThemeEngine/components/panels.tsx
+++ b/src/equicordplugins/videoThemeEngine/components/panels.tsx
@@ -1,0 +1,408 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Button } from "@components/Button";
+import { Flex } from "@components/Flex";
+import { FormSwitch } from "@components/FormSwitch";
+import { Paragraph } from "@components/Paragraph";
+import { ColorPicker, Forms, Slider, Toasts, useEffect, useState } from "@webpack/common";
+
+import { settings } from "../settings";
+import { hexToInt, intToHex } from "../utils/colors";
+import {
+    COLOR_SWATCHES,
+    DEFAULT_UI_SETTINGS,
+    formatSliderValue,
+    getSliderMarkers,
+    PRESET_IDS,
+    PRESET_LABELS,
+    PRESET_VALUES,
+    SIZE_MODE_IDS,
+    SIZE_MODE_LABELS,
+    type SizeModeId,
+    type SliderSettingKey,
+    snapSliderValue,
+    type UiSettings,
+} from "../utils/constants";
+import { basename, getVideoSource, loadStoredVideo, pickLocalVideo } from "../utils/video";
+
+export function applyThemePreset(presetId: string): void {
+    const meta = PRESET_LABELS[presetId as keyof typeof PRESET_LABELS];
+    const values = PRESET_VALUES[presetId] ?? {};
+
+    for (const [k, v] of Object.entries(DEFAULT_UI_SETTINGS)) {
+        (settings.store as Record<string, unknown>)[k] = v;
+    }
+    for (const [k, v] of Object.entries(values)) {
+        (settings.store as Record<string, unknown>)[k] = v;
+    }
+
+    Toasts.show({
+        message: `Applied preset: ${meta?.name ?? presetId}`,
+        type: Toasts.Type.SUCCESS,
+        id: Toasts.genId(),
+    });
+}
+
+export function resetUiDefaults(): void {
+    for (const [k, v] of Object.entries(DEFAULT_UI_SETTINGS)) {
+        (settings.store as Record<string, unknown>)[k] = v;
+    }
+    Toasts.show({
+        message: "UI settings reset to defaults.",
+        type: Toasts.Type.SUCCESS,
+        id: Toasts.genId(),
+    });
+}
+
+function LiveSlider({ label, settingKey }: {
+    label: string;
+    settingKey: SliderSettingKey;
+}) {
+    const markers = getSliderMarkers(settingKey);
+    const store = settings.use([settingKey]);
+    const rawValue = Number(store[settingKey]);
+    const value = snapSliderValue(settingKey, rawValue);
+    const displayValue = formatSliderValue(settingKey, value);
+
+    return (
+        <div style={{ marginBottom: "0.75em" }}>
+            <Forms.FormText style={{ marginBottom: "0.35em" }}>{label}: <strong>{displayValue}</strong></Forms.FormText>
+            <Slider
+                markers={markers}
+                minValue={markers[0]}
+                maxValue={markers[markers.length - 1]}
+                initialValue={value}
+                stickToMarkers
+                onValueChange={(v: number) => {
+                    (settings.store as Record<string, unknown>)[settingKey] = snapSliderValue(settingKey, v);
+                }}
+                onValueRender={(v: number) => formatSliderValue(settingKey, v)}
+            />
+        </div>
+    );
+}
+
+function LiveSwitch({ label, settingKey, description }: {
+    label: string;
+    settingKey: keyof UiSettings;
+    description?: string;
+}) {
+    const store = settings.use([settingKey]);
+    const value = Boolean(store[settingKey]);
+
+    return (
+        <FormSwitch
+            title={label}
+            description={description}
+            value={value}
+            onChange={(v: boolean) => {
+                (settings.store as Record<string, unknown>)[settingKey] = v;
+            }}
+        />
+    );
+}
+
+function SettingColorRow({ settingKey, label }: { settingKey: keyof UiSettings; label: string; }) {
+    const store = settings.use([settingKey]);
+    const hex = String(store[settingKey] ?? "#000000");
+
+    return (
+        <Flex style={{ alignItems: "center", justifyContent: "space-between", gap: "1em", marginBottom: "0.35em" }}>
+            <Paragraph style={{ flex: 1, margin: 0 }}>{label}</Paragraph>
+            <ColorPicker
+                color={hexToInt(hex)}
+                onChange={(c: number) => {
+                    (settings.store as Record<string, unknown>)[settingKey] = intToHex(c);
+                }}
+                showEyeDropper
+                suggestedColors={COLOR_SWATCHES}
+            />
+        </Flex>
+    );
+}
+
+export function VideoFiltersPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Video Filters</Forms.FormTitle>
+            <LiveSlider label="Brightness" settingKey="videoBrightness" />
+            <LiveSlider label="Contrast" settingKey="videoContrast" />
+            <LiveSlider label="Saturation" settingKey="videoSaturation" />
+            <LiveSlider label="Opacity" settingKey="videoOpacity" />
+            <LiveSlider label="Blur" settingKey="videoBlur" />
+        </Flex>
+    );
+}
+
+export function VideoSizeSlidersPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Video Size Sliders</Forms.FormTitle>
+            <LiveSlider label="Zoom" settingKey="videoScale" />
+            <LiveSlider label="Width %" settingKey="videoWidthPercent" />
+            <LiveSlider label="Height %" settingKey="videoHeightPercent" />
+            <LiveSlider label="Position X" settingKey="videoPositionX" />
+            <LiveSlider label="Position Y" settingKey="videoPositionY" />
+        </Flex>
+    );
+}
+
+export function TypographyPanel() {
+    const { messageFontWeight, headerFontWeight } = settings.use([
+        "messageFontWeight", "headerFontWeight",
+    ]);
+
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Typography</Forms.FormTitle>
+            <LiveSlider label="Message size" settingKey="messageFontSize" />
+            <LiveSlider label="Header size" settingKey="headerFontSize" />
+            <LiveSlider label="Channel size" settingKey="channelFontSize" />
+            <LiveSlider label="Muted size" settingKey="mutedFontSize" />
+            <LiveSlider label="Line height" settingKey="messageLineHeight" />
+            <Forms.FormText>Message weight</Forms.FormText>
+            <Flex gap="0.35em" style={{ flexWrap: "wrap", marginBottom: "0.5em" }}>
+                {["400", "500", "600", "700"].map(w => (
+                    <Button key={w} size="small" variant={messageFontWeight === w ? "primary" : "secondary"}
+                        onClick={() => { settings.store.messageFontWeight = w; }}>
+                        {w}
+                    </Button>
+                ))}
+            </Flex>
+            <Forms.FormText>Header weight</Forms.FormText>
+            <Flex gap="0.35em" style={{ flexWrap: "wrap", marginBottom: "0.5em" }}>
+                {["400", "500", "600", "700"].map(w => (
+                    <Button key={w} size="small" variant={headerFontWeight === w ? "primary" : "secondary"}
+                        onClick={() => { settings.store.headerFontWeight = w; }}>
+                        {w}
+                    </Button>
+                ))}
+            </Flex>
+        </Flex>
+    );
+}
+
+export function PanelOpacityPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Panel Opacity</Forms.FormTitle>
+            <LiveSlider label="Chat" settingKey="chatBgOpacity" />
+            <LiveSlider label="Sidebar" settingKey="sidebarBgOpacity" />
+            <LiveSlider label="Server list" settingKey="serverListBgOpacity" />
+            <LiveSlider label="Member list" settingKey="memberListBgOpacity" />
+            <LiveSlider label="Input" settingKey="inputBgOpacity" />
+            <LiveSlider label="Title bar" settingKey="titleBarBgOpacity" />
+            <LiveSlider label="Extra message area" settingKey="messageAreaExtraOpacity" />
+        </Flex>
+    );
+}
+
+export function EffectsPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Effects</Forms.FormTitle>
+            <LiveSlider label="Chat backdrop blur" settingKey="chatBackdropBlur" />
+            <LiveSlider label="Panel border radius" settingKey="panelBorderRadius" />
+            <LiveSwitch label="Text shadow" settingKey="textShadowEnabled" />
+            <LiveSlider label="Shadow blur" settingKey="textShadowBlur" />
+            <LiveSlider label="Shadow offset Y" settingKey="textShadowOffsetY" />
+        </Flex>
+    );
+}
+
+export function GlobalPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Global</Forms.FormTitle>
+            <LiveSlider label="Global overlay opacity" settingKey="globalOverlayOpacity" />
+            <LiveSwitch
+                label="Strip Discord overlays"
+                settingKey="stripDiscordOverlays"
+                description="Makes Discord's built-in backgrounds transparent so the video shows through."
+            />
+            <LiveSwitch label="Hide body overlay" settingKey="hideBodyOverlay" />
+        </Flex>
+    );
+}
+
+export function TextColorsPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Text Colors</Forms.FormTitle>
+            <SettingColorRow settingKey="messageTextColor" label="Message text" />
+            <SettingColorRow settingKey="messageMutedColor" label="Muted text" />
+            <SettingColorRow settingKey="headerTextColor" label="Header text" />
+            <SettingColorRow settingKey="inputTextColor" label="Input text" />
+            <Paragraph style={{ fontSize: "0.85em", opacity: 0.8, marginTop: "0.25em" }}>
+                Username colors still follow role colors when set on the server.
+            </Paragraph>
+        </Flex>
+    );
+}
+
+export function ChannelNamesPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Channel Names</Forms.FormTitle>
+            <Paragraph>Customize sidebar and header channel name colors separately.</Paragraph>
+            <SettingColorRow settingKey="sidebarChannelNameColor" label="Sidebar channel names" />
+            <SettingColorRow settingKey="channelTextColor" label="Header channel name" />
+        </Flex>
+    );
+}
+
+export function BackgroundColorsPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Background Colors</Forms.FormTitle>
+            <SettingColorRow settingKey="chatBgColor" label="Chat background" />
+            <SettingColorRow settingKey="sidebarBgColor" label="Sidebar" />
+            <SettingColorRow settingKey="serverListBgColor" label="Server list" />
+            <SettingColorRow settingKey="memberListBgColor" label="Member list" />
+            <SettingColorRow settingKey="inputBgColor" label="Input background" />
+            <SettingColorRow settingKey="titleBarBgColor" label="Title bar" />
+            <SettingColorRow settingKey="globalOverlayColor" label="Global overlay" />
+        </Flex>
+    );
+}
+
+export function EffectColorsPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.25em">
+            <Forms.FormTitle tag="h3">Effect Colors</Forms.FormTitle>
+            <SettingColorRow settingKey="textShadowColor" label="Text shadow" />
+        </Flex>
+    );
+}
+
+export function ThemePresetsPanel() {
+    const [activeId, setActiveId] = useState<string | null>(null);
+
+    return (
+        <Flex flexDirection="column" gap="0.75em">
+            <Forms.FormTitle tag="h3">Theme Presets</Forms.FormTitle>
+            <Paragraph>Apply a coordinated color and opacity preset. You can tweak individual settings afterward.</Paragraph>
+            <div className="vc-videothemeengine-preset-grid">
+                {PRESET_IDS.map(id => {
+                    const meta = PRESET_LABELS[id];
+                    return (
+                        <Button
+                            key={id}
+                            variant={activeId === id ? "primary" : "secondary"}
+                            onClick={() => {
+                                setActiveId(id);
+                                applyThemePreset(id);
+                            }}
+                            style={{ height: "auto", padding: "0.6em 0.75em", flexDirection: "column" }}
+                        >
+                            <span style={{ fontWeight: 600 }}>{meta.name}</span>
+                            <span style={{ fontSize: "0.8em", opacity: 0.75, whiteSpace: "normal" }}>{meta.desc}</span>
+                        </Button>
+                    );
+                })}
+            </div>
+        </Flex>
+    );
+}
+
+export function VideoSizePanel() {
+    const { videoSizeMode } = settings.use(["videoSizeMode"]);
+
+    return (
+        <Flex flexDirection="column" gap="0.75em">
+            <Forms.FormTitle tag="h3">Video Size Mode</Forms.FormTitle>
+            <Paragraph>Choose how the background video is scaled on screen.</Paragraph>
+            <div className="vc-videothemeengine-size-grid">
+                {SIZE_MODE_IDS.map(id => {
+                    const meta = SIZE_MODE_LABELS[id];
+                    return (
+                        <Button
+                            key={id}
+                            variant={videoSizeMode === id ? "primary" : "secondary"}
+                            onClick={() => { settings.store.videoSizeMode = id as SizeModeId; }}
+                            style={{
+                                height: "auto",
+                                minHeight: "3.75em",
+                                padding: "0.55em 0.65em",
+                                flexDirection: "column",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                textAlign: "center",
+                                whiteSpace: "normal",
+                                wordBreak: "break-word",
+                                lineHeight: 1.25,
+                            }}
+                        >
+                            <span style={{ fontWeight: 600, fontSize: "0.9em", display: "block", width: "100%" }}>{meta.name}</span>
+                            <span style={{ fontSize: "0.75em", opacity: 0.75, display: "block", width: "100%", marginTop: "0.2em" }}>{meta.desc}</span>
+                        </Button>
+                    );
+                })}
+            </div>
+        </Flex>
+    );
+}
+
+export function VideoPickerPanel() {
+    const { localVideoPath } = settings.use(["localVideoPath"]);
+    const [previewError, setPreviewError] = useState(false);
+    const [previewSrc, setPreviewSrc] = useState("");
+
+    useEffect(() => {
+        let cancelled = false;
+        void loadStoredVideo().then(s => { if (!cancelled) setPreviewSrc(s ?? ""); });
+        return () => { cancelled = true; };
+    }, [localVideoPath]);
+
+    const reloadVideo = async () => {
+        const source = await getVideoSource();
+        if (!source) {
+            Toasts.show({
+                message: "No video loaded. Pick an MP4 file first.",
+                type: Toasts.Type.FAILURE,
+                id: Toasts.genId(),
+            });
+        }
+    };
+
+    return (
+        <Flex flexDirection="column" gap="0.75em">
+            <Forms.FormTitle tag="h3">Background Video</Forms.FormTitle>
+            <Button onClick={() => void pickLocalVideo()}>Pick video file</Button>
+            <Button variant="secondary" onClick={() => void reloadVideo()}>Reload video</Button>
+            {localVideoPath
+                ? <Paragraph>Current file: <strong>{basename(localVideoPath)}</strong></Paragraph>
+                : <Paragraph style={{ color: "var(--status-danger)" }}>No video selected.</Paragraph>}
+            {previewSrc && !previewError && (
+                <video
+                    key={previewSrc}
+                    src={previewSrc}
+                    muted
+                    loop
+                    autoPlay
+                    playsInline
+                    controls
+                    onError={() => setPreviewError(true)}
+                    className="vc-videothemeengine-preview"
+                />
+            )}
+        </Flex>
+    );
+}
+
+export function UiResetPanel() {
+    return (
+        <Flex flexDirection="column" gap="0.5em">
+            <Forms.FormTitle tag="h3">Guide</Forms.FormTitle>
+            <Paragraph>
+                Video Theme Engine plays a looping video behind Discord with customizable panel colors,
+                typography, and effects. Pick a video, try a preset, then fine-tune sliders and colors.
+            </Paragraph>
+            <Button variant="secondary" onClick={resetUiDefaults}>Reset UI to defaults</Button>
+        </Flex>
+    );
+}

--- a/src/equicordplugins/videoThemeEngine/index.tsx
+++ b/src/equicordplugins/videoThemeEngine/index.tsx
@@ -1,0 +1,59 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { EquicordDevs } from "@utils/constants";
+import definePlugin, { StartAt } from "@utils/types";
+import { createRoot, React } from "@webpack/common";
+import type { Root } from "react-dom/client";
+
+import { VideoLayer } from "./components/VideoLayer";
+import { migrateLegacySettings, settings } from "./settings";
+import managedStyle from "./styles.css?managed";
+import { applyUiStyles, removeUiStyles, startSettingsListener, stopSettingsListener } from "./utils/styleManager";
+import { revokeActiveObjectUrl } from "./utils/video";
+
+let videoRoot: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+export default definePlugin({
+    name: "VideoThemeEngine",
+    description: "Set a local MP4 as a fullscreen background behind a transparent Discord UI, with live presets and panel controls.",
+    authors: [EquicordDevs.remyvn],
+    tags: ["Appearance", "Customisation", "Media"],
+    managedStyle,
+    settings,
+    startAt: StartAt.DOMContentLoaded,
+
+    start() {
+        migrateLegacySettings();
+        startSettingsListener();
+
+        container = document.createElement("div");
+        container.id = "vc-videothemeengine-root";
+        document.body.insertBefore(container, document.body.firstChild);
+
+        videoRoot = createRoot(container);
+        videoRoot.render(<VideoLayer />);
+
+        applyUiStyles();
+    },
+
+    stop() {
+        stopSettingsListener();
+
+        if (videoRoot) {
+            videoRoot.unmount();
+            videoRoot = null;
+        }
+        if (container) {
+            container.remove();
+            container = null;
+        }
+
+        removeUiStyles();
+        revokeActiveObjectUrl();
+    },
+});

--- a/src/equicordplugins/videoThemeEngine/settings.ts
+++ b/src/equicordplugins/videoThemeEngine/settings.ts
@@ -1,0 +1,130 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { OptionType } from "@utils/types";
+
+import {
+    BackgroundColorsPanel,
+    ChannelNamesPanel,
+    EffectColorsPanel,
+    EffectsPanel,
+    GlobalPanel,
+    PanelOpacityPanel,
+    TextColorsPanel,
+    ThemePresetsPanel,
+    TypographyPanel,
+    UiResetPanel,
+    VideoFiltersPanel,
+    VideoPickerPanel,
+    VideoSizePanel,
+    VideoSizeSlidersPanel,
+} from "./components/panels";
+import {
+    DEFAULT_UI_SETTINGS,
+    getSliderMarkers,
+    SLIDER_MARKERS,
+    type SliderSettingKey,
+    snapToNearestMarker,
+    VALID_SIZE_MODES,
+} from "./utils/constants";
+
+export const settings = definePluginSettings({
+    localVideoPath: { type: OptionType.STRING, default: "", hidden: true, description: "" },
+    videoPicker: { type: OptionType.COMPONENT, component: VideoPickerPanel },
+    videoSizePanel: { type: OptionType.COMPONENT, component: VideoSizePanel },
+    videoSizeSlidersPanel: { type: OptionType.COMPONENT, component: VideoSizeSlidersPanel },
+    videoFiltersPanel: { type: OptionType.COMPONENT, component: VideoFiltersPanel },
+    themePresetsPanel: { type: OptionType.COMPONENT, component: ThemePresetsPanel },
+    textColorsPanel: { type: OptionType.COMPONENT, component: TextColorsPanel },
+    channelNamesPanel: { type: OptionType.COMPONENT, component: ChannelNamesPanel },
+    backgroundColorsPanel: { type: OptionType.COMPONENT, component: BackgroundColorsPanel },
+    effectColorsPanel: { type: OptionType.COMPONENT, component: EffectColorsPanel },
+    typographyPanel: { type: OptionType.COMPONENT, component: TypographyPanel },
+    panelOpacityPanel: { type: OptionType.COMPONENT, component: PanelOpacityPanel },
+    effectsPanel: { type: OptionType.COMPONENT, component: EffectsPanel },
+    globalPanel: { type: OptionType.COMPONENT, component: GlobalPanel },
+    uiResetPanel: { type: OptionType.COMPONENT, component: UiResetPanel },
+
+    videoBrightness: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoBrightness, hidden: true, description: "", markers: getSliderMarkers("videoBrightness") },
+    videoContrast: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoContrast, hidden: true, description: "", markers: getSliderMarkers("videoContrast") },
+    videoSaturation: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoSaturation, hidden: true, description: "", markers: getSliderMarkers("videoSaturation") },
+    videoOpacity: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoOpacity, hidden: true, description: "", markers: getSliderMarkers("videoOpacity") },
+    videoBlur: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoBlur, hidden: true, description: "", markers: getSliderMarkers("videoBlur") },
+    videoSizeMode: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.videoSizeMode, hidden: true, description: "" },
+    videoScale: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoScale, hidden: true, description: "", markers: getSliderMarkers("videoScale") },
+    videoWidthPercent: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoWidthPercent, hidden: true, description: "", markers: getSliderMarkers("videoWidthPercent") },
+    videoHeightPercent: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoHeightPercent, hidden: true, description: "", markers: getSliderMarkers("videoHeightPercent") },
+    videoPositionX: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoPositionX, hidden: true, description: "", markers: getSliderMarkers("videoPositionX") },
+    videoPositionY: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.videoPositionY, hidden: true, description: "", markers: getSliderMarkers("videoPositionY") },
+    messageTextColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.messageTextColor, hidden: true, description: "" },
+    messageMutedColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.messageMutedColor, hidden: true, description: "" },
+    headerTextColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.headerTextColor, hidden: true, description: "" },
+    channelTextColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.channelTextColor, hidden: true, description: "" },
+    sidebarChannelNameColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.sidebarChannelNameColor, hidden: true, description: "" },
+    inputTextColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.inputTextColor, hidden: true, description: "" },
+    messageFontSize: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.messageFontSize, hidden: true, description: "", markers: getSliderMarkers("messageFontSize") },
+    headerFontSize: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.headerFontSize, hidden: true, description: "", markers: getSliderMarkers("headerFontSize") },
+    channelFontSize: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.channelFontSize, hidden: true, description: "", markers: getSliderMarkers("channelFontSize") },
+    mutedFontSize: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.mutedFontSize, hidden: true, description: "", markers: getSliderMarkers("mutedFontSize") },
+    messageLineHeight: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.messageLineHeight, hidden: true, description: "", markers: getSliderMarkers("messageLineHeight") },
+    messageFontWeight: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.messageFontWeight, hidden: true, description: "" },
+    headerFontWeight: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.headerFontWeight, hidden: true, description: "" },
+    chatBgColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.chatBgColor, hidden: true, description: "" },
+    chatBgOpacity: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.chatBgOpacity, hidden: true, description: "", markers: getSliderMarkers("chatBgOpacity") },
+    sidebarBgColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.sidebarBgColor, hidden: true, description: "" },
+    sidebarBgOpacity: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.sidebarBgOpacity, hidden: true, description: "", markers: getSliderMarkers("sidebarBgOpacity") },
+    serverListBgColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.serverListBgColor, hidden: true, description: "" },
+    serverListBgOpacity: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.serverListBgOpacity, hidden: true, description: "", markers: getSliderMarkers("serverListBgOpacity") },
+    memberListBgColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.memberListBgColor, hidden: true, description: "" },
+    memberListBgOpacity: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.memberListBgOpacity, hidden: true, description: "", markers: getSliderMarkers("memberListBgOpacity") },
+    inputBgColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.inputBgColor, hidden: true, description: "" },
+    inputBgOpacity: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.inputBgOpacity, hidden: true, description: "", markers: getSliderMarkers("inputBgOpacity") },
+    titleBarBgColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.titleBarBgColor, hidden: true, description: "" },
+    titleBarBgOpacity: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.titleBarBgOpacity, hidden: true, description: "", markers: getSliderMarkers("titleBarBgOpacity") },
+    messageAreaExtraOpacity: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.messageAreaExtraOpacity, hidden: true, description: "", markers: getSliderMarkers("messageAreaExtraOpacity") },
+    chatBackdropBlur: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.chatBackdropBlur, hidden: true, description: "", markers: getSliderMarkers("chatBackdropBlur") },
+    panelBorderRadius: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.panelBorderRadius, hidden: true, description: "", markers: getSliderMarkers("panelBorderRadius") },
+    textShadowEnabled: { type: OptionType.BOOLEAN, default: DEFAULT_UI_SETTINGS.textShadowEnabled, hidden: true, description: "" },
+    textShadowColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.textShadowColor, hidden: true, description: "" },
+    textShadowBlur: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.textShadowBlur, hidden: true, description: "", markers: getSliderMarkers("textShadowBlur") },
+    textShadowOffsetY: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.textShadowOffsetY, hidden: true, description: "", markers: getSliderMarkers("textShadowOffsetY") },
+    globalOverlayColor: { type: OptionType.STRING, default: DEFAULT_UI_SETTINGS.globalOverlayColor, hidden: true, description: "" },
+    globalOverlayOpacity: { type: OptionType.SLIDER, default: DEFAULT_UI_SETTINGS.globalOverlayOpacity, hidden: true, description: "", markers: getSliderMarkers("globalOverlayOpacity") },
+    stripDiscordOverlays: { type: OptionType.BOOLEAN, default: DEFAULT_UI_SETTINGS.stripDiscordOverlays, hidden: true, description: "" },
+    hideBodyOverlay: { type: OptionType.BOOLEAN, default: DEFAULT_UI_SETTINGS.hideBodyOverlay, hidden: true, description: "" },
+});
+
+function snapSliderSettings(): void {
+    const s = settings.store as Record<string, unknown>;
+    for (const key of Object.keys(SLIDER_MARKERS) as SliderSettingKey[]) {
+        const markers = SLIDER_MARKERS[key];
+        const current = Number(s[key]);
+        if (!Number.isNaN(current)) {
+            s[key] = snapToNearestMarker(current, markers);
+        }
+    }
+}
+
+export function migrateLegacySettings(): void {
+    const s = settings.store as Record<string, unknown>;
+    const legacyFit = s.videoObjectFit as string | undefined;
+    if (legacyFit) {
+        if (!s.videoSizeMode) {
+            const map: Record<string, string> = { cover: "cover", contain: "contain", fill: "fill" };
+            s.videoSizeMode = map[legacyFit] ?? "cover";
+        }
+        delete s.videoObjectFit;
+    }
+    if (!VALID_SIZE_MODES.has(String(s.videoSizeMode))) {
+        s.videoSizeMode = DEFAULT_UI_SETTINGS.videoSizeMode;
+    }
+    if (!s.sidebarChannelNameColor) {
+        s.sidebarChannelNameColor = s.channelTextColor || DEFAULT_UI_SETTINGS.sidebarChannelNameColor;
+    }
+    delete s.usernameColor;
+    snapSliderSettings();
+}

--- a/src/equicordplugins/videoThemeEngine/settings.ts
+++ b/src/equicordplugins/videoThemeEngine/settings.ts
@@ -123,7 +123,7 @@ export function migrateLegacySettings(): void {
         s.videoSizeMode = DEFAULT_UI_SETTINGS.videoSizeMode;
     }
     if (!s.sidebarChannelNameColor) {
-        s.sidebarChannelNameColor = s.channelTextColor || DEFAULT_UI_SETTINGS.sidebarChannelNameColor;
+        s.sidebarChannelNameColor = s.channelTextColor ?? DEFAULT_UI_SETTINGS.sidebarChannelNameColor;
     }
     delete s.usernameColor;
     snapSliderSettings();

--- a/src/equicordplugins/videoThemeEngine/settings.ts
+++ b/src/equicordplugins/videoThemeEngine/settings.ts
@@ -34,6 +34,7 @@ import {
 
 export const settings = definePluginSettings({
     localVideoPath: { type: OptionType.STRING, default: "", hidden: true, description: "" },
+    videoReloadToken: { type: OptionType.NUMBER, default: 0, hidden: true, description: "" },
     videoPicker: { type: OptionType.COMPONENT, component: VideoPickerPanel },
     videoSizePanel: { type: OptionType.COMPONENT, component: VideoSizePanel },
     videoSizeSlidersPanel: { type: OptionType.COMPONENT, component: VideoSizeSlidersPanel },

--- a/src/equicordplugins/videoThemeEngine/styles.css
+++ b/src/equicordplugins/videoThemeEngine/styles.css
@@ -5,10 +5,10 @@
  */
 
 .vc-videothemeengine-container {
-    position: fixed !important;
-    inset: 0 !important;
-    z-index: 0 !important;
-    pointer-events: none !important;
+    position: fixed !important; /* override Discord layer positioning */
+    inset: 0 !important; /* fill viewport behind app UI */
+    z-index: 0 !important; /* sit below #app-mount content */
+    pointer-events: none !important; /* do not block Discord clicks */
     overflow: hidden !important;
 }
 

--- a/src/equicordplugins/videoThemeEngine/styles.css
+++ b/src/equicordplugins/videoThemeEngine/styles.css
@@ -1,0 +1,37 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+.vc-videothemeengine-container {
+    position: fixed !important;
+    inset: 0 !important;
+    z-index: 0 !important;
+    pointer-events: none !important;
+    overflow: hidden !important;
+}
+
+.vc-videothemeengine-video {
+    display: block;
+}
+
+.vc-videothemeengine-preview {
+    width: 100%;
+    max-height: 160px;
+    border-radius: 8px;
+    object-fit: cover;
+    background: #000;
+}
+
+.vc-videothemeengine-preset-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 0.5em;
+}
+
+.vc-videothemeengine-size-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(148px, 1fr));
+    gap: 0.5em;
+}

--- a/src/equicordplugins/videoThemeEngine/utils/colors.ts
+++ b/src/equicordplugins/videoThemeEngine/utils/colors.ts
@@ -1,0 +1,26 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export function parseHexColor(hex: string, fallback: string): string {
+    const v = hex.trim();
+    return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(v) ? v : fallback;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number; } {
+    const h = parseHexColor(hex, "#000000").replace("#", "");
+    const full = h.length === 3 ? h.split("").map(c => c + c).join("") : h;
+    const n = parseInt(full, 16);
+    return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+export function rgba(hex: string, opacityPercent: number): string {
+    const { r, g, b } = hexToRgb(hex);
+    const a = Math.max(0, Math.min(100, opacityPercent)) / 100;
+    return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
+export const hexToInt = (hex: string): number => parseInt(parseHexColor(hex, "#000000").replace("#", ""), 16);
+export const intToHex = (n: number): string => "#" + n.toString(16).padStart(6, "0");

--- a/src/equicordplugins/videoThemeEngine/utils/constants.ts
+++ b/src/equicordplugins/videoThemeEngine/utils/constants.ts
@@ -1,0 +1,312 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export const CONTAINER_ID = "vc-videothemeengine-container";
+export const VIDEO_ID = "vc-videothemeengine-video";
+export const VIDEO_STORE_KEY = "VideoThemeEngine_file";
+export const SETTINGS_PREFIX = "plugins.VideoThemeEngine";
+export const BASE_STYLE_ID = "vc-videothemeengine-base";
+export const UI_STYLE_ID = "vc-videothemeengine-ui";
+
+export const COLOR_SWATCHES = [
+    "#ffffff", "#dbdee1", "#b5bac1", "#000000", "#1e1f22",
+    "#2b2d31", "#5865f2", "#57f287", "#fee75c", "#ed4245",
+    "#eb459e", "#00d4ff", "#ff6b35", "#8b5cf6", "#134e4a",
+];
+
+export type SizeModeId =
+    | "cover"
+    | "contain"
+    | "fill"
+    | "scale-down"
+    | "width-fit"
+    | "height-fit"
+    | "viewport"
+    | "custom-zoom"
+    | "custom-percent"
+    | "native";
+
+export interface UiSettings {
+    messageTextColor: string;
+    messageMutedColor: string;
+    headerTextColor: string;
+    channelTextColor: string;
+    sidebarChannelNameColor: string;
+    inputTextColor: string;
+    messageFontSize: number;
+    headerFontSize: number;
+    channelFontSize: number;
+    mutedFontSize: number;
+    messageFontWeight: string;
+    headerFontWeight: string;
+    messageLineHeight: number;
+    chatBgColor: string;
+    chatBgOpacity: number;
+    sidebarBgColor: string;
+    sidebarBgOpacity: number;
+    serverListBgColor: string;
+    serverListBgOpacity: number;
+    memberListBgColor: string;
+    memberListBgOpacity: number;
+    inputBgColor: string;
+    inputBgOpacity: number;
+    titleBarBgColor: string;
+    titleBarBgOpacity: number;
+    messageAreaExtraOpacity: number;
+    chatBackdropBlur: number;
+    panelBorderRadius: number;
+    textShadowEnabled: boolean;
+    textShadowColor: string;
+    textShadowBlur: number;
+    textShadowOffsetY: number;
+    videoBrightness: number;
+    videoContrast: number;
+    videoSaturation: number;
+    videoOpacity: number;
+    videoBlur: number;
+    videoSizeMode: SizeModeId;
+    videoScale: number;
+    videoWidthPercent: number;
+    videoHeightPercent: number;
+    videoPositionX: number;
+    videoPositionY: number;
+    globalOverlayColor: string;
+    globalOverlayOpacity: number;
+    stripDiscordOverlays: boolean;
+    hideBodyOverlay: boolean;
+}
+
+export const DEFAULT_UI_SETTINGS: UiSettings = {
+    messageTextColor: "#ffffff",
+    messageMutedColor: "#b5bac1",
+    headerTextColor: "#ffffff",
+    channelTextColor: "#ffffff",
+    sidebarChannelNameColor: "#ffffff",
+    inputTextColor: "#dbdee1",
+    messageFontSize: 16,
+    headerFontSize: 16,
+    channelFontSize: 14,
+    mutedFontSize: 12,
+    messageFontWeight: "500",
+    headerFontWeight: "600",
+    messageLineHeight: 1.4,
+    chatBgColor: "#000000",
+    chatBgOpacity: 12,
+    sidebarBgColor: "#000000",
+    sidebarBgOpacity: 8,
+    serverListBgColor: "#000000",
+    serverListBgOpacity: 8,
+    memberListBgColor: "#000000",
+    memberListBgOpacity: 8,
+    inputBgColor: "#000000",
+    inputBgOpacity: 20,
+    titleBarBgColor: "#000000",
+    titleBarBgOpacity: 8,
+    messageAreaExtraOpacity: 0,
+    chatBackdropBlur: 2,
+    panelBorderRadius: 0,
+    textShadowEnabled: true,
+    textShadowColor: "#000000",
+    textShadowBlur: 4,
+    textShadowOffsetY: 1,
+    videoBrightness: 100,
+    videoContrast: 100,
+    videoSaturation: 100,
+    videoOpacity: 100,
+    videoBlur: 0,
+    videoSizeMode: "cover" as const,
+    videoScale: 100,
+    videoWidthPercent: 100,
+    videoHeightPercent: 100,
+    videoPositionX: 50,
+    videoPositionY: 50,
+    globalOverlayColor: "#000000",
+    globalOverlayOpacity: 0,
+    stripDiscordOverlays: true,
+    hideBodyOverlay: true,
+};
+
+export const VALID_SIZE_MODES = new Set<string>([
+    "cover", "contain", "fill", "scale-down", "width-fit", "height-fit",
+    "viewport", "custom-zoom", "custom-percent", "native",
+]);
+
+export const PRESET_IDS = [
+    "default", "frosted-light", "midnight", "neon", "sunset", "high-contrast", "crystal",
+] as const;
+
+export type PresetId = (typeof PRESET_IDS)[number];
+
+export const PRESET_VALUES: Record<string, Partial<UiSettings>> = {
+    default: {},
+    "frosted-light": {
+        messageTextColor: "#000000", messageMutedColor: "#333333",
+        headerTextColor: "#000000", channelTextColor: "#111111",
+        sidebarChannelNameColor: "#111111",
+        inputTextColor: "#1a1a1a",
+        chatBgColor: "#ffffff", chatBgOpacity: 55,
+        sidebarBgColor: "#ffffff", sidebarBgOpacity: 40,
+        serverListBgColor: "#f2f3f5", serverListBgOpacity: 35,
+        memberListBgColor: "#ffffff", memberListBgOpacity: 45,
+        inputBgColor: "#ffffff", inputBgOpacity: 50,
+        titleBarBgColor: "#ffffff", titleBarBgOpacity: 30,
+        textShadowEnabled: false, chatBackdropBlur: 8, panelBorderRadius: 8,
+    },
+    midnight: {
+        messageTextColor: "#e8eeff", messageMutedColor: "#8b9dc3",
+        headerTextColor: "#ffffff", channelTextColor: "#c7d6ff",
+        sidebarChannelNameColor: "#c7d6ff",
+        inputTextColor: "#dce6ff",
+        chatBgColor: "#0a1628", chatBgOpacity: 45,
+        sidebarBgColor: "#0d1b2a", sidebarBgOpacity: 55,
+        serverListBgColor: "#06101f", serverListBgOpacity: 60,
+        memberListBgColor: "#0a1628", memberListBgOpacity: 50,
+        inputBgColor: "#0f2038", inputBgOpacity: 55,
+        titleBarBgColor: "#06101f", titleBarBgOpacity: 50,
+        textShadowColor: "#000814", chatBackdropBlur: 6,
+    },
+    neon: {
+        messageTextColor: "#00f5ff", messageMutedColor: "#7dd3fc",
+        headerTextColor: "#e879f9", channelTextColor: "#c084fc",
+        sidebarChannelNameColor: "#c084fc",
+        inputTextColor: "#a5f3fc",
+        chatBgColor: "#1a0533", chatBgOpacity: 35,
+        sidebarBgColor: "#120428", sidebarBgOpacity: 45,
+        memberListBgColor: "#1a0533", memberListBgOpacity: 40,
+        inputBgColor: "#1e0a40", inputBgOpacity: 50,
+        textShadowEnabled: true, textShadowColor: "#7c3aed", textShadowBlur: 8,
+        videoSaturation: 130, videoContrast: 110, chatBackdropBlur: 4, panelBorderRadius: 6,
+    },
+    sunset: {
+        messageTextColor: "#fff5eb", messageMutedColor: "#d4a574",
+        headerTextColor: "#ffe4c4", channelTextColor: "#ffd6a5",
+        sidebarChannelNameColor: "#ffd6a5",
+        inputTextColor: "#ffe8d6",
+        chatBgColor: "#2d1810", chatBgOpacity: 40,
+        sidebarBgColor: "#1f1008", sidebarBgOpacity: 50,
+        memberListBgColor: "#2d1810", memberListBgOpacity: 45,
+        inputBgColor: "#3d2218", inputBgOpacity: 55,
+        titleBarBgColor: "#1a0e08", titleBarBgOpacity: 45,
+        textShadowColor: "#1a0a00", videoBrightness: 105, videoSaturation: 115, chatBackdropBlur: 3,
+    },
+    "high-contrast": {
+        messageTextColor: "#ffffff", messageMutedColor: "#cccccc",
+        headerTextColor: "#ffffff", channelTextColor: "#ffffff",
+        sidebarChannelNameColor: "#ffffff",
+        inputTextColor: "#ffffff",
+        chatBgColor: "#000000", chatBgOpacity: 85,
+        sidebarBgColor: "#000000", sidebarBgOpacity: 90,
+        serverListBgColor: "#000000", serverListBgOpacity: 95,
+        memberListBgColor: "#000000", memberListBgOpacity: 85,
+        inputBgColor: "#111111", inputBgOpacity: 90,
+        titleBarBgColor: "#000000", titleBarBgOpacity: 90,
+        textShadowEnabled: true, textShadowColor: "#000000", textShadowBlur: 2,
+        chatBackdropBlur: 0, stripDiscordOverlays: false, globalOverlayOpacity: 15,
+    },
+    crystal: {
+        messageTextColor: "#ffffff", messageMutedColor: "#e0e0e0",
+        headerTextColor: "#ffffff", channelTextColor: "#ffffff",
+        sidebarChannelNameColor: "#ffffff",
+        inputTextColor: "#f0f0f0",
+        chatBgColor: "#000000", chatBgOpacity: 5,
+        sidebarBgColor: "#000000", sidebarBgOpacity: 4,
+        serverListBgColor: "#000000", serverListBgOpacity: 4,
+        memberListBgColor: "#000000", memberListBgOpacity: 4,
+        inputBgColor: "#000000", inputBgOpacity: 10,
+        titleBarBgColor: "#000000", titleBarBgOpacity: 4,
+        textShadowEnabled: true, textShadowColor: "#000000", textShadowBlur: 6,
+        chatBackdropBlur: 1, stripDiscordOverlays: true, hideBodyOverlay: true, globalOverlayOpacity: 0,
+    },
+};
+
+export const PRESET_LABELS: Record<PresetId, { name: string; desc: string; }> = {
+    default: { name: "Default", desc: "Balanced dark theme with subtle panels." },
+    "frosted-light": { name: "Frosted Light", desc: "Bright frosted glass panels with dark text." },
+    midnight: { name: "Midnight", desc: "Deep blue tones with soft glow." },
+    neon: { name: "Neon", desc: "Vivid cyberpunk colors and boosted video." },
+    sunset: { name: "Sunset", desc: "Warm amber tones over the video." },
+    "high-contrast": { name: "High Contrast", desc: "Opaque panels for maximum readability." },
+    crystal: { name: "Crystal", desc: "Ultra-transparent panels over the video." },
+};
+
+export const SIZE_MODE_IDS = [
+    "cover", "contain", "fill", "scale-down", "width-fit", "height-fit",
+    "viewport", "custom-zoom", "custom-percent", "native",
+] as const;
+
+export const SIZE_MODE_LABELS: Record<SizeModeId, { name: string; desc: string; }> = {
+    cover: { name: "Cover", desc: "Fill the screen, crop edges." },
+    contain: { name: "Contain", desc: "Fit entire video, may letterbox." },
+    fill: { name: "Stretch", desc: "Stretch to fill the screen." },
+    "scale-down": { name: "Scale Down", desc: "Shrink large videos to fit." },
+    "width-fit": { name: "Width Fit", desc: "Match screen width." },
+    "height-fit": { name: "Height Fit", desc: "Match screen height." },
+    viewport: { name: "Viewport", desc: "Exact viewport dimensions." },
+    "custom-zoom": { name: "Custom Zoom", desc: "Scale with the zoom slider." },
+    "custom-percent": { name: "Custom Size", desc: "Set width and height percent." },
+    native: { name: "Native", desc: "Original video resolution." },
+};
+
+export const SLIDER_MARKERS = {
+    videoBrightness: [0, 25, 50, 75, 100, 125, 150, 175, 200],
+    videoContrast: [0, 25, 50, 75, 100, 125, 150, 175, 200],
+    videoSaturation: [0, 25, 50, 75, 100, 125, 150, 175, 200],
+    videoOpacity: [0, 5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+    videoBlur: [0, 1, 2, 3, 4, 5, 8, 10, 15, 20],
+    videoScale: [50, 60, 70, 75, 80, 90, 100, 110, 120, 125, 150, 175, 200, 225, 250, 275, 300],
+    videoWidthPercent: [25, 50, 75, 100, 125, 150, 175, 200],
+    videoHeightPercent: [25, 50, 75, 100, 125, 150, 175, 200],
+    videoPositionX: [0, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+    videoPositionY: [0, 10, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+    messageFontSize: [10, 11, 12, 13, 14, 15, 16, 18, 20, 22, 24, 28, 32],
+    headerFontSize: [10, 11, 12, 13, 14, 15, 16, 18, 20, 22, 24, 28, 32],
+    channelFontSize: [10, 11, 12, 13, 14, 15, 16, 18, 20],
+    mutedFontSize: [10, 11, 12, 13, 14, 15, 16],
+    messageLineHeight: [1, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.8, 2],
+    chatBgOpacity: [0, 2, 4, 5, 6, 8, 10, 12, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+    sidebarBgOpacity: [0, 2, 4, 5, 6, 8, 10, 12, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+    serverListBgOpacity: [0, 2, 4, 5, 6, 8, 10, 12, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+    memberListBgOpacity: [0, 2, 4, 5, 6, 8, 10, 12, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+    inputBgOpacity: [0, 5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+    titleBarBgOpacity: [0, 2, 4, 5, 6, 8, 10, 12, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+    messageAreaExtraOpacity: [0, 5, 10, 15, 20, 25, 30],
+    chatBackdropBlur: [0, 1, 2, 3, 4, 5, 8, 10, 15, 20],
+    panelBorderRadius: [0, 2, 4, 6, 8, 10, 12, 16],
+    textShadowBlur: [0, 1, 2, 3, 4, 5, 6, 8, 10],
+    textShadowOffsetY: [0, 1, 2, 3, 4, 5],
+    globalOverlayOpacity: [0, 5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 75, 80, 90, 100],
+} as const satisfies Partial<Record<keyof UiSettings, readonly number[]>>;
+
+export type SliderSettingKey = keyof typeof SLIDER_MARKERS;
+
+export function getSliderMarkers(settingKey: SliderSettingKey): number[] {
+    return [...SLIDER_MARKERS[settingKey]];
+}
+
+export function snapToNearestMarker(value: number, markers: readonly number[]): number {
+    let best = markers[0];
+    let bestDist = Math.abs(value - best);
+    for (let i = 1; i < markers.length; i++) {
+        const dist = Math.abs(value - markers[i]);
+        if (dist < bestDist) {
+            best = markers[i];
+            bestDist = dist;
+        }
+    }
+    return best;
+}
+
+export function snapSliderValue(settingKey: SliderSettingKey, value: number): number {
+    return snapToNearestMarker(value, SLIDER_MARKERS[settingKey]);
+}
+
+export function formatSliderValue(settingKey: SliderSettingKey, value: number): string {
+    const snapped = snapSliderValue(settingKey, value);
+    if (settingKey === "messageLineHeight") {
+        return Number.isInteger(snapped) ? String(snapped) : snapped.toFixed(1);
+    }
+    return String(snapped);
+}

--- a/src/equicordplugins/videoThemeEngine/utils/css.ts
+++ b/src/equicordplugins/videoThemeEngine/utils/css.ts
@@ -154,7 +154,7 @@ export function buildUiCss(s: UiSettings): string {
     const primaryBg = s.stripDiscordOverlays ? "transparent" : globalOverlay;
 
     return `
-        :root, #app-mount, .theme-dark, .theme-light {
+        html, #app-mount, .theme-dark, .theme-light {
             --var-opacity-option: 0 !important;
             --var-opacity-inner-messages: ${s.chatBgOpacity / 100} !important;
             --var-opacity-left-sidebar: ${s.sidebarBgOpacity / 100} !important;

--- a/src/equicordplugins/videoThemeEngine/utils/css.ts
+++ b/src/equicordplugins/videoThemeEngine/utils/css.ts
@@ -1,0 +1,299 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { parseHexColor, rgba } from "./colors";
+import { type UiSettings, VIDEO_ID } from "./constants";
+
+const OVERLAY_SELECTOR = '[class*="overlayBackground_"]';
+
+export function buildVideoSizeCss(s: UiSettings): string {
+    const pos = `${s.videoPositionX}% ${s.videoPositionY}%`;
+    const scale = s.videoScale / 100;
+    const base = `
+        position: fixed !important;
+        top: 50% !important;
+        left: 50% !important;
+        pointer-events: none !important;
+        object-position: ${pos} !important;
+    `;
+
+    switch (s.videoSizeMode as string) {
+        case "contain":
+            return base + `
+                width: 100% !important; height: 100% !important;
+                min-width: unset !important; min-height: unset !important;
+                transform: translate(-50%, -50%) !important;
+                object-fit: contain !important;
+            `;
+        case "fill":
+            return base + `
+                width: 100% !important; height: 100% !important;
+                min-width: unset !important; min-height: unset !important;
+                transform: translate(-50%, -50%) !important;
+                object-fit: fill !important;
+            `;
+        case "scale-down":
+            return base + `
+                max-width: 100% !important; max-height: 100% !important;
+                width: auto !important; height: auto !important;
+                min-width: unset !important; min-height: unset !important;
+                transform: translate(-50%, -50%) !important;
+                object-fit: scale-down !important;
+            `;
+        case "width-fit":
+            return base + `
+                width: 100% !important; height: auto !important;
+                min-width: unset !important; min-height: unset !important;
+                transform: translate(-50%, -50%) !important;
+                object-fit: cover !important;
+            `;
+        case "height-fit":
+            return base + `
+                height: 100% !important; width: auto !important;
+                min-width: unset !important; min-height: unset !important;
+                transform: translate(-50%, -50%) !important;
+                object-fit: cover !important;
+            `;
+        case "custom-percent":
+            return base + `
+                width: ${s.videoWidthPercent}% !important;
+                height: ${s.videoHeightPercent}% !important;
+                min-width: unset !important; min-height: unset !important;
+                transform: translate(-50%, -50%) !important;
+                object-fit: cover !important;
+            `;
+        case "custom-zoom":
+            return base + `
+                width: 100% !important; height: 100% !important;
+                min-width: 100% !important; min-height: 100% !important;
+                transform: translate(-50%, -50%) scale(${scale}) !important;
+                object-fit: cover !important;
+            `;
+        case "native":
+            return base + `
+                width: auto !important; height: auto !important;
+                min-width: unset !important; min-height: unset !important;
+                max-width: 100vw !important; max-height: 100vh !important;
+                transform: translate(-50%, -50%) !important;
+                object-fit: none !important;
+            `;
+        case "viewport":
+            return base + `
+                width: 100vw !important; height: 100vh !important;
+                min-width: unset !important; min-height: unset !important;
+                transform: translate(-50%, -50%) !important;
+                object-fit: cover !important;
+            `;
+        default:
+            return base + `
+                min-width: 100% !important; min-height: 100% !important;
+                width: auto !important; height: auto !important;
+                transform: translate(-50%, -50%) !important;
+                object-fit: cover !important;
+            `;
+    }
+}
+
+export function buildStructuralTransparencyCss(): string {
+    const panelExclude = [
+        '[class*="guilds_"]',
+        '[class*="sidebar_"]',
+        '[class*="membersWrap_"]',
+        '[class*="chatContent_"]',
+        '[class*="channelTextArea_"]',
+        '[class*="titleBar_"]',
+        '[class*="toolbar_"]',
+    ].join(", ");
+
+    return `
+        html, body, #app-mount,
+        #app-mount [class*="typeWindows_"],
+        #app-mount [class*="app_"],
+        #app-mount [class*="layers_"],
+        #app-mount [class*="page_"],
+        #app-mount [class*="panels_"],
+        #app-mount [class*="standardSidebarView_"],
+        #app-mount [class*="wrapper_"]:not(${panelExclude}),
+        #app-mount [class*="container_"]:not([class*="layerContainer_"]):not(${panelExclude}),
+        #app-mount [class*="bg_"],
+        #app-mount [class*="content_"]:not(${panelExclude}),
+        #app-mount [class*="messagesWrapper_"],
+        #app-mount [class*="overlayBackground_"],
+        #app-mount [class*="sidebar_"] [class*="scroller_"],
+        #app-mount [class*="membersWrap_"] [class*="scroller_"],
+        #app-mount [class*="chatContent_"] [class*="scroller_"] {
+            background: transparent !important;
+            background-color: transparent !important;
+            background-image: none !important;
+        }
+    `;
+}
+
+export function buildUiCss(s: UiSettings): string {
+    const msgShadow = s.textShadowEnabled
+        ? `0 ${s.textShadowOffsetY}px ${s.textShadowBlur}px ${parseHexColor(s.textShadowColor, "#000000")}`
+        : "none";
+
+    const videoFilter = [
+        `brightness(${s.videoBrightness}%)`,
+        `contrast(${s.videoContrast}%)`,
+        `saturate(${s.videoSaturation}%)`,
+        s.videoBlur > 0 ? `blur(${s.videoBlur}px)` : "",
+    ].filter(Boolean).join(" ");
+
+    const chatBg = rgba(s.chatBgColor, s.chatBgOpacity);
+    const sidebarBg = rgba(s.sidebarBgColor, s.sidebarBgOpacity);
+    const serverBg = rgba(s.serverListBgColor, s.serverListBgOpacity);
+    const memberBg = rgba(s.memberListBgColor, s.memberListBgOpacity);
+    const inputBg = rgba(s.inputBgColor, s.inputBgOpacity);
+    const titleBg = rgba(s.titleBarBgColor, s.titleBarBgOpacity);
+    const globalOverlay = rgba(s.globalOverlayColor, s.globalOverlayOpacity);
+    const primaryBg = s.stripDiscordOverlays ? "transparent" : globalOverlay;
+
+    return `
+        :root, #app-mount, .theme-dark, .theme-light {
+            --var-opacity-option: 0 !important;
+            --var-opacity-inner-messages: ${s.chatBgOpacity / 100} !important;
+            --var-opacity-left-sidebar: ${s.sidebarBgOpacity / 100} !important;
+            --var-opacity-right-sidebar: ${s.memberListBgOpacity / 100} !important;
+            --var-opacity-titlebar: ${s.titleBarBgOpacity / 100} !important;
+            --var-opacity-bottom-input: ${s.inputBgOpacity / 100} !important;
+            --bg-overlay-app-frame: ${s.stripDiscordOverlays ? "transparent" : globalOverlay} !important;
+            --bg-overlay-1: transparent !important;
+            --bg-overlay-2: transparent !important;
+            --bg-overlay-3: ${s.stripDiscordOverlays ? "transparent" : globalOverlay} !important;
+            --bg-overlay-4: transparent !important;
+            --bg-overlay-5: transparent !important;
+            --bg-overlay-6: transparent !important;
+            --bg-overlay-selected: transparent !important;
+            --background-primary: ${primaryBg} !important;
+            --background-secondary: transparent !important;
+            --background-secondary-alt: transparent !important;
+            --background-tertiary: transparent !important;
+            --background-accent: transparent !important;
+            --background-floating: transparent !important;
+            --background-nested-floating: transparent !important;
+            --background-base-lowest: transparent !important;
+            --background-base-lower: transparent !important;
+            --background-base-lower-alt: transparent !important;
+            --background-base-low: transparent !important;
+            --background-base: transparent !important;
+            --background-surface: transparent !important;
+            --custom-app-background: transparent !important;
+            --custom-app-background-overlay: transparent !important;
+            --background-mobile-primary: transparent !important;
+            --background-mobile-secondary: transparent !important;
+            --home-background: transparent !important;
+            --chat-background: transparent !important;
+            --channeltextarea-background: ${inputBg} !important;
+            --text-normal: ${parseHexColor(s.messageTextColor, "#ffffff")} !important;
+            --text-muted: ${parseHexColor(s.messageMutedColor, "#b5bac1")} !important;
+            --header-primary: ${parseHexColor(s.headerTextColor, "#ffffff")} !important;
+            --header-secondary: ${parseHexColor(s.sidebarChannelNameColor, "#ffffff")} !important;
+            --interactive-normal: ${parseHexColor(s.sidebarChannelNameColor, "#ffffff")} !important;
+        }
+
+        html, body, #app-mount { background: transparent !important; }
+
+        body::before {
+            display: ${s.hideBodyOverlay ? "none" : "block"} !important;
+            background: transparent !important;
+            opacity: ${s.globalOverlayOpacity / 100} !important;
+        }
+
+        ${s.stripDiscordOverlays ? buildStructuralTransparencyCss() : ""}
+
+        #${VIDEO_ID} {
+            opacity: ${s.videoOpacity / 100} !important;
+            filter: ${videoFilter} !important;
+            ${buildVideoSizeCss(s)}
+        }
+
+        #app-mount [class*="guilds_"] { background: ${serverBg} !important; background-color: ${serverBg} !important; }
+        #app-mount [class*="sidebar_"] { background: ${sidebarBg} !important; background-color: ${sidebarBg} !important; }
+        #app-mount [class*="membersWrap_"],
+        #app-mount [class*="members_"]:not([class*="member_"]) {
+            background: ${memberBg} !important; background-color: ${memberBg} !important;
+        }
+        #app-mount [class*="titleBar_"], #app-mount [class*="toolbar_"] { background: ${titleBg} !important; background-color: ${titleBg} !important; }
+        #app-mount [class*="chatContent_"],
+        #app-mount main[class*="chatContent_"] {
+            background: ${chatBg} !important; background-color: ${chatBg} !important;
+            backdrop-filter: blur(${s.chatBackdropBlur}px) !important;
+            -webkit-backdrop-filter: blur(${s.chatBackdropBlur}px) !important;
+            border-radius: ${s.panelBorderRadius}px !important;
+        }
+        #app-mount [class*="chatContent_"] [class*="scroller_"],
+        #app-mount [class*="messagesWrapper_"],
+        #app-mount [class*="chat_"] [class*="scroller_"] {
+            background: ${rgba(s.chatBgColor, Math.min(100, s.chatBgOpacity + s.messageAreaExtraOpacity))} !important;
+            background-color: ${rgba(s.chatBgColor, Math.min(100, s.chatBgOpacity + s.messageAreaExtraOpacity))} !important;
+        }
+        #app-mount [class*="channelTextArea_"], #app-mount [class*="scrollableContainer_"], #app-mount [class*="textArea_"] {
+            background: ${inputBg} !important; background-color: ${inputBg} !important;
+            border-radius: ${s.panelBorderRadius}px !important;
+        }
+
+        div[class*="markup_"], div[class*="messageContent_"] {
+            color: ${parseHexColor(s.messageTextColor, "#ffffff")} !important;
+            font-size: ${s.messageFontSize}px !important;
+            font-weight: ${s.messageFontWeight} !important;
+            text-shadow: ${msgShadow} !important;
+            line-height: ${s.messageLineHeight} !important;
+        }
+        [class*="username_"], [class*="headerText_"] {
+            font-size: ${s.headerFontSize}px !important;
+            font-weight: ${s.headerFontWeight} !important;
+            text-shadow: ${msgShadow} !important;
+        }
+        #app-mount [class*="sidebar_"] [class*="name_"],
+        #app-mount [class*="sidebar_"] [class*="channelName_"],
+        #app-mount [class*="sidebar_"] [class*="channel_"] [class*="name_"] {
+            color: ${parseHexColor(s.sidebarChannelNameColor, "#ffffff")} !important;
+            font-size: ${s.channelFontSize}px !important;
+            text-shadow: ${msgShadow} !important;
+        }
+        #app-mount [class*="titleBar_"] [class*="channelName_"],
+        #app-mount [class*="chatHeader_"] [class*="title_"],
+        #app-mount [class*="subtitle_"] [class*="topic_"] {
+            color: ${parseHexColor(s.channelTextColor, "#ffffff")} !important;
+            font-size: ${s.channelFontSize}px !important;
+            text-shadow: ${msgShadow} !important;
+        }
+        [class*="timestamp_"], [class*="edited_"] {
+            color: ${parseHexColor(s.messageMutedColor, "#b5bac1")} !important;
+            font-size: ${s.mutedFontSize}px !important;
+        }
+        [class*="slateTextArea_"], [class*="placeholder_"] {
+            color: ${parseHexColor(s.inputTextColor, "#dbdee1")} !important;
+            font-size: ${s.messageFontSize}px !important;
+        }
+
+        ${s.stripDiscordOverlays ? `
+        ${OVERLAY_SELECTOR},
+        #app-mount [class*="app_"],
+        #app-mount [class*="bg_"],
+        #app-mount [class*="layers_"] {
+            background: transparent !important;
+            background-color: transparent !important;
+            background-image: none !important;
+        }` : ""}
+
+        [class*="layerContainer_"] [class*="modal_"],
+        [class*="userPopout_"],
+        [class*="menu_"],
+        [class*="tooltip_"] {
+            background: rgba(20, 20, 20, 0.92) !important;
+        }
+    `;
+}
+
+export function buildBaseCss(): string {
+    return `
+        html, body, #app-mount { background: transparent !important; }
+        #app-mount { position: relative !important; z-index: 1 !important; }
+    `;
+}

--- a/src/equicordplugins/videoThemeEngine/utils/styleManager.ts
+++ b/src/equicordplugins/videoThemeEngine/utils/styleManager.ts
@@ -1,0 +1,70 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { SettingsStore } from "@api/Settings";
+import { managedStyleRootNode } from "@api/Styles";
+import { createAndAppendStyle } from "@utils/css";
+
+import { settings } from "../settings";
+import { BASE_STYLE_ID, SETTINGS_PREFIX, UI_STYLE_ID, type UiSettings } from "./constants";
+import { buildBaseCss, buildUiCss } from "./css";
+
+const styleCache = {
+    base: null as HTMLStyleElement | null,
+    ui: null as HTMLStyleElement | null,
+};
+
+let settingsChangeHandler: ((_v: unknown, _path: string) => void) | null = null;
+let applyRaf = 0;
+
+function getOrCreateStyle(id: string): HTMLStyleElement {
+    if (id === BASE_STYLE_ID) {
+        if (!styleCache.base) {
+            styleCache.base = createAndAppendStyle(BASE_STYLE_ID, managedStyleRootNode);
+        }
+        return styleCache.base;
+    }
+    if (!styleCache.ui) {
+        styleCache.ui = createAndAppendStyle(UI_STYLE_ID, managedStyleRootNode);
+    }
+    return styleCache.ui;
+}
+
+export function applyUiStyles(): void {
+    getOrCreateStyle(BASE_STYLE_ID).textContent = buildBaseCss();
+    getOrCreateStyle(UI_STYLE_ID).textContent = buildUiCss(settings.store as UiSettings);
+}
+
+export function removeUiStyles(): void {
+    styleCache.base?.remove();
+    styleCache.ui?.remove();
+    styleCache.base = null;
+    styleCache.ui = null;
+}
+
+function applyLivePreview(): void {
+    if (applyRaf) cancelAnimationFrame(applyRaf);
+    applyRaf = requestAnimationFrame(() => {
+        applyRaf = 0;
+        applyUiStyles();
+    });
+}
+
+export function startSettingsListener(): void {
+    settingsChangeHandler ??= () => applyLivePreview();
+    SettingsStore.addPrefixChangeListener(SETTINGS_PREFIX, settingsChangeHandler);
+}
+
+export function stopSettingsListener(): void {
+    if (settingsChangeHandler) {
+        SettingsStore.removePrefixChangeListener(SETTINGS_PREFIX, settingsChangeHandler);
+        settingsChangeHandler = null;
+    }
+    if (applyRaf) {
+        cancelAnimationFrame(applyRaf);
+        applyRaf = 0;
+    }
+}

--- a/src/equicordplugins/videoThemeEngine/utils/video.ts
+++ b/src/equicordplugins/videoThemeEngine/utils/video.ts
@@ -5,11 +5,14 @@
  */
 
 import { DataStore } from "@api/index";
+import { Logger } from "@utils/Logger";
 import { chooseFile } from "@utils/web";
 import { Toasts } from "@webpack/common";
 
 import { settings } from "../settings";
 import { VIDEO_STORE_KEY } from "./constants";
+
+const logger = new Logger("VideoThemeEngine");
 
 interface StoredVideo {
     data: Uint8Array | number[];
@@ -18,6 +21,15 @@ interface StoredVideo {
 }
 
 let activeObjectUrl: string | null = null;
+let activeBlobKey: string | null = null;
+
+function storedVideoKey(stored: StoredVideo, byteLength: number): string {
+    return `${stored.name}:${byteLength}:${stored.mime}`;
+}
+
+export function bumpVideoReloadToken(): void {
+    settings.store.videoReloadToken = (settings.store.videoReloadToken ?? 0) + 1;
+}
 
 export function basename(path: string): string {
     return path.split(/[/\\]/).pop() || path;
@@ -31,7 +43,9 @@ function getEquicordDataDir(): string {
             const parts = userData.split(/[/\\]/);
             parts.pop();
             return parts.join(sep) + sep + "Equicord";
-        } catch { /* empty */ }
+        } catch (e) {
+            logger.warn("Could not resolve Equicord data directory.", e);
+        }
     }
     return "";
 }
@@ -84,6 +98,7 @@ export function revokeActiveObjectUrl(): void {
     if (activeObjectUrl) {
         URL.revokeObjectURL(activeObjectUrl);
         activeObjectUrl = null;
+        activeBlobKey = null;
     }
 }
 
@@ -92,14 +107,21 @@ export async function loadStoredVideo(): Promise<string | null> {
     if (!stored?.data) return null;
     const bytes = stored.data instanceof Uint8Array ? stored.data : new Uint8Array(stored.data as number[]);
     if (!bytes.length) return null;
+
+    const key = storedVideoKey(stored, bytes.length);
+    if (activeObjectUrl && activeBlobKey === key) return activeObjectUrl;
+
     revokeActiveObjectUrl();
+    activeBlobKey = key;
     activeObjectUrl = URL.createObjectURL(new Blob([new Uint8Array(bytes)], { type: stored.mime || "video/mp4" }));
     return activeObjectUrl;
 }
 
 async function saveVideoData(data: Uint8Array, name: string): Promise<void> {
+    revokeActiveObjectUrl();
     await DataStore.set(VIDEO_STORE_KEY, { data: Array.from(data), name, mime: getMimeType(name) });
     settings.store.localVideoPath = name;
+    bumpVideoReloadToken();
 }
 
 async function readFileArrayBuffer(path: string): Promise<Uint8Array | null> {
@@ -110,7 +132,9 @@ async function readFileArrayBuffer(path: string): Promise<Uint8Array | null> {
                 const buffer = new Uint8Array(await response.arrayBuffer());
                 if (buffer.length) return buffer;
             }
-        } catch { /* continue */ }
+        } catch {
+            continue;
+        }
     }
     return new Promise(resolve => {
         const xhr = new XMLHttpRequest();
@@ -167,7 +191,9 @@ export async function pickLocalVideo(): Promise<void> {
                 });
                 return;
             }
-        } catch (e) { console.error("[VideoThemeEngine]", e); }
+        } catch (e) {
+            logger.error("Desktop file picker failed.", e);
+        }
     }
     const file = await chooseFile("video/mp4,video/webm,.mp4,.webm,.mov");
     if (!file) return;

--- a/src/equicordplugins/videoThemeEngine/utils/video.ts
+++ b/src/equicordplugins/videoThemeEngine/utils/video.ts
@@ -1,0 +1,180 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2025 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { DataStore } from "@api/index";
+import { chooseFile } from "@utils/web";
+import { Toasts } from "@webpack/common";
+
+import { settings } from "../settings";
+import { VIDEO_STORE_KEY } from "./constants";
+
+interface StoredVideo {
+    data: Uint8Array | number[];
+    name: string;
+    mime: string;
+}
+
+let activeObjectUrl: string | null = null;
+
+export function basename(path: string): string {
+    return path.split(/[/\\]/).pop() || path;
+}
+
+function getEquicordDataDir(): string {
+    if (IS_DISCORD_DESKTOP) {
+        try {
+            const userData = DiscordNative.app.getPath("userData");
+            const sep = userData.includes("\\") ? "\\" : "/";
+            const parts = userData.split(/[/\\]/);
+            parts.pop();
+            return parts.join(sep) + sep + "Equicord";
+        } catch { /* empty */ }
+    }
+    return "";
+}
+
+function getDefaultVideoPaths(): string[] {
+    const dir = getEquicordDataDir();
+    if (!dir) return [];
+    const sep = dir.includes("\\") ? "\\" : "/";
+    return [`${dir}${sep}background-video.mp4`];
+}
+
+function isAbsolutePath(path: string): boolean {
+    return /^[a-zA-Z]:[\\/]/.test(path) || path.startsWith("/");
+}
+
+function getMimeType(filename: string): string {
+    const ext = filename.split(".").pop()?.toLowerCase();
+    switch (ext) {
+        case "webm": return "video/webm";
+        case "ogg": return "video/ogg";
+        case "mov": return "video/quicktime";
+        default: return "video/mp4";
+    }
+}
+
+function toFileUrl(path: string): string {
+    if (/^https?:\/\//i.test(path) || path.startsWith("file://") || path.startsWith("blob:")) {
+        return path;
+    }
+    return `file:///${path.replace(/\\/g, "/")}`;
+}
+
+function resolvePaths(path: string): string[] {
+    const out = new Set<string>(getDefaultVideoPaths());
+    if (path.trim()) {
+        if (isAbsolutePath(path)) out.add(path.trim());
+        else {
+            const dir = getEquicordDataDir();
+            if (dir) {
+                const sep = dir.includes("\\") ? "\\" : "/";
+                out.add(`${dir}${sep}${path.trim()}`);
+            }
+            for (const p of getDefaultVideoPaths()) out.add(p);
+        }
+    }
+    return [...out];
+}
+
+export function revokeActiveObjectUrl(): void {
+    if (activeObjectUrl) {
+        URL.revokeObjectURL(activeObjectUrl);
+        activeObjectUrl = null;
+    }
+}
+
+export async function loadStoredVideo(): Promise<string | null> {
+    const stored = await DataStore.get<StoredVideo>(VIDEO_STORE_KEY);
+    if (!stored?.data) return null;
+    const bytes = stored.data instanceof Uint8Array ? stored.data : new Uint8Array(stored.data as number[]);
+    if (!bytes.length) return null;
+    revokeActiveObjectUrl();
+    activeObjectUrl = URL.createObjectURL(new Blob([new Uint8Array(bytes)], { type: stored.mime || "video/mp4" }));
+    return activeObjectUrl;
+}
+
+async function saveVideoData(data: Uint8Array, name: string): Promise<void> {
+    await DataStore.set(VIDEO_STORE_KEY, { data: Array.from(data), name, mime: getMimeType(name) });
+    settings.store.localVideoPath = name;
+}
+
+async function readFileArrayBuffer(path: string): Promise<Uint8Array | null> {
+    for (const src of [path, toFileUrl(path)]) {
+        try {
+            const response = await fetch(src);
+            if (response.ok) {
+                const buffer = new Uint8Array(await response.arrayBuffer());
+                if (buffer.length) return buffer;
+            }
+        } catch { /* continue */ }
+    }
+    return new Promise(resolve => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("GET", toFileUrl(path), true);
+        xhr.responseType = "arraybuffer";
+        xhr.onload = () => resolve(xhr.status === 200 || xhr.status === 0 ? new Uint8Array(xhr.response) : null);
+        xhr.onerror = () => resolve(null);
+        xhr.send();
+    });
+}
+
+async function importVideoFromPath(path: string): Promise<boolean> {
+    const buffer = await readFileArrayBuffer(path);
+    if (!buffer?.length) return false;
+    await saveVideoData(buffer, basename(path));
+    return true;
+}
+
+async function ensureVideoStored(): Promise<void> {
+    const existing = await DataStore.get<StoredVideo>(VIDEO_STORE_KEY);
+    if (existing?.data && (existing.data instanceof Uint8Array ? existing.data.length : existing.data.length)) return;
+    for (const candidate of resolvePaths(settings.store.localVideoPath)) {
+        if (await importVideoFromPath(candidate)) return;
+    }
+}
+
+export async function getVideoSource(): Promise<string | null> {
+    await ensureVideoStored();
+    const storedUrl = await loadStoredVideo();
+    if (storedUrl) return storedUrl;
+    for (const candidate of resolvePaths(settings.store.localVideoPath)) {
+        if (isAbsolutePath(candidate)) return candidate;
+    }
+    return null;
+}
+
+export async function pickLocalVideo(): Promise<void> {
+    if (IS_DISCORD_DESKTOP) {
+        try {
+            const [file] = await DiscordNative.fileManager.openFiles({
+                filters: [
+                    { name: "Video files", extensions: ["mp4", "webm", "ogg", "mov", "mkv"] },
+                    { name: "All files", extensions: ["*"] },
+                ],
+            });
+            if (file?.data?.length) {
+                const name = (file as { name?: string; filename?: string; }).name
+                    ?? (file as { filename?: string; }).filename ?? "background-video.mp4";
+                await saveVideoData(file.data, name);
+                Toasts.show({
+                    message: `Saved video: ${basename(name)}`,
+                    type: Toasts.Type.SUCCESS,
+                    id: Toasts.genId(),
+                });
+                return;
+            }
+        } catch (e) { console.error("[VideoThemeEngine]", e); }
+    }
+    const file = await chooseFile("video/mp4,video/webm,.mp4,.webm,.mov");
+    if (!file) return;
+    await saveVideoData(new Uint8Array(await file.arrayBuffer()), file.name || "video.mp4");
+    Toasts.show({
+        message: `Saved video: ${basename(file.name || "video.mp4")}`,
+        type: Toasts.Type.SUCCESS,
+        id: Toasts.genId(),
+    });
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -613,6 +613,10 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "RamziAH",
         id: 1279957227612147747n
     },
+    remyvn: {
+        name: "remyvn",
+        id: 1110386112477806654n
+    },
     SomeAspy: {
         name: "SomeAspy",
         id: 516750892372852754n
@@ -720,6 +724,10 @@ export const EquicordDevs = Object.freeze({
     Wolfie: {
         name: "wolfieeeeeeee",
         id: 347096063569559553n
+    },
+    remyvn: {
+        name: "remyvn",
+        id: 1110386112477806654n
     },
     ryan: {
         name: "ryan",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -613,10 +613,6 @@ export const Devs = /* #__PURE__*/ Object.freeze({
         name: "RamziAH",
         id: 1279957227612147747n
     },
-    remyvn: {
-        name: "remyvn",
-        id: 1110386112477806654n
-    },
     SomeAspy: {
         name: "SomeAspy",
         id: 516750892372852754n


### PR DESCRIPTION
## Describe your Changes

Adds VideoThemeEngine, a plugin that lets users set a local MP4 file as a
fullscreen video background behind a transparent Discord UI.

Features:
- Pick and store a local MP4 via file picker (desktop)
- Video size modes, filters, and opacity controls
- Transparency presets for chat, sidebar, member list, and input panels
- Live preview when changing colors or presets

Font customization is intentionally omitted because FontLoader already
covers Google Fonts. This plugin focuses on the video layer and the
transparency settings required to make it visible.

## Checklist before submitting
- [x] I have read the CONTRIBUTING.md file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent

## Test plan
- [x] pnpm testTsc passes for VideoThemeEngine (no plugin-specific TS errors)
- [x] eslint and stylelint pass on src/equicordplugins/videoThemeEngine/
- [ ] Enabled plugin, picked local MP4, verified looped playback behind chat (manual)
- [ ] Applied each preset, confirmed live color/opacity updates (manual)
- [ ] Disabled plugin, confirmed video and styles are fully removed (manual)
