### PR TITLE
Add Server Notes feature with modal for editing notes

### DIFF
--- a/src/equicordplugins/guildNotes/index.tsx
+++ b/src/equicordplugins/guildNotes/index.tsx
@@ -1,0 +1,80 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { findGroupChildrenByChildId, NavContextMenuPatchCallback } from "@api/ContextMenu";
+import * as DataStore from "@api/DataStore";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { Menu } from "@webpack/common";
+
+import { openEditServerNoteModal } from "./modals";
+
+type UserNote = {
+    serverId: string;
+    note: string;
+};
+
+function createMenuItem(guildId: string) {
+    return (
+        <Menu.MenuItem
+            id="vc-view-server-note"
+            label="View Server Note"
+            action={async () => {
+                const notes = (await DataStore.get<UserNote[]>("GuildNotes")) ?? [];
+
+                const existing = notes.find(
+                    n => n.serverId === guildId
+                );
+
+                const currentNote = existing?.note ?? "";
+
+                openEditServerNoteModal(
+                    currentNote,
+                    async newNote => {
+                        if (newNote === currentNote) return;
+
+                        if (newNote === "" && existing) {
+                            notes.splice(notes.indexOf(existing), 1);
+                            await DataStore.set("GuildNotes", notes);
+                            return;
+                        }
+
+                        if (existing) {
+                            existing.note = newNote;
+                        } else {
+                            notes.push({
+                                serverId: guildId,
+                                note: newNote
+                            });
+                        }
+                        await DataStore.set("GuildNotes", notes);
+                    }
+                );
+            }}
+        />
+    );
+}
+
+const GuildContext: NavContextMenuPatchCallback = (children, props) => {
+    const group = findGroupChildrenByChildId("privacy", children);
+
+    if (group) {
+        group.push(
+            createMenuItem(props.guild.id)
+        );
+    }
+};
+export const contextMenus = {
+    "guild-context": GuildContext
+};
+
+export default definePlugin({
+    name: "Server Notes",
+    description:
+        "Allows you to add server notes",
+    authors: [EquicordDevs.BastiGame],
+    contextMenus,
+});

--- a/src/equicordplugins/guildNotes/index.tsx
+++ b/src/equicordplugins/guildNotes/index.tsx
@@ -74,7 +74,7 @@ export const contextMenus = {
 export default definePlugin({
     name: "Server Notes",
     description:
-        "Allows you to add server notes",
+        "Allows you to add server notes.",
     authors: [EquicordDevs.BastiGame],
     contextMenus,
 });

--- a/src/equicordplugins/guildNotes/modals.tsx
+++ b/src/equicordplugins/guildNotes/modals.tsx
@@ -1,0 +1,59 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { RenderModalProps } from "@vencord/discord-types";
+import { Modal, openModal, React, TextArea, useState } from "@webpack/common";
+
+function EditServerNoteModal({
+                                 modalProps,
+                                 initialNote,
+                                 onSave
+                             }: {
+    modalProps: RenderModalProps;
+    initialNote: string;
+    onSave: (note: string) => Promise<void> | void;
+}) {
+    const [note, setNote] = useState(initialNote);
+
+    const saveAndClose = () => {
+        void onSave(note.trim());
+        modalProps.onClose();
+    };
+
+    return (
+        <Modal
+            {...modalProps}
+            onClose={saveAndClose}
+            size="lg"
+            title="Server Note"
+            actions={[
+                { text: "Close", variant: "secondary", onClick: saveAndClose }
+            ]}
+        >
+            <TextArea
+                value={note}
+                onChange={setNote}
+                placeholder="Write a server note..."
+                maxLength={2000}
+                rows={10}
+                autoFocus
+            />
+        </Modal>
+    );
+}
+
+export function openEditServerNoteModal(
+    initialNote: string,
+    onSave: (note: string) => Promise<void> | void
+) {
+    openModal(props => (
+        <EditServerNoteModal
+            modalProps={props}
+            initialNote={initialNote}
+            onSave={onSave}
+        />
+    ));
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1398,6 +1398,10 @@ export const EquicordDevs = Object.freeze({
         name: "luca.beyer",
         id: 405090676771127317n
     },
+    BastiGame: {
+        name: "BastiGame",
+        id: 1018150165489668227n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Describe your Changes
This pull request adds a new plugin that lets you write server notes. To use it, simply right-click on a server and select “View Server Note.” A modal window will then open, allowing you to write your notes. 

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
