### PR TITLE
feat: add optional NVIDIA VA-API hardware video decoding

### DIFF
--- a/src/api/Settings.ts
+++ b/src/api/Settings.ts
@@ -56,6 +56,7 @@ export interface Settings {
     frameless: boolean;
     transparent: boolean;
     winCtrlQ: boolean;
+    enableLinuxNvidiaVideoDecode: boolean;
     macosVibrancyStyle:
     | "content"
     | "fullscreen-ui"
@@ -126,6 +127,7 @@ const DefaultSettings: Settings = {
     frameless: false,
     transparent: false,
     winCtrlQ: false,
+    enableLinuxNvidiaVideoDecode: false,
     macosVibrancyStyle: undefined,
     windowsMaterial: "none",
     disableMinSize: false,

--- a/src/components/settings/tabs/vencord/index.tsx
+++ b/src/components/settings/tabs/vencord/index.tsx
@@ -21,7 +21,7 @@ import { QuickAction, QuickActionCard } from "@components/settings/QuickAction";
 import { SpecialCard } from "@components/settings/SpecialCard";
 import BadgeAPI from "@plugins/_api/badges";
 import { gitRemote } from "@shared/vencordUserAgent";
-import { DONOR_ROLE_ID, GUILD_ID, IS_WINDOWS, VC_DONOR_ROLE_ID, VC_GUILD_ID } from "@utils/constants";
+import { DONOR_ROLE_ID, GUILD_ID, IS_LINUX, IS_WINDOWS, VC_DONOR_ROLE_ID, VC_GUILD_ID } from "@utils/constants";
 import { classNameFactory } from "@utils/css";
 import { Margins } from "@utils/margins";
 import { isAnyPluginDev } from "@utils/misc";
@@ -49,7 +49,7 @@ type KeysOfType<Object, Type> = {
 }[keyof Object];
 
 function Switches() {
-    const settings = useSettings(["useQuickCss", "enableReactDevtools", "mainWindowFrameless", "frameless", "winNativeTitleBar", "transparent", "winCtrlQ", "disableMinSize"]);
+    const settings = useSettings(["useQuickCss", "enableReactDevtools", "mainWindowFrameless", "frameless", "winNativeTitleBar", "transparent", "winCtrlQ", "disableMinSize", "enableLinuxNvidiaVideoDecode"]);
 
     const Switches = [
         {
@@ -96,6 +96,12 @@ function Switches() {
             key: "disableMinSize",
             title: "Disable Minimum Window Size",
             description: "Allow the Discord window to be resized smaller than its default minimum size. Useful for tiling window managers or small screens.",
+            restartRequired: true,
+        },
+        IS_DISCORD_DESKTOP && IS_LINUX && {
+            key: "enableLinuxNvidiaVideoDecode",
+            title: "Enable NVIDIA VA-API Video Decoding",
+            description: "Enable experimental hardware video decoding on Linux. Requires nvidia-vaapi-driver and Wayland.",
             restartRequired: true,
         },
         !IS_WEB && IS_WINDOWS && {

--- a/src/components/settings/tabs/vencord/index.tsx
+++ b/src/components/settings/tabs/vencord/index.tsx
@@ -101,7 +101,7 @@ function Switches() {
         IS_DISCORD_DESKTOP && IS_LINUX && {
             key: "enableLinuxNvidiaVideoDecode",
             title: "Enable NVIDIA VA-API Video Decoding",
-            description: "Enable experimental hardware video decoding on Linux. Requires nvidia-vaapi-driver and Wayland.",
+            description: "Enable experimental hardware video decoding on Linux. Requires nvidia-vaapi-driver. Wayland is supported and preferred.",
             restartRequired: true,
         },
         !IS_WEB && IS_WINDOWS && {

--- a/src/main/patcher.ts
+++ b/src/main/patcher.ts
@@ -42,6 +42,53 @@ app.setAppPath(asarPath);
 if (!IS_VANILLA) {
     const settings = RendererSettings.store;
 
+    const videoDecodeMarker = "--equicord-linux-nvidia-video-decode";
+    const videoDecodeFeatures = [
+        "AcceleratedVideoDecodeLinuxGL",
+        "AcceleratedVideoDecodeLinuxZeroCopyGL",
+        "VaapiOnNvidiaGPUs",
+        "VaapiIgnoreDriverChecks"
+    ];
+    const enableLinuxNvidiaVideoDecode = IS_DISCORD_DESKTOP
+        && process.platform === "linux"
+        && settings.enableLinuxNvidiaVideoDecode;
+    const videoDecodeRelaunched = app.commandLine.hasSwitch(videoDecodeMarker.slice(2));
+
+    if (enableLinuxNvidiaVideoDecode !== videoDecodeRelaunched) {
+        const features = new Set<string>();
+        const featurePrefix = "--enable-features=";
+        const args = process.argv.slice(1).filter(arg => {
+            if (arg === videoDecodeMarker
+                || arg === "--ignore-gpu-blocklist"
+                || ["--ozone-platform=", "--use-angle=", "--use-gl="].some(prefix => arg.startsWith(prefix)))
+                return false;
+
+            if (!arg.startsWith(featurePrefix)) return true;
+            for (const feature of arg.slice(featurePrefix.length).split(","))
+                if (feature && !videoDecodeFeatures.includes(feature)) features.add(feature);
+            return false;
+        });
+
+        if (enableLinuxNvidiaVideoDecode) {
+            process.env.LIBVA_DRIVER_NAME ??= "nvidia";
+            process.env.NVD_BACKEND ??= "direct";
+            for (const feature of videoDecodeFeatures) features.add(feature);
+            args.push(videoDecodeMarker, "--use-gl=angle", "--use-angle=gl", "--ignore-gpu-blocklist");
+            if (process.env.XDG_SESSION_TYPE === "wayland" || process.env.WAYLAND_DISPLAY) {
+                process.env.ELECTRON_OZONE_PLATFORM_HINT ??= "wayland";
+                args.push("--ozone-platform=wayland");
+            }
+        } else {
+            if (process.env.LIBVA_DRIVER_NAME === "nvidia") delete process.env.LIBVA_DRIVER_NAME;
+            if (process.env.NVD_BACKEND === "direct") delete process.env.NVD_BACKEND;
+            if (process.env.ELECTRON_OZONE_PLATFORM_HINT === "wayland") delete process.env.ELECTRON_OZONE_PLATFORM_HINT;
+        }
+
+        if (features.size) args.push(`${featurePrefix}${[...features].join(",")}`);
+        app.relaunch({ args });
+        app.exit(0);
+    }
+
     patchTrayMenu();
 
     /*
@@ -165,6 +212,14 @@ if (!IS_VANILLA) {
             disabledFeatures.add("WidgetLayering");
             disabledFeatures.add("UseEcoQoSForBackgroundProcess");
             args[1] += [...disabledFeatures].join(",");
+        } else if (enableLinuxNvidiaVideoDecode && args[0] === "enable-features") {
+            const enabledFeatures = new Set([
+                ...app.commandLine.getSwitchValue("enable-features").split(","),
+                ...(args[1] ?? "").split(","),
+                ...videoDecodeFeatures
+            ]);
+            enabledFeatures.delete("");
+            args[1] = [...enabledFeatures].join(",");
         }
         return originalAppend.apply(this, args);
     };

--- a/src/main/patcher.ts
+++ b/src/main/patcher.ts
@@ -55,7 +55,9 @@ if (!IS_VANILLA) {
         ELECTRON_OZONE_PLATFORM_HINT: "wayland"
     };
     const videoDecodeOwnedMarker = "EQUICORD_VIDEO_DECODE_OWNED";
-    const { enableLinuxNvidiaVideoDecode } = settings;
+    const enableLinuxNvidiaVideoDecode = IS_DISCORD_DESKTOP
+        && process.platform === "linux"
+        && settings.enableLinuxNvidiaVideoDecode;
     const videoDecodeRelaunched = app.commandLine.hasSwitch(videoDecodeMarker.slice(2));
     const owned = new Set((process.env[videoDecodeOwnedMarker] ?? "").split(",").filter(Boolean));
 

--- a/src/main/patcher.ts
+++ b/src/main/patcher.ts
@@ -49,39 +49,66 @@ if (!IS_VANILLA) {
         "VaapiOnNvidiaGPUs",
         "VaapiIgnoreDriverChecks"
     ];
+    const videoDecodeEnv: Record<string, string> = {
+        LIBVA_DRIVER_NAME: "nvidia",
+        NVD_BACKEND: "direct",
+        ELECTRON_OZONE_PLATFORM_HINT: "wayland"
+    };
+    const videoDecodeOwnedMarker = "EQUICORD_VIDEO_DECODE_OWNED";
     const enableLinuxNvidiaVideoDecode = IS_DISCORD_DESKTOP
         && process.platform === "linux"
         && settings.enableLinuxNvidiaVideoDecode;
     const videoDecodeRelaunched = app.commandLine.hasSwitch(videoDecodeMarker.slice(2));
+    const owned = new Set((process.env[videoDecodeOwnedMarker] ?? "").split(",").filter(Boolean));
 
     if (enableLinuxNvidiaVideoDecode !== videoDecodeRelaunched) {
         const features = new Set<string>();
         const featurePrefix = "--enable-features=";
         const args = process.argv.slice(1).filter(arg => {
-            if (arg === videoDecodeMarker
-                || arg === "--ignore-gpu-blocklist"
-                || ["--ozone-platform=", "--use-angle=", "--use-gl="].some(prefix => arg.startsWith(prefix)))
-                return false;
+            if (arg === videoDecodeMarker || (!enableLinuxNvidiaVideoDecode && owned.has(arg))) return false;
 
             if (!arg.startsWith(featurePrefix)) return true;
             for (const feature of arg.slice(featurePrefix.length).split(","))
-                if (feature && !videoDecodeFeatures.includes(feature)) features.add(feature);
+                if (feature) features.add(feature);
             return false;
         });
 
         if (enableLinuxNvidiaVideoDecode) {
-            process.env.LIBVA_DRIVER_NAME ??= "nvidia";
-            process.env.NVD_BACKEND ??= "direct";
-            for (const feature of videoDecodeFeatures) features.add(feature);
-            args.push(videoDecodeMarker, "--use-gl=angle", "--use-angle=gl", "--ignore-gpu-blocklist");
-            if (process.env.XDG_SESSION_TYPE === "wayland" || process.env.WAYLAND_DISPLAY) {
-                process.env.ELECTRON_OZONE_PLATFORM_HINT ??= "wayland";
-                args.push("--ozone-platform=wayland");
+            for (const name of ["LIBVA_DRIVER_NAME", "NVD_BACKEND"]) {
+                if (process.env[name] == null) {
+                    process.env[name] = videoDecodeEnv[name];
+                    owned.add(name);
+                }
             }
+
+            const requiredArgs = ["--use-gl=angle", "--use-angle=gl", "--ignore-gpu-blocklist"];
+            if (process.env.XDG_SESSION_TYPE === "wayland" || process.env.WAYLAND_DISPLAY) {
+                if (process.env.ELECTRON_OZONE_PLATFORM_HINT == null) {
+                    process.env.ELECTRON_OZONE_PLATFORM_HINT = videoDecodeEnv.ELECTRON_OZONE_PLATFORM_HINT;
+                    owned.add("ELECTRON_OZONE_PLATFORM_HINT");
+                }
+                requiredArgs.push("--ozone-platform=wayland");
+            }
+
+            for (const arg of requiredArgs) {
+                if (!args.includes(arg)) {
+                    args.push(arg);
+                    owned.add(arg);
+                }
+            }
+
+            for (const feature of videoDecodeFeatures) {
+                if (!features.has(feature)) owned.add(feature);
+                features.add(feature);
+            }
+            process.env[videoDecodeOwnedMarker] = [...owned].join(",");
+            args.push(videoDecodeMarker);
         } else {
-            if (process.env.LIBVA_DRIVER_NAME === "nvidia") delete process.env.LIBVA_DRIVER_NAME;
-            if (process.env.NVD_BACKEND === "direct") delete process.env.NVD_BACKEND;
-            if (process.env.ELECTRON_OZONE_PLATFORM_HINT === "wayland") delete process.env.ELECTRON_OZONE_PLATFORM_HINT;
+            for (const feature of videoDecodeFeatures)
+                if (owned.has(feature)) features.delete(feature);
+            for (const [name, value] of Object.entries(videoDecodeEnv))
+                if (owned.has(name) && process.env[name] === value) delete process.env[name];
+            delete process.env[videoDecodeOwnedMarker];
         }
 
         if (features.size) args.push(`${featurePrefix}${[...features].join(",")}`);

--- a/src/main/patcher.ts
+++ b/src/main/patcher.ts
@@ -55,9 +55,7 @@ if (!IS_VANILLA) {
         ELECTRON_OZONE_PLATFORM_HINT: "wayland"
     };
     const videoDecodeOwnedMarker = "EQUICORD_VIDEO_DECODE_OWNED";
-    const enableLinuxNvidiaVideoDecode = IS_DISCORD_DESKTOP
-        && process.platform === "linux"
-        && settings.enableLinuxNvidiaVideoDecode;
+    const { enableLinuxNvidiaVideoDecode } = settings;
     const videoDecodeRelaunched = app.commandLine.hasSwitch(videoDecodeMarker.slice(2));
     const owned = new Set((process.env[videoDecodeOwnedMarker] ?? "").split(",").filter(Boolean));
 

--- a/src/main/patcher.ts
+++ b/src/main/patcher.ts
@@ -57,7 +57,7 @@ if (!IS_VANILLA) {
     const videoDecodeOwnedMarker = "EQUICORD_VIDEO_DECODE_OWNED";
     const enableLinuxNvidiaVideoDecode = IS_DISCORD_DESKTOP
         && process.platform === "linux"
-        && settings.enableLinuxNvidiaVideoDecode;
+        && settings.enableLinuxNvidiaVideoDecode === true;
     const videoDecodeRelaunched = app.commandLine.hasSwitch(videoDecodeMarker.slice(2));
     const owned = new Set((process.env[videoDecodeOwnedMarker] ?? "").split(",").filter(Boolean));
 

--- a/src/main/patcher.ts
+++ b/src/main/patcher.ts
@@ -72,6 +72,8 @@ if (!IS_VANILLA) {
                 if (feature) features.add(feature);
             return false;
         });
+        const separatorIndex = args.indexOf("--");
+        const trailingArgs = separatorIndex === -1 ? [] : args.splice(separatorIndex);
 
         if (enableLinuxNvidiaVideoDecode) {
             for (const name of ["LIBVA_DRIVER_NAME", "NVD_BACKEND"]) {
@@ -112,6 +114,7 @@ if (!IS_VANILLA) {
         }
 
         if (features.size) args.push(`${featurePrefix}${[...features].join(",")}`);
+        args.push(...trailingArgs);
         app.relaunch({ args });
         app.exit(0);
     }


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->

## Describe your Changes
This adds an option which fixes the annoying video playback issues (stuttering, audio desync, no playback at all) native discord has on linux compared to windows or vesktop/equibop by enabling VA-API decoding on wayland (nvidia-vaapi-driver is required and mentioned in the description).
Electron decoding in discord normally goes though OpenH264/libvpx/dav1d which then decodes on the CPU and for h264 is limited to level 5.2 at max.
Even at level <= 5.2 or other codecs like AV1/VP8/9, any demanding video (120fps for example) will not play properly because its limited by software decoding and a level higher than 5.2 will not play at all.

Forcing these when necessary gets Chromium to use the VA-API path and use hardware decoding (like it always should have in my opinion):
  **env:**
  - `LIBVA_DRIVER_NAME=nvidia`
  - `NVD_BACKEND=direct`
  - `ELECTRON_OZONE_PLATFORM_HINT=wayland`

  **launch options:**
  - `--use-gl=angle`
  - `--use-angle=gl`
  - `--ignore-gpu-blocklist`
  - `--ozone-platform=wayland`

  **chromium features:**
  - `AcceleratedVideoDecodeLinuxGL`
  - `AcceleratedVideoDecodeLinuxZeroCopyGL`
  - `VaapiOnNvidiaGPUs`
  - `VaapiIgnoreDriverChecks`

The full relaunch code is necessary because the normal settings restart isn't able to modify the startup arguments or env variables. This way we can also remove the env variables properly if the feature is turned off again.

Below is a very very short (less than one second) clip that discord refuses to play natively on linux due to level 6.0 when this feature is not enabled.
I could not upload a longer one due to the 10mb github upload restriction.

https://github.com/user-attachments/assets/50d36cec-2b78-4dbe-be6f-1c5b37ce6b17

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
