### PR TITLE
fix(CleanChannelName): trim repeated decoration separators

### DIFF
--- a/src/equicordplugins/cleanChannelName/index.ts
+++ b/src/equicordplugins/cleanChannelName/index.ts
@@ -20,13 +20,15 @@ const ORIGINAL_NAME = Symbol("cleanChannelName.original");
 let editingChannelId: string | null = null;
 
 function computeClean(name: string, type: number): string {
+    const separator = [2, 4].includes(type) ? " " : "-";
     const cleaned = name
         .normalize("NFKC")
         .replace(/[ᴀʙᴄᴅᴇꜰɢʜɪᴊᴋʟᴍɴᴏᴘǫʀꜱᴛᴜᴠᴡxʏᴢ]/g, m => SMALL_CAPS[m])
         .replace(/[^ -~]?\p{Extended_Pictographic}[^ -~]?/ug, "")
-        .replace(/-?[^\p{Letter} -~]-?/ug, [2, 4].includes(type) ? " " : "-")
-        .replace(/(^-|-$)/g, "")
-        .replace(/-+/g, "-");
+        .replace(/-?\|-?/g, separator)
+        .replace(/-?[^\p{Letter} -~]-?/ug, separator)
+        .replace(/-+/g, "-")
+        .replace(/(^-|-$)/g, "");
     return cleaned || name;
 }
 


### PR DESCRIPTION
Fixed CleanChannelName leaving a `-` prefix when channel names start with multiple decoration characters. Also treats `|` as a decoration so it gets removed as well.

Example: `━━┊𝗩𝗜𝗗𝗘𝗢𝗦` converts to `-VIDEOS`. After the patch: `VIDEOS`
Another example is with flag-prefixed names like `🇺🇸-general` could hit the same issue:
Before/After:
<img width="316" height="198" alt="image" src="https://github.com/user-attachments/assets/ad7e08a3-4ee9-4091-9cbc-4a9c28cd2d70" /><img width="279" height="183" alt="image" src="https://github.com/user-attachments/assets/ebeab06f-cd0e-4181-ac3d-20e7adfb690d" />

The clean function now collapses repeated separators before trimming edge separators.

