### PR TITLE
channelTabs: preserve tabs across random crashes, disconnects etc

### DIFF
--- a/src/equicordplugins/channelTabs/components/ChannelTabsContainer.tsx
+++ b/src/equicordplugins/channelTabs/components/ChannelTabsContainer.tsx
@@ -102,22 +102,28 @@ export default function ChannelsTabsContainer(props: BasicChannelTabsProps) {
     const _update = useForceUpdater();
     const update = useCallback((save = true) => {
         _update();
-        if (save) saveTabs(userId);
-    }, [userId]);
+        const currentUserId = UserStore.getCurrentUser()?.id;
+        if (save && currentUserId) void saveTabs(currentUserId);
+    }, []);
 
     const ref = useRef<HTMLDivElement>(null);
     const scrollerRef = useRef<HTMLDivElement>(null);
+    const currentChannelRef = useRef(props);
+    currentChannelRef.current = props;
 
     useEffect(() => {
-        setUpdaterFunction(update);
-        const onLogin = () => {
-            const { id } = UserStore.getCurrentUser();
-            if (id === userId && openedTabs.length) return;
-            setUserId(id);
+        return setUpdaterFunction(update);
+    }, [update]);
 
-            openStartupTabs({ ...props, userId: id }, setUserId);
+    useEffect(() => {
+        const onLogin = () => {
+            const user = UserStore.getCurrentUser();
+            if (!user) return;
+
+            void openStartupTabs({ ...currentChannelRef.current, userId: user.id }, setUserId);
         };
 
+        onLogin();
         FluxDispatcher.subscribe("CONNECTION_OPEN_SUPPLEMENTAL", onLogin);
         return () => {
             FluxDispatcher.unsubscribe("CONNECTION_OPEN_SUPPLEMENTAL", onLogin);

--- a/src/equicordplugins/channelTabs/util/tabs.tsx
+++ b/src/equicordplugins/channelTabs/util/tabs.tsx
@@ -94,7 +94,9 @@ const openTabs: ChannelTabsProps[] = [];
 const closedTabs: ChannelTabsProps[] = [];
 let currentlyOpenTab: number;
 const openTabHistory: number[] = [];
-let persistedTabs: Promise<PersistedTabs | undefined>;
+let hydratedUserId: string | undefined;
+let hydrationGeneration = 0;
+let saveQueue = Promise.resolve();
 
 // cache for the tab state (so like scroll pos etc)
 interface TabStateCache {
@@ -113,9 +115,12 @@ const _ = {
 };
 export const { openedTabs } = _;
 
-let update = (save = true) => {
+type UpdateFunction = (save?: boolean) => void;
+
+const unsetUpdate: UpdateFunction = () => {
     logger.warn("Update function not set");
 };
+let update = unsetUpdate;
 let bumpGhostTabCount = () => {
     logger.warn("Set ghost tab function not set");
 };
@@ -451,55 +456,68 @@ export function moveToTab(id: number) {
     }, NAVIGATION_TIMEOUT_MS);
 }
 
-export function openStartupTabs(props: BasicChannelTabsProps & { userId: string; }, setUserId: (id: string) => void) {
+export async function openStartupTabs(props: BasicChannelTabsProps & { userId: string; }, setUserId: (id: string) => void): Promise<void> {
     const { userId } = props;
-    persistedTabs ??= DataStore.get("ChannelTabs_openChannels_v2");
+
+    if (hydratedUserId === userId && openTabs.length) {
+        setUserId(userId);
+        update(false);
+        return;
+    }
+
+    setUserId("");
+    const generation = ++hydrationGeneration;
+    await saveQueue;
+    if (generation !== hydrationGeneration) return;
+
+    let savedTabs: PersistedTabs[string] | undefined;
+    if (settings.store.onStartup === "remember" && !isPluginEnabled("KeepCurrentChannel")) {
+        try {
+            const persistedTabs = await DataStore.get<PersistedTabs>("ChannelTabs_openChannels_v2");
+            if (generation !== hydrationGeneration) return;
+            savedTabs = persistedTabs?.[userId];
+        } catch (error) {
+            logger.error("Failed to load persisted tabs from DataStore", error);
+            showToast("Failed to load saved tabs", Toasts.Type.FAILURE);
+        }
+    }
+
     replaceArray(openTabs);
+    replaceArray(closedTabs);
     replaceArray(openTabHistory);
+    tabStateCache.clear();
     highestIdIndex = 0;
 
-    if (settings.store.onStartup !== "nothing" && isPluginEnabled("KeepCurrentChannel"))
-        return showToast("Not restoring tabs as KeepCurrentChannel is enabled", Toasts.Type.FAILURE);
+    const keepCurrentChannel = settings.store.onStartup !== "nothing" && isPluginEnabled("KeepCurrentChannel");
+    if (keepCurrentChannel)
+        showToast("Not restoring tabs as KeepCurrentChannel is enabled", Toasts.Type.FAILURE);
 
-    switch (settings.store.onStartup) {
+    switch (keepCurrentChannel ? "nothing" : settings.store.onStartup) {
         case "remember": {
-            persistedTabs
-                .then(tabs => {
-                    const t = tabs?.[userId];
-                    if (!t) {
-                        createTab({ channelId: props.channelId, guildId: props.guildId }, true);
-                        return showToast("Failed to restore tabs", Toasts.Type.FAILURE);
-                    }
-                    replaceArray(openTabs); // empty the array
-                    t.openTabs.forEach(tab => createTab(tab));
-                    currentlyOpenTab = openTabs[t.openTabIndex]?.id ?? 0;
+            if (!savedTabs?.openTabs.length) {
+                showToast("Failed to restore tabs", Toasts.Type.FAILURE);
+                break;
+            }
 
-                    setUserId(userId);
-                    moveToTab(currentlyOpenTab);
-                })
-                .catch(error => {
-                    logger.error("Failed to load persisted tabs from DataStore", error);
-                    showToast("Failed to load saved tabs", Toasts.Type.FAILURE);
-                    createTab({ channelId: props.channelId, guildId: props.guildId }, true);
-                    setUserId(userId);
-                });
+            savedTabs.openTabs.forEach(tab => createTab(tab, false, tab.messageId, false));
+            currentlyOpenTab = openTabs[savedTabs.openTabIndex]?.id ?? openTabs[0]?.id;
             break;
         }
         case "preset": {
             const tabs = settings.store.tabSet?.[userId];
             if (!tabs) break;
-            tabs.forEach(t => createTab(t));
-            setOpenTab(0);
-            setUserId(userId);
+            tabs.forEach(tab => createTab(tab, false, tab.messageId, false));
+            currentlyOpenTab = openTabs[0]?.id;
             break;
-        }
-        default: {
-            setUserId(userId);
         }
     }
 
-    if (!openTabs.length) createTab({ channelId: props.channelId, guildId: props.guildId }, true, undefined, false);
-    for (let i = 0; i < openTabHistory.length; i++) openTabHistory.pop();
+    if (!openTabs.length)
+        createTab({ channelId: props.channelId, guildId: props.guildId }, false, undefined, false);
+
+    currentlyOpenTab = openTabs.find(tab => tab.id === currentlyOpenTab)?.id ?? openTabs[0].id;
+    hydratedUserId = userId;
+    setUserId(userId);
     moveToTab(currentlyOpenTab);
 }
 
@@ -509,16 +527,25 @@ export function reopenClosedTab() {
     createTab(tab, true);
 }
 
-export const saveTabs = async (userId: string) => {
-    if (!userId) return;
+export function saveTabs(userId: string): Promise<void> {
+    if (!userId) return Promise.resolve();
 
-    DataStore.update<PersistedTabs>("ChannelTabs_openChannels_v2", old => {
-        return {
+    const snapshot = {
+        openTabs: openTabs.map(tab => ({ ...tab })),
+        openTabIndex: openTabs.findIndex(tab => tab.id === currentlyOpenTab)
+    };
+
+    saveQueue = saveQueue
+        .then(() => DataStore.update<PersistedTabs>("ChannelTabs_openChannels_v2", old => ({
             ...(old ?? {}),
-            [userId]: { openTabs, openTabIndex: openTabs.findIndex(t => t.id === currentlyOpenTab) }
-        };
-    });
-};
+            [userId]: snapshot
+        })))
+        .catch(error => {
+            logger.error("Failed to save tabs to DataStore", error);
+        });
+
+    return saveQueue;
+}
 
 export function setOpenTab(id: number) {
     const i = openTabs.findIndex(v => v.id === id);
@@ -528,8 +555,11 @@ export function setOpenTab(id: number) {
     openTabHistory.push(id);
 }
 
-export function setUpdaterFunction(fn: () => void) {
+export function setUpdaterFunction(fn: UpdateFunction): () => void {
     update = fn;
+    return () => {
+        if (update === fn) update = unsetUpdate;
+    };
 }
 
 export function switchChannel(ch: BasicChannelTabsProps) {

--- a/src/equicordplugins/channelTabs/util/tabs.tsx
+++ b/src/equicordplugins/channelTabs/util/tabs.tsx
@@ -470,8 +470,9 @@ export async function openStartupTabs(props: BasicChannelTabsProps & { userId: s
     await saveQueue;
     if (generation !== hydrationGeneration) return;
 
+    const keepCurrentChannel = settings.store.onStartup !== "nothing" && isPluginEnabled("KeepCurrentChannel");
     let savedTabs: PersistedTabs[string] | undefined;
-    if (settings.store.onStartup === "remember" && !isPluginEnabled("KeepCurrentChannel")) {
+    if (settings.store.onStartup === "remember" && !keepCurrentChannel) {
         try {
             const persistedTabs = await DataStore.get<PersistedTabs>("ChannelTabs_openChannels_v2");
             if (generation !== hydrationGeneration) return;
@@ -488,11 +489,13 @@ export async function openStartupTabs(props: BasicChannelTabsProps & { userId: s
     tabStateCache.clear();
     highestIdIndex = 0;
 
-    const keepCurrentChannel = settings.store.onStartup !== "nothing" && isPluginEnabled("KeepCurrentChannel");
-    if (keepCurrentChannel)
+    if (keepCurrentChannel) {
+        hydratedUserId = undefined;
         showToast("Not restoring tabs as KeepCurrentChannel is enabled", Toasts.Type.FAILURE);
+        return;
+    }
 
-    switch (keepCurrentChannel ? "nothing" : settings.store.onStartup) {
+    switch (settings.store.onStartup) {
         case "remember": {
             if (!savedTabs?.openTabs.length) {
                 showToast("Failed to restore tabs", Toasts.Type.FAILURE);


### PR DESCRIPTION
reconnects and renderer remounts could restore a stale tab snapshot from the previous clean restart

so i fixed it
how did i fix it?
 - hydrate tabs ONCE per account (some people like different workspaces on diff accounts) and preserve this state
 - read fresh persisted state when discord genuinely is restarted
 - serialize immutable snapshots for every tab mutation (keep things fresh)
 - prevent stale async hydration from overwriting newer sessions because that would just ruin things
 
 verified myself by injecting different tab states into my datastore and then turning off my wifi. first snapshot was not shown, but instead the most recent tab mutation (so the most recent tabs)
 
 thank you @fabian42 on discord for the report