### PR TITLE
feat(timezones): show recipient timezone in dms

### DIFF
--- a/src/equicordplugins/timezones/index.tsx
+++ b/src/equicordplugins/timezones/index.tsx
@@ -14,7 +14,7 @@ import { Devs, EquicordDevs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import { Message, User } from "@vencord/discord-types";
 import { findByPropsLazy, findCssClassesLazy } from "@webpack";
-import { Button, Menu, openModal,showToast, Toasts, Tooltip, useEffect, UserStore, useState } from "@webpack/common";
+import { Button, ChannelStore, Menu, openModal, showToast, Toasts, Tooltip, useEffect, UserStore, useState } from "@webpack/common";
 
 import { deleteTimezone, getTimezone, loadDatabaseTimezones, setUserDatabaseTimezone } from "./database";
 import { SetTimezoneModal } from "./TimezoneModal";
@@ -64,6 +64,12 @@ export const settings = definePluginSettings({
         type: OptionType.BOOLEAN,
         description: "Show time in message headers",
         default: true
+    },
+
+    recipientTimezoneInDms: {
+        type: OptionType.BOOLEAN,
+        description: "In DMs, show the recipient's timezone on your messages",
+        default: false
     },
 
     showProfileTime: {
@@ -342,9 +348,19 @@ export default definePlugin({
     },
 
     renderMessageTimezone: (props?: { message?: Message; }) => {
-        if (!settings.store.showMessageHeaderTime || !props?.message) return null;
-        if (props.message.author.id === UserStore.getCurrentUser().id && !settings.store["Show Own Timezone"]) return null;
+        const { showMessageHeaderTime, recipientTimezoneInDms, "Show Own Timezone": showOwnTimezone } = settings.store;
 
-        return <TimestampComponent userId={props.message.author.id} timestamp={props.message.timestamp.toISOString()} type="message" />;
+        if (!showMessageHeaderTime || !props?.message) return null;
+
+        let userId = props.message.author.id;
+
+        if (userId === UserStore.getCurrentUser().id) {
+            const channel = recipientTimezoneInDms ? ChannelStore.getChannel(props.message.channel_id) : undefined;
+
+            if (channel?.type === 1) userId = channel.recipients[0];
+            else if (!showOwnTimezone) return null;
+        }
+
+        return <TimestampComponent userId={userId} timestamp={props.message.timestamp.toISOString()} type="message" />;
     }
 });


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
satisfy this request: https://discord.com/channels/1173279886065029291/1523841786957791433
<img width="815" height="135" alt="image" src="https://github.com/user-attachments/assets/72dc02dd-fcfd-4ca6-93ef-26b4407e64c5" />

Wanna keep this as an option or make it default behavior?


## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
