### PR TITLE
feat(richPresence): resolve navidrome pause state and cache drift with opensubsonic api

### DIFF
--- a/src/equicordplugins/richPresence/SettingsPanel.tsx
+++ b/src/equicordplugins/richPresence/SettingsPanel.tsx
@@ -214,6 +214,7 @@ function NavidromeSettings() {
                 { label: "Show state line content", value: "artist" },
                 { label: "Show details line content", value: "track" }
             ]} />
+            <SwitchSetting name="Hide On Pause" description="Hide Rich Presence when music is paused (instead of showing a stopwatch)" settingsKey="nd_hideOnPause" />
             {Number(nd_activityType ?? 2) !== 0 && (
                 <TextSetting name="Activity Name Format" description="The 'Listening to' text (e.g. {artist})" settingsKey="nd_nameString" placeholder="Navidrome" />
             )}

--- a/src/equicordplugins/richPresence/services/navidrome.ts
+++ b/src/equicordplugins/richPresence/services/navidrome.ts
@@ -24,6 +24,8 @@ let updateTimer: NodeJS.Timeout | undefined;
 let abortController: AbortController | undefined;
 let currentTrackId: string | undefined;
 let cachedStartTimestamp: number | undefined;
+let cachedPauseTimestamp: number | undefined;
+let cachedTrackState: string | undefined;
 let lastMinutesAgo: number | undefined;
 let cachedActivity: Activity | undefined;
 let cachedSettingsJSON: string | undefined;
@@ -41,6 +43,9 @@ interface NdTrack {
     minutesAgo?: number;
     coverArt?: string;
     username?: string;
+    state?: string;
+    positionMs?: number;
+    playbackRate?: number;
 }
 
 function customFormat(formatStr: string | undefined, track: NdTrack): string {
@@ -101,6 +106,9 @@ async function fetchNowPlaying(signal?: AbortSignal): Promise<NdTrack | null> {
         if (!entries || !Array.isArray(entries) || entries.length === 0) return null;
 
         const myEntry = entries.find((e: NdTrack) => e.username?.toLowerCase() === nd_username.toLowerCase());
+        if (myEntry) {
+            logger.info("Navidrome NowPlayingEntry:", myEntry);
+        }
         return myEntry ?? null;
     } catch (e: unknown) {
         if (e instanceof Error && e.name === "AbortError") throw e;
@@ -140,11 +148,26 @@ async function getActivity(signal?: AbortSignal): Promise<Activity | null> {
     if (!track) return null;
 
     const currentSettingsJSON = getSettingsJSON();
+
+    const isPaused = track.state?.toLowerCase() === "paused";
+
     if (track.id === currentTrackId && cachedActivity && cachedSettingsJSON === currentSettingsJSON) {
-        return cachedActivity;
+        let drift = false;
+        if (track.positionMs !== undefined && !isPaused && cachedStartTimestamp) {
+            const expectedPosition = Date.now() - cachedStartTimestamp;
+            if (Math.abs(expectedPosition - track.positionMs) > 2000) drift = true;
+        }
+        if (track.state === cachedTrackState && track.minutesAgo === lastMinutesAgo && !drift) {
+            return cachedActivity;
+        }
     }
 
-    const { nd_clientId, nd_showSmallImage, nd_serverUrl, nd_showAlbum, nd_nameString, nd_detailsString, nd_stateString, nd_largeTextString, nd_activityType, nd_statusDisplayType, nd_lastfmApiKey } = settings.store;
+    const { nd_clientId, nd_showSmallImage, nd_serverUrl, nd_showAlbum, nd_nameString, nd_detailsString, nd_stateString, nd_largeTextString, nd_activityType, nd_statusDisplayType, nd_lastfmApiKey, nd_hideOnPause } = settings.store;
+
+    if (isPaused && nd_hideOnPause) {
+        cachedPauseTimestamp = undefined;
+        return null;
+    }
 
     const _clientId = nd_clientId?.trim();
     const appId = _clientId === "" ? "1470554657506984069" : (_clientId ?? "1470554657506984069");
@@ -159,24 +182,49 @@ async function getActivity(signal?: AbortSignal): Promise<Activity | null> {
 
     if (track.id !== currentTrackId || !cachedStartTimestamp) {
         currentTrackId = track.id;
-        const elapsedMs = trackMinutesAgo * 60 * 1000;
+        const elapsedMs = track.positionMs ?? (trackMinutesAgo * 60 * 1000);
         cachedStartTimestamp = Date.now() - elapsedMs;
         lastMinutesAgo = trackMinutesAgo;
     } else {
-        if (trackMinutesAgo < (lastMinutesAgo ?? 0) || trackMinutesAgo > (lastMinutesAgo ?? 0) + 1) {
-            const elapsedMs = trackMinutesAgo * 60 * 1000;
-            cachedStartTimestamp = Date.now() - elapsedMs;
+        if (track.positionMs !== undefined) {
+            if (!isPaused) {
+                const expectedPosition = Date.now() - cachedStartTimestamp;
+                if (Math.abs(expectedPosition - track.positionMs) > 2000) {
+                    cachedStartTimestamp = Date.now() - track.positionMs;
+                }
+            }
+        } else {
+            if (trackMinutesAgo < (lastMinutesAgo ?? 0) || trackMinutesAgo > (lastMinutesAgo ?? 0) + 1) {
+                const elapsedMs = trackMinutesAgo * 60 * 1000;
+                cachedStartTimestamp = Date.now() - elapsedMs;
+            }
         }
         lastMinutesAgo = trackMinutesAgo;
     }
 
+    if (isPaused) {
+        if (!cachedPauseTimestamp) {
+            cachedPauseTimestamp = Date.now();
+        }
+    } else {
+        cachedPauseTimestamp = undefined;
+    }
+
     const endTimestamp = cachedStartTimestamp + durationMs;
+
+    if (!isPaused && durationMs > 0 && Date.now() >= endTimestamp) {
+        return null;
+    }
 
     const isPlaying = Number(nd_activityType ?? 2) === 0;
     const nameString = !isPlaying ? customFormat(nd_nameString || "Navidrome", track) : "Navidrome";
 
     const detailsString = customFormat(nd_detailsString, track);
     let stateString = customFormat(nd_stateString, track);
+    
+    if (isPaused) {
+        stateString = stateString ? `${stateString} (Paused)` : "Paused";
+    }
 
     const assets: Activity["assets"] = {};
     if (nd_showAlbum && nd_largeTextString) {
@@ -273,9 +321,11 @@ async function getActivity(signal?: AbortSignal): Promise<Activity | null> {
             "artist": ActivityStatusDisplayType.STATE,
             "track": ActivityStatusDisplayType.DETAILS
         }[nd_statusDisplayType as "off" | "artist" | "track"] : undefined,
-        type: Number(nd_activityType ?? 2),
+        type: (isPaused && !nd_hideOnPause) ? 0 : Number(nd_activityType ?? 2),
         flags: ActivityFlags.INSTANCE,
-        timestamps: {
+        timestamps: isPaused && !nd_hideOnPause ? {
+            start: cachedPauseTimestamp,
+        } : {
             start: cachedStartTimestamp,
             end: durationMs > 0 ? endTimestamp : undefined,
         },
@@ -284,6 +334,7 @@ async function getActivity(signal?: AbortSignal): Promise<Activity | null> {
 
     cachedSettingsJSON = currentSettingsJSON;
     cachedActivity = activity;
+    cachedTrackState = track.state;
     return activity;
 }
 
@@ -292,11 +343,9 @@ async function updatePresence() {
         const activity = await getActivity(abortController?.signal);
         setActivity(activity);
         if (!activity) {
-            currentTrackId = undefined;
-            cachedStartTimestamp = undefined;
-            lastMinutesAgo = undefined;
             cachedActivity = undefined;
             cachedSettingsJSON = undefined;
+            cachedTrackState = undefined;
         }
     } catch (e: unknown) {
         if (e instanceof Error && e.name === "AbortError") return;
@@ -304,9 +353,11 @@ async function updatePresence() {
         setActivity(null);
         currentTrackId = undefined;
         cachedStartTimestamp = undefined;
+        cachedPauseTimestamp = undefined;
         lastMinutesAgo = undefined;
         cachedActivity = undefined;
         cachedSettingsJSON = undefined;
+        cachedTrackState = undefined;
     }
 
     if (abortController && !abortController.signal.aborted) {
@@ -343,8 +394,10 @@ export function stop() {
     updateTimer = undefined;
     currentTrackId = undefined;
     cachedStartTimestamp = undefined;
+    cachedPauseTimestamp = undefined;
     lastMinutesAgo = undefined;
     cachedActivity = undefined;
     cachedSettingsJSON = undefined;
+    cachedTrackState = undefined;
     setActivity(null);
 }

--- a/src/equicordplugins/richPresence/services/navidrome.ts
+++ b/src/equicordplugins/richPresence/services/navidrome.ts
@@ -106,9 +106,6 @@ async function fetchNowPlaying(signal?: AbortSignal): Promise<NdTrack | null> {
         if (!entries || !Array.isArray(entries) || entries.length === 0) return null;
 
         const myEntry = entries.find((e: NdTrack) => e.username?.toLowerCase() === nd_username.toLowerCase());
-        if (myEntry) {
-            logger.info("Navidrome NowPlayingEntry:", myEntry);
-        }
         return myEntry ?? null;
     } catch (e: unknown) {
         if (e instanceof Error && e.name === "AbortError") throw e;

--- a/src/equicordplugins/richPresence/services/navidrome.ts
+++ b/src/equicordplugins/richPresence/services/navidrome.ts
@@ -153,7 +153,7 @@ async function getActivity(signal?: AbortSignal): Promise<Activity | null> {
             const expectedPosition = Date.now() - cachedStartTimestamp;
             if (Math.abs(expectedPosition - track.positionMs) > 2000) drift = true;
         }
-        if (track.state === cachedTrackState && track.minutesAgo === lastMinutesAgo && !drift) {
+        if (track.state === cachedTrackState && (track.minutesAgo ?? 0) === (lastMinutesAgo ?? 0) && !drift) {
             return cachedActivity;
         }
     }
@@ -342,6 +342,7 @@ async function updatePresence() {
             cachedActivity = undefined;
             cachedSettingsJSON = undefined;
             cachedTrackState = undefined;
+            cachedPauseTimestamp = undefined;
         }
     } catch (e: unknown) {
         if (e instanceof Error && e.name === "AbortError") return;

--- a/src/equicordplugins/richPresence/services/navidrome.ts
+++ b/src/equicordplugins/richPresence/services/navidrome.ts
@@ -339,6 +339,9 @@ async function updatePresence() {
         const activity = await getActivity(abortController?.signal);
         setActivity(activity);
         if (!activity) {
+            currentTrackId = undefined;
+            cachedStartTimestamp = undefined;
+            lastMinutesAgo = undefined;
             cachedActivity = undefined;
             cachedSettingsJSON = undefined;
             cachedTrackState = undefined;

--- a/src/equicordplugins/richPresence/services/navidrome.ts
+++ b/src/equicordplugins/richPresence/services/navidrome.ts
@@ -114,8 +114,6 @@ async function fetchNowPlaying(signal?: AbortSignal): Promise<NdTrack | null> {
     }
 }
 
-
-
 function getSettingsJSON() {
     return JSON.stringify({
         nd_clientId: settings.store.nd_clientId,
@@ -218,7 +216,7 @@ async function getActivity(signal?: AbortSignal): Promise<Activity | null> {
 
     const detailsString = customFormat(nd_detailsString, track);
     let stateString = customFormat(nd_stateString, track);
-    
+
     if (isPaused) {
         stateString = stateString ? `${stateString} (Paused)` : "Paused";
     }

--- a/src/equicordplugins/richPresence/services/navidrome.ts
+++ b/src/equicordplugins/richPresence/services/navidrome.ts
@@ -129,7 +129,8 @@ function getSettingsJSON() {
         nd_statusDisplayType: settings.store.nd_statusDisplayType,
         nd_albumArtMode: settings.store.nd_albumArtMode,
         nd_lastfmApiKey: settings.store.nd_lastfmApiKey,
-        nd_showAlbum: settings.store.nd_showAlbum
+        nd_showAlbum: settings.store.nd_showAlbum,
+        nd_hideOnPause: settings.store.nd_hideOnPause
     });
 }
 

--- a/src/equicordplugins/richPresence/settings.ts
+++ b/src/equicordplugins/richPresence/settings.ts
@@ -469,6 +469,12 @@ export const settings = definePluginSettings({
         ],
         hidden: true,
     },
+    nd_hideOnPause: {
+        description: "Hide Rich Presence when music is paused",
+        type: OptionType.BOOLEAN,
+        default: true,
+        hidden: true,
+    }
 });
 
 export type SettingsStore = typeof settings["store"];


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
adds what i should have added before: usage of the opensubsonic api. With this, pausing works well. The rich presence will now resync with where the actual navidrome client is when you either fast forward or rewind too. On top of this, I also fixed songs staying on your status when you are done listening to them (when the elapsed time bar completes, it disappears).

prob should have been using this from the start... oh well lmao
## Checklist before submitting
- [X] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [X] This pull request was written by me, and not an AI agent
