### PR TITLE
FakeProfileThemes: fix crash opening edit profile

### DIFF
--- a/src/plugins/fakeProfileThemes/index.tsx
+++ b/src/plugins/fakeProfileThemes/index.tsx
@@ -223,7 +223,7 @@ export default definePlugin({
             replacement: [
                 {
                     match: /\(0,\i\.jsxs?\)\(\i,\{heading:.{0,40}#{intl::USER_SETTINGS_PROFILE_EFFECT}/,
-                    replace: "$self.addCopy3y3Button(),$&"
+                    replace: " $self.addCopy3y3Button(),$&"
                 }
             ]
         }


### PR DESCRIPTION
## Describe your Changes
Fixes a crash when opening the new profile editor, it was missing a space that resulted "return" and "Vencord" to mix into "returnVencord" on builds.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
