### PR TITLE
feat(RichPresence): add Storyteller service

### DIFF
--- a/src/equicordplugins/richPresence/SettingsPanel.tsx
+++ b/src/equicordplugins/richPresence/SettingsPanel.tsx
@@ -233,6 +233,28 @@ function NavidromeSettings() {
     );
 }
 
+
+function StorytellerSettings() {
+    const [threshold, setThreshold] = useState(settings.store.st_activeThreshold ?? 120);
+    return (
+        <>
+            <SettingsSection id="storyteller-settings" name="" description="Display your currently playing audiobook from Storyteller as Discord Rich Presence. Requires your Storyteller server URL, username, and password. The plugin detects active listening by checking which book had its position updated most recently." />
+            <TextSetting name="Server URL" description="Storyteller server URL." settingsKey="st_serverUrl" placeholder="https://storyteller.example.com" />
+            <TextSetting name="Username / Email" description="Storyteller username or email." settingsKey="st_username" />
+            <TextSetting name="Password" description="Storyteller password." settingsKey="st_password" />
+            <SwitchSetting name="Fetch Cover Art" description="Look up book covers from Open Library and Google Books. Sends book title and author name to these services." settingsKey="st_fetchCovers" />
+            <SettingsSection id="st-active-threshold" name="Active Threshold" description="How many seconds since last position update to consider a book as 'currently playing'. Increase this if your presence disappears too quickly.">
+                <Slider
+                    markers={[30, 60, 120, 300, 600]}
+                    initialValue={threshold}
+                    onValueChange={v => { setThreshold(v); settings.store.st_activeThreshold = v; }}
+                    onValueRender={v => `${v}s`}
+                    stickToMarkers
+                />
+            </SettingsSection>
+        </>
+    );
+}
 const TAB_COMPONENTS: Record<ServiceTab, React.ComponentType> = {
     [ServiceTab.AudioBookShelf]: AudioBookShelfSettings,
     [ServiceTab.Tosu]: TosuSettings,
@@ -241,6 +263,7 @@ const TAB_COMPONENTS: Record<ServiceTab, React.ComponentType> = {
     [ServiceTab.ListenBrainz]: ListenBrainzSettings,
     [ServiceTab.GensokyoRadio]: GensokyoRadioSettings,
     [ServiceTab.Navidrome]: NavidromeSettings,
+    [ServiceTab.Storyteller]: StorytellerSettings,
 };
 
 const TAB_LABELS: Record<ServiceTab, string> = {
@@ -251,6 +274,7 @@ const TAB_LABELS: Record<ServiceTab, string> = {
     [ServiceTab.ListenBrainz]: "ListenBrainz",
     [ServiceTab.GensokyoRadio]: "Gensokyo Radio",
     [ServiceTab.Navidrome]: "Navidrome",
+    [ServiceTab.Storyteller]: "Storyteller",
 };
 
 const ENABLE_KEYS: Record<ServiceTab, SettingsKey> = {
@@ -261,6 +285,7 @@ const ENABLE_KEYS: Record<ServiceTab, SettingsKey> = {
     [ServiceTab.ListenBrainz]: "lb_enabled",
     [ServiceTab.GensokyoRadio]: "gr_enabled",
     [ServiceTab.Navidrome]: "nd_enabled",
+    [ServiceTab.Storyteller]: "st_enabled",
 };
 
 const TABS = Object.values(ServiceTab);

--- a/src/equicordplugins/richPresence/index.tsx
+++ b/src/equicordplugins/richPresence/index.tsx
@@ -15,6 +15,7 @@ import * as jellyfin from "./services/jellyfin";
 import * as listenbrainz from "./services/listenbrainz";
 import * as navidrome from "./services/navidrome";
 import * as statsfm from "./services/statsfm";
+import * as storyteller from "./services/storyteller";
 import * as tosu from "./services/tosu";
 import { setOnServiceChange, settings, SettingsStore } from "./settings";
 import { ServiceTab } from "./types";
@@ -31,6 +32,7 @@ const services: Record<string, { start(): void; stop(): void; forceUpdate?(): vo
     [ServiceTab.ListenBrainz]: listenbrainz,
     [ServiceTab.GensokyoRadio]: gensokyoRadio,
     [ServiceTab.Navidrome]: navidrome,
+    [ServiceTab.Storyteller]: storyteller,
 };
 
 const enableKeys: Record<string, SettingsKey> = {
@@ -41,6 +43,7 @@ const enableKeys: Record<string, SettingsKey> = {
     [ServiceTab.ListenBrainz]: "lb_enabled",
     [ServiceTab.GensokyoRadio]: "gr_enabled",
     [ServiceTab.Navidrome]: "nd_enabled",
+    [ServiceTab.Storyteller]: "st_enabled",
 };
 
 const activeServices = new Set<string>();
@@ -77,7 +80,7 @@ function stopAllServices() {
 
 export default definePlugin({
     name: "RichPresence",
-    description: "Unified rich presence hub for AudioBookShelf, osu!, stats.fm, Jellyfin, ListenBrainz, Navidrome, and Gensokyo Radio.",
+    description: "Unified rich presence hub for AudioBookShelf, osu!, stats.fm, Jellyfin, ListenBrainz, Navidrome, Gensokyo Radio, and Storyteller.",
     tags: ["Activity"],
     authors: [
         EquicordDevs.vmohammad,

--- a/src/equicordplugins/richPresence/native.ts
+++ b/src/equicordplugins/richPresence/native.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+import { IpcMainInvokeEvent } from "electron";
+
 import type { GrTrackData } from "./types/gensokyoRadio";
+import type { StorytellerBook } from "./types/storyteller";
 
 export async function fetchTrackData(): Promise<GrTrackData | null> {
     const song = await (await fetch("https://gensokyoradio.net/api/station/playing/")).json();
@@ -17,4 +20,34 @@ export async function fetchTrackData(): Promise<GrTrackData | null> {
         duration: song.SONGTIMES.SONGEND,
         artwork: song.MISC.ALBUMART ? `https://gensokyoradio.net/images/albums/500/${song.MISC.ALBUMART}` : "",
     };
+}
+
+export async function storytellerGetToken(_event: IpcMainInvokeEvent, serverUrl: string, usernameOrEmail: string, password: string): Promise<string | null> {
+    try {
+        const baseUrl = serverUrl.replace(/\/$/, "");
+        const body = `usernameOrEmail=${encodeURIComponent(usernameOrEmail)}&password=${encodeURIComponent(password)}`;
+        const res = await fetch(`${baseUrl}/api/v2/token`, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body,
+        });
+        if (!res.ok) return null;
+        const data = await res.json();
+        return data.access_token ?? null;
+    } catch {
+        return null;
+    }
+}
+
+export async function storytellerFetchBooks(_event: IpcMainInvokeEvent, serverUrl: string, token: string): Promise<StorytellerBook[] | null> {
+    try {
+        const baseUrl = serverUrl.replace(/\/$/, "");
+        const res = await fetch(`${baseUrl}/api/v2/books`, {
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) return null;
+        return await res.json();
+    } catch {
+        return null;
+    }
 }

--- a/src/equicordplugins/richPresence/services/storyteller.ts
+++ b/src/equicordplugins/richPresence/services/storyteller.ts
@@ -1,0 +1,333 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { Logger } from "@utils/Logger";
+import { PluginNative } from "@utils/types";
+import { Activity } from "@vencord/discord-types";
+import {
+    ApplicationAssetUtils,
+    FluxDispatcher,
+    showToast,
+} from "@webpack/common";
+
+import { settings } from "../settings";
+import { StorytellerBook, StorytellerMediaData } from "../types/storyteller";
+
+const Native = VencordNative.pluginHelpers.RichPresence as PluginNative<
+    typeof import("../native")
+>;
+
+const APPLICATION_ID = "1108588077900898414";
+const SOCKET_ID = "RichPresence_Storyteller";
+const FALLBACK_COVER = "https://cdn-icons-png.flaticon.com/512/29/29302.png";
+const logger = new Logger("RichPresence:Storyteller");
+
+let authToken: string | null = null;
+let updateInterval: NodeJS.Timeout | undefined;
+const coverCache = new Map<string, string | null>();
+
+let cachedTimestamps: { start: number; end: number } | undefined;
+let cachedBookId: string | null = null;
+let cachedProgression: number | null = null;
+
+async function getAsset(key: string): Promise<string> {
+    return (
+        await ApplicationAssetUtils.fetchAssetIds(APPLICATION_ID, [key])
+    )[0];
+}
+
+function setActivity(activity: Activity | null) {
+    FluxDispatcher.dispatch({
+        type: "LOCAL_ACTIVITY_UPDATE",
+        activity,
+        socketId: SOCKET_ID,
+    });
+}
+
+function cleanTitle(title: string): string {
+    return title
+        .replace(/\s*\(.*?\)/g, "")
+        .replace(/\s*:.*$/, "")
+        .trim();
+}
+
+async function searchOpenLibrary(
+    title: string,
+    author?: string,
+): Promise<string | null> {
+    const params = new URLSearchParams({
+        title,
+        ...(author && { author }),
+        limit: "5",
+        fields: "title,cover_i",
+    });
+    const res = await fetch(
+        `https://openlibrary.org/search.json?${params.toString()}`,
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+
+    for (const doc of data?.docs ?? []) {
+        if (!doc.cover_i) continue;
+        return `https://covers.openlibrary.org/b/id/${doc.cover_i}-M.jpg`;
+    }
+    return null;
+}
+
+async function searchGoogleBooks(
+    title: string,
+    author?: string,
+): Promise<string | null> {
+    const query = author
+        ? `intitle:${title}+inauthor:${author}`
+        : `intitle:${title}`;
+    const res = await fetch(
+        `https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(query)}&maxResults=3&fields=items(volumeInfo/imageLinks)`,
+    );
+    if (!res.ok) return null;
+    const data = await res.json();
+
+    for (const item of data?.items ?? []) {
+        const thumbnail =
+            item?.volumeInfo?.imageLinks?.thumbnail ??
+            item?.volumeInfo?.imageLinks?.smallThumbnail;
+        if (thumbnail) return thumbnail.replace(/^http:/, "https:");
+    }
+    return null;
+}
+
+async function fetchCoverUrl(
+    title: string,
+    author?: string,
+): Promise<string | null> {
+    try {
+        const clean = cleanTitle(title);
+
+        let url = await searchOpenLibrary(clean, author);
+        if (url) return url;
+
+        if (author) {
+            url = await searchOpenLibrary(clean);
+            if (url) return url;
+        }
+
+        if (clean !== title) {
+            url = await searchOpenLibrary(title, author);
+            if (url) return url;
+        }
+
+        url = await searchGoogleBooks(clean, author);
+        if (url) return url;
+
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+async function authenticate(): Promise<boolean> {
+    const { st_serverUrl, st_username, st_password } = settings.store;
+    if (!st_serverUrl || !st_username || !st_password) {
+        logger.warn(
+            "Storyteller server URL, username, or password is not set.",
+        );
+        showToast("Storyteller RPC is not configured.", "failure", {
+            duration: 15000,
+        });
+        return false;
+    }
+
+    try {
+        const token = await Native.storytellerGetToken(
+            st_serverUrl,
+            st_username,
+            st_password,
+        );
+        if (!token) {
+            logger.error("Failed to authenticate with Storyteller");
+            authToken = null;
+            return false;
+        }
+        authToken = token;
+        return true;
+    } catch (e) {
+        logger.error("Failed to authenticate with Storyteller", e);
+        authToken = null;
+        return false;
+    }
+}
+
+async function fetchBooks(): Promise<StorytellerBook[] | null> {
+    if (!authToken && !(await authenticate())) return null;
+
+    try {
+        const books = await Native.storytellerFetchBooks(
+            settings.store.st_serverUrl!,
+            authToken!,
+        );
+
+        if (!books) {
+            authToken = null;
+            if (await authenticate()) {
+                return await Native.storytellerFetchBooks(
+                    settings.store.st_serverUrl!,
+                    authToken!,
+                );
+            }
+            return null;
+        }
+
+        return books;
+    } catch (e) {
+        logger.error("Failed to fetch books from Storyteller", e);
+        return null;
+    }
+}
+
+function findActiveBook(books: StorytellerBook[]): StorytellerBook | null {
+    const thresholdMs = (settings.store.st_activeThreshold ?? 120) * 1000;
+    const now = Date.now();
+
+    let bestBook: StorytellerBook | null = null;
+    let bestTimestamp = 0;
+
+    for (const book of books) {
+        if (!book.position) continue;
+
+        const timeSince = now - book.position.timestamp;
+        if (timeSince > thresholdMs) continue;
+
+        if (book.position.timestamp > bestTimestamp) {
+            bestTimestamp = book.position.timestamp;
+            bestBook = book;
+        }
+    }
+
+    return bestBook;
+}
+
+function buildMediaData(book: StorytellerBook): StorytellerMediaData {
+    const baseUrl = settings.store.st_serverUrl!.replace(/\/$/, "");
+
+    return {
+        name: book.title,
+        author: book.authors?.[0]?.name,
+        narrator: book.narrators?.[0]?.name,
+        series: book.series?.[0]?.name,
+        seriesPosition: book.series?.[0]?.position,
+        duration: book.audiobook?.duration ?? undefined,
+        totalProgression:
+            book.position?.locator?.locations?.totalProgression ?? undefined,
+        imageUrl: `${baseUrl}/api/v2/books/${book.uuid}/cover`,
+        bookId: book.uuid,
+    };
+}
+
+async function getActivity(): Promise<Activity | null> {
+    const books = await fetchBooks();
+    if (!books || books.length === 0) return null;
+
+    const activeBook = findActiveBook(books);
+    if (!activeBook) return null;
+
+    const mediaData = buildMediaData(activeBook);
+
+    let coverUrl: string | null = null;
+    if (settings.store.st_fetchCovers !== false) {
+        const cacheKey = mediaData.bookId;
+        if (coverCache.has(cacheKey)) {
+            coverUrl = coverCache.get(cacheKey) ?? null;
+        } else {
+            try {
+                coverUrl = await fetchCoverUrl(
+                    mediaData.name,
+                    mediaData.author,
+                );
+            } catch {
+                /* noop */
+            }
+            coverCache.set(cacheKey, coverUrl);
+        }
+    }
+
+    const assets = {
+        large_image: await getAsset(coverUrl || FALLBACK_COVER),
+        large_text: mediaData.series
+            ? mediaData.seriesPosition != null
+                ? `${mediaData.series} #${mediaData.seriesPosition}`
+                : mediaData.series
+            : "Storyteller",
+    };
+
+    const displayTitle = cleanTitle(mediaData.name);
+
+    let state: string;
+    if (mediaData.series && mediaData.author) {
+        state = `${mediaData.series} \u2022 ${mediaData.author}`;
+    } else if (mediaData.author) {
+        state = `by ${mediaData.author}`;
+    } else if (mediaData.narrator) {
+        state = `Narrated by ${mediaData.narrator}`;
+    } else {
+        state = "Audiobook";
+    }
+
+    // Only recalculate timestamps when progression changes to avoid bar resets
+    let timestamps: { start: number; end: number } | undefined;
+    if (mediaData.duration && mediaData.totalProgression != null) {
+        if (
+            cachedBookId !== mediaData.bookId ||
+            cachedProgression !== mediaData.totalProgression ||
+            !cachedTimestamps
+        ) {
+            const elapsed = mediaData.duration * mediaData.totalProgression;
+            const remaining = mediaData.duration - elapsed;
+            cachedTimestamps = {
+                start: Date.now() - elapsed * 1000,
+                end: Date.now() + remaining * 1000,
+            };
+            cachedBookId = mediaData.bookId;
+            cachedProgression = mediaData.totalProgression;
+        }
+        timestamps = cachedTimestamps;
+    }
+
+    return {
+        application_id: APPLICATION_ID,
+        name: "Storyteller",
+        details: displayTitle,
+        state,
+        assets,
+        timestamps,
+        type: 2,
+        flags: 1,
+    };
+}
+
+async function updatePresence() {
+    try {
+        setActivity(await getActivity());
+    } catch (e) {
+        logger.error("Failed to update presence", e);
+        setActivity(null);
+    }
+}
+
+export function start() {
+    authToken = null;
+    updatePresence();
+    updateInterval = setInterval(updatePresence, 15000);
+}
+
+export function stop() {
+    clearInterval(updateInterval);
+    updateInterval = undefined;
+    authToken = null;
+    cachedTimestamps = undefined;
+    cachedBookId = null;
+    cachedProgression = null;
+    setActivity(null);
+}

--- a/src/equicordplugins/richPresence/settings.ts
+++ b/src/equicordplugins/richPresence/settings.ts
@@ -77,6 +77,13 @@ export const settings = definePluginSettings({
         hidden: true,
         onChange: () => onServiceChange?.(),
     },
+    st_enabled: {
+        description: "Enable Storyteller presence.",
+        type: OptionType.BOOLEAN,
+        default: false,
+        hidden: true,
+        onChange: () => onServiceChange?.(),
+    },
 
     // AudioBookShelf
     abs_serverUrl: {
@@ -467,6 +474,39 @@ export const settings = definePluginSettings({
                 value: "track"
             }
         ],
+        hidden: true,
+    },
+
+    // Storyteller
+    st_serverUrl: {
+        description: "Storyteller server URL.",
+        type: OptionType.STRING,
+        default: "",
+        hidden: true,
+    },
+    st_username: {
+        description: "Storyteller username or email.",
+        type: OptionType.STRING,
+        default: "",
+        hidden: true,
+    },
+    st_password: {
+        description: "Storyteller password.",
+        type: OptionType.STRING,
+        default: "",
+        hidden: true,
+    },
+    st_fetchCovers: {
+        description: "Fetch book cover art from Open Library and Google Books. Sends book title and author to these services.",
+        type: OptionType.BOOLEAN,
+        default: true,
+        hidden: true,
+    },
+    st_activeThreshold: {
+        description: "Seconds since last position update to consider a book as 'currently playing'.",
+        type: OptionType.SLIDER,
+        markers: [30, 60, 120, 300, 600],
+        default: 120,
         hidden: true,
     },
 });

--- a/src/equicordplugins/richPresence/types/index.ts
+++ b/src/equicordplugins/richPresence/types/index.ts
@@ -12,6 +12,7 @@ export enum ServiceTab {
     ListenBrainz = "listenbrainz",
     GensokyoRadio = "gensokyoRadio",
     Navidrome = "navidrome",
+    Storyteller = "storyteller",
 }
 
 export const enum NameFormat {

--- a/src/equicordplugins/richPresence/types/storyteller.ts
+++ b/src/equicordplugins/richPresence/types/storyteller.ts
@@ -1,0 +1,87 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export interface StorytellerAuthor {
+    uuid: string;
+    name: string;
+    fileAs?: string;
+}
+
+export interface StorytellerNarrator {
+    uuid: string;
+    name: string;
+    fileAs?: string;
+}
+
+export interface StorytellerSeries {
+    uuid: string;
+    name: string;
+    position?: number;
+}
+
+export interface StorytellerLocator {
+    href?: string;
+    type?: string;
+    locations?: {
+        fragments?: string[];
+        progression?: number;
+        totalProgression?: number;
+        position?: number;
+    };
+    target?: number;
+}
+
+export interface StorytellerPosition {
+    uuid: string;
+    locator: StorytellerLocator;
+    timestamp: number;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+export interface StorytellerAudiobook {
+    uuid: string;
+    filepath?: string;
+    missing?: boolean;
+    duration?: number;
+    fileSize?: number;
+}
+
+export interface StorytellerEbook {
+    uuid: string;
+    filepath?: string;
+    missing?: boolean;
+    pageCount?: number;
+}
+
+export interface StorytellerBook {
+    uuid: string;
+    title: string;
+    language?: string | null;
+    description?: string | null;
+    publicationDate?: string | null;
+    subtitle?: string | null;
+    duration?: number | null;
+    authors: StorytellerAuthor[];
+    narrators: StorytellerNarrator[];
+    series: StorytellerSeries[];
+    position: StorytellerPosition | null;
+    audiobook: StorytellerAudiobook | null;
+    ebook: StorytellerEbook | null;
+    status?: { name?: string } | null;
+}
+
+export interface StorytellerMediaData {
+    name: string;
+    author?: string;
+    narrator?: string;
+    series?: string;
+    seriesPosition?: number;
+    duration?: number;
+    totalProgression?: number;
+    imageUrl?: string;
+    bookId: string;
+}


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
Adds Storyteller as a supported service to the RichPresence plugin. 

It polls the '/api/v2/books' endpoint to check for the most recently updated position. I added a toggle to disable external cover art lookups (Open Library/Google Books) for users who prefer strict privacy. The plugin defaults to a fallback icon if no cover art is available.

## Preview
![Storyteller Settings](https://github.com/user-attachments/assets/74bdc806-104a-43ab-9cc6-dd9240207f80)
![Active Presence](https://github.com/user-attachments/assets/20b65700-8b99-4fe2-a7c5-4940c5717e3a)
![Fallback Presence](https://github.com/user-attachments/assets/5794014b-b54e-45f2-b03a-578f530d71f2)
![Mouseover](https://github.com/user-attachments/assets/dbed4533-96fb-4419-8dd9-b8efdc96b418)


## Checklist before submitting

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
