### PR TITLE
Replace ProfileSets with Profiles plugin

### DIFF
--- a/src/equicordplugins/profileSets/components/confirmModal.tsx
+++ b/src/equicordplugins/profileSets/components/confirmModal.tsx
@@ -8,15 +8,6 @@ import { Paragraph } from "@components/Paragraph";
 import { RenderModalProps } from "@vencord/discord-types";
 import { Modal, React } from "@webpack/common";
 
-interface ConfirmModalProps extends RenderModalProps {
-    title: string;
-    message: string;
-    confirmText: string;
-    cancelText: string;
-    onConfirm: () => void;
-    onCancel: () => void;
-}
-
 interface ImportProfilesModalProps extends RenderModalProps {
     title: string;
     message: string;
@@ -25,44 +16,19 @@ interface ImportProfilesModalProps extends RenderModalProps {
     onCancel: () => void;
 }
 
-export function ConfirmModal({ title, message, confirmText, cancelText, onConfirm, onCancel, ...props }: ConfirmModalProps) {
+export function ImportProfilesModal({ title, message, onOverride, onMerge, onCancel, onClose, ...props }: ImportProfilesModalProps) {
     const closeAfter = (action: () => void) => () => {
         action();
-        props.onClose();
+        onClose();
     };
 
     return (
         <Modal
             {...props}
-            size="sm"
-            title={title}
-            actions={[
-                {
-                    text: confirmText,
-                    variant: "primary",
-                    onClick: closeAfter(onConfirm)
-                },
-                {
-                    text: cancelText,
-                    variant: "secondary",
-                    onClick: closeAfter(onCancel)
-                }
-            ]}
-        >
-            <Paragraph>{message}</Paragraph>
-        </Modal>
-    );
-}
-
-export function ImportProfilesModal({ title, message, onOverride, onMerge, onCancel, ...props }: ImportProfilesModalProps) {
-    const closeAfter = (action: () => void) => () => {
-        action();
-        props.onClose();
-    };
-
-    return (
-        <Modal
-            {...props}
+            onClose={() => {
+                onCancel();
+                onClose();
+            }}
             size="sm"
             title={title}
             actions={[

--- a/src/equicordplugins/profileSets/components/presetList.tsx
+++ b/src/equicordplugins/profileSets/components/presetList.tsx
@@ -42,7 +42,8 @@ export function PresetList({
     return (
         <div className={cl("list-container")}>
             {presets.map(preset => {
-                const actualIndex = allPresets.indexOf(preset);
+                const findIndex = () => allPresets.findIndex(p => p.timestamp === preset.timestamp && p.name === preset.name);
+                const actualIndex = findIndex();
                 const isRenaming = renaming === actualIndex;
                 const isSelected = !isRenaming && selectedPreset === actualIndex;
                 const showMoveOptions = actualIndex > 0 || actualIndex < allPresets.length - 1 || currentPage > 1;
@@ -60,7 +61,9 @@ export function PresetList({
                 const commitRename = () => {
                     const nextName = renameText.trim();
                     if (!nextName) return;
-                    renamePreset(actualIndex, nextName);
+                    const idx = findIndex();
+                    if (idx === -1) return;
+                    renamePreset(idx, nextName);
                     onUpdate();
                 };
 
@@ -70,12 +73,16 @@ export function PresetList({
                         tabIndex={isRenaming ? -1 : 0}
                         role="button"
                         onClick={() => {
-                            if (!isRenaming) onLoad(actualIndex);
+                            if (!isRenaming) {
+                                const idx = findIndex();
+                                if (idx !== -1) onLoad(idx);
+                            }
                         }}
                         onKeyDown={e => {
                             if (!isRenaming && (e.key === "Enter" || e.key === " ")) {
                                 e.preventDefault();
-                                onLoad(actualIndex);
+                                const idx = findIndex();
+                                if (idx !== -1) onLoad(idx);
                             }
                         }}
                         className={classes(cl("row"), isSelected && cl("row-selected"))}
@@ -137,7 +144,9 @@ export function PresetList({
                                                 id="rename"
                                                 label="Rename"
                                                 action={() => {
-                                                    setRenaming(actualIndex);
+                                                    const idx = findIndex();
+                                                    if (idx === -1) return;
+                                                    setRenaming(idx);
                                                     setRenameText(preset.name);
                                                 }}
                                             />
@@ -145,11 +154,13 @@ export function PresetList({
                                                 id="update"
                                                 label="Update"
                                                 action={async () => {
+                                                    const idx = findIndex();
+                                                    if (idx === -1) return;
                                                     const profile = await getCurrentProfile();
                                                     await Promise.all(
                                                         (Object.entries(profile) as [keyof EditableProfile, EditableProfile[keyof EditableProfile]][])
                                                             .filter(([, value]) => isNonNullish(value))
-                                                            .map(([key, value]) => updatePresetField(actualIndex, key, value))
+                                                            .map(([key, value]) => updatePresetField(idx, key, value))
                                                     );
                                                     onUpdate();
                                                 }}
@@ -160,7 +171,9 @@ export function PresetList({
                                                     id="move-up"
                                                     label="Move Up"
                                                     action={() => {
-                                                        movePreset(actualIndex, actualIndex - 1);
+                                                        const idx = findIndex();
+                                                        if (idx <= 0) return;
+                                                        movePreset(idx, idx - 1);
                                                         onUpdate();
                                                     }}
                                                 />
@@ -170,7 +183,9 @@ export function PresetList({
                                                     id="move-down"
                                                     label="Move Down"
                                                     action={() => {
-                                                        movePreset(actualIndex, actualIndex + 1);
+                                                        const idx = findIndex();
+                                                        if (idx === -1 || idx >= allPresets.length - 1) return;
+                                                        movePreset(idx, idx + 1);
                                                         onUpdate();
                                                     }}
                                                 />
@@ -180,7 +195,9 @@ export function PresetList({
                                                     id="move-to-page-1"
                                                     label="Move to Page 1"
                                                     action={() => {
-                                                        movePreset(actualIndex, 0);
+                                                        const idx = findIndex();
+                                                        if (idx === -1) return;
+                                                        movePreset(idx, 0);
                                                         onPageChange(1);
                                                         onUpdate();
                                                     }}
@@ -192,7 +209,9 @@ export function PresetList({
                                                 label="Delete"
                                                 color="danger"
                                                 action={async () => {
-                                                    await deletePreset(actualIndex);
+                                                    const idx = findIndex();
+                                                    if (idx === -1) return;
+                                                    await deletePreset(idx);
                                                     onUpdate();
                                                 }}
                                             />

--- a/src/equicordplugins/profileSets/components/presetList.tsx
+++ b/src/equicordplugins/profileSets/components/presetList.tsx
@@ -12,7 +12,7 @@ import { ContextMenuApi, Menu, React, TextInput } from "@webpack/common";
 import { cl } from "..";
 import { deletePreset, movePreset, renamePreset, updatePresetField } from "../utils/actions";
 import { getCurrentProfile } from "../utils/profile";
-import { PresetSection, type ProfilePresetEx } from "../utils/storage";
+import { type ProfilePresetEx } from "../utils/storage";
 
 interface PresetListProps {
     presets: ProfilePresetEx[];
@@ -21,8 +21,6 @@ interface PresetListProps {
     selectedPreset: number;
     onLoad: (index: number) => void;
     onUpdate: () => void;
-    guildId?: string;
-    section: PresetSection;
     currentPage: number;
     onPageChange: (page: number) => void;
 }
@@ -34,15 +32,12 @@ export function PresetList({
     selectedPreset,
     onLoad,
     onUpdate,
-    guildId,
-    section,
     currentPage,
     onPageChange
 }: PresetListProps) {
     type EditableProfile = Omit<ProfilePreset, "name" | "timestamp">;
     const [renaming, setRenaming] = React.useState<number>(-1);
     const [renameText, setRenameText] = React.useState("");
-    const isGuildProfile = section === "server";
 
     return (
         <div className={cl("list-container")}>
@@ -50,6 +45,7 @@ export function PresetList({
                 const actualIndex = allPresets.indexOf(preset);
                 const isRenaming = renaming === actualIndex;
                 const isSelected = !isRenaming && selectedPreset === actualIndex;
+                const showMoveOptions = actualIndex > 0 || actualIndex < allPresets.length - 1 || currentPage > 1;
                 const date = new Date(preset.timestamp);
                 const formattedDate = date.toLocaleDateString(undefined, {
                     month: "short",
@@ -64,11 +60,9 @@ export function PresetList({
                 const commitRename = () => {
                     const nextName = renameText.trim();
                     if (!nextName) return;
-                    renamePreset(actualIndex, nextName, section, guildId);
+                    renamePreset(actualIndex, nextName);
                     onUpdate();
                 };
-
-                const showMoveOptions = actualIndex > 0 || actualIndex < allPresets.length - 1 || currentPage > 1;
 
                 return (
                     <div
@@ -76,9 +70,7 @@ export function PresetList({
                         tabIndex={isRenaming ? -1 : 0}
                         role="button"
                         onClick={() => {
-                            if (!isRenaming) {
-                                onLoad(actualIndex);
-                            }
+                            if (!isRenaming) onLoad(actualIndex);
                         }}
                         onKeyDown={e => {
                             if (!isRenaming && (e.key === "Enter" || e.key === " ")) {
@@ -87,6 +79,7 @@ export function PresetList({
                             }
                         }}
                         className={classes(cl("row"), isSelected ? "selected" : "")}
+                        style={preset.bannerDataUrl ? { backgroundImage: `url(${preset.bannerDataUrl})` } : undefined}
                     >
                         <div className={cl("avatar-url")}>
                             {preset.avatarDataUrl && (
@@ -138,7 +131,6 @@ export function PresetList({
                                 className={cl("menu-icon")}
                                 onClick={e => {
                                     e.stopPropagation();
-                                    const target = e.currentTarget;
                                     ContextMenuApi.openContextMenu(e, () => (
                                         <Menu.Menu navId="preset-options" onClose={ContextMenuApi.closeContextMenu}>
                                             <Menu.MenuItem
@@ -153,11 +145,11 @@ export function PresetList({
                                                 id="update"
                                                 label="Update"
                                                 action={async () => {
-                                                    const profile = await getCurrentProfile(guildId, { isGuildProfile });
+                                                    const profile = await getCurrentProfile();
                                                     await Promise.all(
                                                         (Object.entries(profile) as [keyof EditableProfile, EditableProfile[keyof EditableProfile]][])
                                                             .filter(([, value]) => isNonNullish(value))
-                                                            .map(([key, value]) => updatePresetField(actualIndex, key, value, section, guildId))
+                                                            .map(([key, value]) => updatePresetField(actualIndex, key, value))
                                                     );
                                                     onUpdate();
                                                 }}
@@ -168,7 +160,7 @@ export function PresetList({
                                                     id="move-up"
                                                     label="Move Up"
                                                     action={() => {
-                                                        movePreset(actualIndex, actualIndex - 1, section, guildId);
+                                                        movePreset(actualIndex, actualIndex - 1);
                                                         onUpdate();
                                                     }}
                                                 />
@@ -178,7 +170,7 @@ export function PresetList({
                                                     id="move-down"
                                                     label="Move Down"
                                                     action={() => {
-                                                        movePreset(actualIndex, actualIndex + 1, section, guildId);
+                                                        movePreset(actualIndex, actualIndex + 1);
                                                         onUpdate();
                                                     }}
                                                 />
@@ -188,7 +180,7 @@ export function PresetList({
                                                     id="move-to-page-1"
                                                     label="Move to Page 1"
                                                     action={() => {
-                                                        movePreset(actualIndex, 0, section, guildId);
+                                                        movePreset(actualIndex, 0);
                                                         onPageChange(1);
                                                         onUpdate();
                                                     }}
@@ -200,7 +192,7 @@ export function PresetList({
                                                 label="Delete"
                                                 color="danger"
                                                 action={async () => {
-                                                    await deletePreset(actualIndex, section, guildId);
+                                                    await deletePreset(actualIndex);
                                                     onUpdate();
                                                 }}
                                             />

--- a/src/equicordplugins/profileSets/components/presetList.tsx
+++ b/src/equicordplugins/profileSets/components/presetList.tsx
@@ -66,7 +66,7 @@ export function PresetList({
 
                 return (
                     <div
-                        key={actualIndex}
+                        key={`${preset.timestamp}-${preset.name}`}
                         tabIndex={isRenaming ? -1 : 0}
                         role="button"
                         onClick={() => {
@@ -78,14 +78,14 @@ export function PresetList({
                                 onLoad(actualIndex);
                             }
                         }}
-                        className={classes(cl("row"), isSelected ? "selected" : "")}
+                        className={classes(cl("row"), isSelected && cl("row-selected"))}
                         style={preset.bannerDataUrl ? { backgroundImage: `url(${preset.bannerDataUrl})` } : undefined}
                     >
                         <div className={cl("avatar-url")}>
                             {preset.avatarDataUrl && (
                                 <img
                                     src={preset.avatarDataUrl}
-                                    alt=""
+                                    alt={`${preset.name} avatar`}
                                     className={cl("avatar")}
                                     style={{ width: `${avatarSize}px`, height: `${avatarSize}px` }}
                                 />

--- a/src/equicordplugins/profileSets/components/presetManager.tsx
+++ b/src/equicordplugins/profileSets/components/presetManager.tsx
@@ -7,23 +7,18 @@
 import { Button } from "@components/Button";
 import { Heading } from "@components/Heading";
 import { classes } from "@utils/misc";
-import { openModal, React, SelectedGuildStore, TextInput, useStateFromStores } from "@webpack/common";
+import { openModal, React, TextInput } from "@webpack/common";
 
 import { cl, settings } from "../index";
 import { exportPresets, ImportDecision, importPresets, savePreset } from "../utils/actions";
 import { loadPresetAsPending } from "../utils/profile";
-import { loadPresets, presets, PresetSection, setCurrentPresetIndex } from "../utils/storage";
+import { loadPresets, presets, setCurrentPresetIndex } from "../utils/storage";
 import { ImportProfilesModal } from "./confirmModal";
 import { PresetList } from "./presetList";
 
 const PRESETS_PER_PAGE = 5;
 
-type PresetManagerProps = {
-    section?: PresetSection;
-    guildId?: string;
-};
-
-export function PresetManager({ section, guildId }: PresetManagerProps) {
+export function PresetManager({ userId }: { userId: string; }) {
     const [presetName, setPresetName] = React.useState("");
     const [, forceUpdate] = React.useReducer(x => x + 1, 0);
     const [isSaving, setIsSaving] = React.useState(false);
@@ -32,29 +27,19 @@ export function PresetManager({ section, guildId }: PresetManagerProps) {
     const [selectedPreset, setSelectedPreset] = React.useState<number>(-1);
     const [searchMode, setSearchMode] = React.useState(false);
     const lastRandomIndexRef = React.useRef<number>(-1);
-    const resolvedSection: PresetSection = section ?? "main";
-    const isServerSection = resolvedSection === "server";
-    const lastSelectedGuildId = useStateFromStores(
-        [SelectedGuildStore],
-        () => SelectedGuildStore.getLastSelectedGuildId() ?? SelectedGuildStore.getGuildId()
-    );
-    const resolvedGuildId = isServerSection ? (guildId ?? lastSelectedGuildId ?? undefined) : undefined;
-    const canUseGuild = !isServerSection || Boolean(resolvedGuildId);
 
     React.useEffect(() => {
         let isActive = true;
         (async () => {
-            await loadPresets(resolvedSection);
+            await loadPresets();
             if (!isActive) return;
             setSelectedPreset(-1);
             setCurrentPage(1);
             setPageInput("1");
             forceUpdate();
         })();
-        return () => {
-            isActive = false;
-        };
-    }, [resolvedGuildId, resolvedSection]);
+        return () => { isActive = false; };
+    }, [userId]);
 
     const filteredPresets = !searchMode
         ? presets
@@ -72,11 +57,10 @@ export function PresetManager({ section, guildId }: PresetManagerProps) {
     };
 
     const handleSavePreset = async () => {
-        if (!canUseGuild) return;
         const trimmedName = presetName.trim();
         if (!trimmedName) return;
         setIsSaving(true);
-        await savePreset(trimmedName, resolvedSection, resolvedGuildId);
+        await savePreset(trimmedName);
         setPresetName("");
         setIsSaving(false);
         const newTotalPages = Math.ceil(presets.length / PRESETS_PER_PAGE);
@@ -87,29 +71,17 @@ export function PresetManager({ section, guildId }: PresetManagerProps) {
     const applyPreset = (index: number) => {
         setSelectedPreset(index);
         setCurrentPresetIndex(index);
-        loadPresetAsPending(presets[index], resolvedGuildId, {
-            isGuildProfile: resolvedSection === "server"
-        });
+        loadPresetAsPending(presets[index]);
         forceUpdate();
     };
 
     const handleLoadPreset = (index: number) => {
-        if (!canUseGuild) return;
         applyPreset(index);
     };
 
-    const selectRandomPreset = (sectionType: PresetSection) => {
-        const availablePresets = presets;
-        if (!availablePresets.length) return null;
-        const randomIndex = Math.floor(Math.random() * availablePresets.length);
-        return { preset: availablePresets[randomIndex], index: randomIndex, section: sectionType };
-    };
-
     const handleRandomPreset = () => {
-        if (!canUseGuild) return;
-        const selection = selectRandomPreset(resolvedSection);
-        if (!selection) return;
-        let nextIndex = selection.index;
+        if (!presets.length) return;
+        let nextIndex = Math.floor(Math.random() * presets.length);
         if (presets.length > 1 && nextIndex === lastRandomIndexRef.current) {
             let attempts = 0;
             while (attempts < 5 && nextIndex === lastRandomIndexRef.current) {
@@ -127,7 +99,7 @@ export function PresetManager({ section, guildId }: PresetManagerProps) {
                 <ImportProfilesModal
                     {...props}
                     title="Import Profiles"
-                    message={`You have ${existingCount} existing profiles in this section. Do you want to override them or merge with imported profiles?`}
+                    message={`You have ${existingCount} existing profiles. Do you want to override them or merge with imported profiles?`}
                     onOverride={() => resolve("override")}
                     onMerge={() => resolve("merge")}
                     onCancel={() => resolve("cancel")}
@@ -141,7 +113,7 @@ export function PresetManager({ section, guildId }: PresetManagerProps) {
     const shouldShowPagination = filteredPresets.length > PRESETS_PER_PAGE;
 
     return (
-        <div className={classes(cl("section"), isServerSection ? cl("section-server") : "")} >
+        <div className={cl("section")}>
             <Heading tag="h3" className={cl("heading")}>
                 Saved Profiles
             </Heading>
@@ -159,7 +131,7 @@ export function PresetManager({ section, guildId }: PresetManagerProps) {
                 {!searchMode && (
                     <Button
                         size="small"
-                        disabled={isSaving || !presetName.trim() || !canUseGuild}
+                        disabled={isSaving || !presetName.trim()}
                         onClick={handleSavePreset}
                         className={cl("search-button")}
                     >
@@ -182,24 +154,21 @@ export function PresetManager({ section, guildId }: PresetManagerProps) {
                     size="small"
                     variant="secondary"
                     onClick={handleRandomPreset}
-                    disabled={!presets.length || !canUseGuild}
+                    disabled={!presets.length}
                 >
                     Random
                 </Button>
-            </div>
-            <div className={cl("import")}>
                 <Button
                     size="small"
                     variant="secondary"
-                    onClick={() => importPresets(forceUpdate, showImportPrompt, resolvedSection, resolvedGuildId)}
-                    disabled={!canUseGuild}
+                    onClick={() => importPresets(forceUpdate, showImportPrompt)}
                 >
                     Import
                 </Button>
                 <Button
                     size="small"
                     variant="secondary"
-                    onClick={() => exportPresets(resolvedSection)}
+                    onClick={() => exportPresets()}
                 >
                     Export All
                 </Button>
@@ -222,8 +191,6 @@ export function PresetManager({ section, guildId }: PresetManagerProps) {
                             }
                             forceUpdate();
                         }}
-                        guildId={resolvedGuildId}
-                        section={resolvedSection}
                         currentPage={currentPage}
                         onPageChange={handlePageChange}
                     />
@@ -271,9 +238,6 @@ export function PresetManager({ section, guildId }: PresetManagerProps) {
                 </>
             )}
             <hr className={cl("block")} />
-            {resolvedSection === "server" && (
-                <hr className={cl("block")} />
-            )}
         </div>
     );
 }

--- a/src/equicordplugins/profileSets/components/presetManager.tsx
+++ b/src/equicordplugins/profileSets/components/presetManager.tsx
@@ -44,7 +44,7 @@ export function PresetManager({ userId }: { userId: string; }) {
 
     const filteredPresets = !searchMode
         ? presets
-        : presets.filter(preset => preset.name.toLowerCase().includes(presetName.toLowerCase()));
+        : presets.filter(preset => preset.name?.toLowerCase().includes(presetName.toLowerCase()));
 
     const totalPages = Math.ceil(filteredPresets.length / PRESETS_PER_PAGE);
     const startIndex = (currentPage - 1) * PRESETS_PER_PAGE;

--- a/src/equicordplugins/profileSets/components/presetManager.tsx
+++ b/src/equicordplugins/profileSets/components/presetManager.tsx
@@ -7,7 +7,7 @@
 import { Button } from "@components/Button";
 import { Heading } from "@components/Heading";
 import { classes } from "@utils/misc";
-import { openModal, React, TextInput } from "@webpack/common";
+import { openModal, React, showToast, TextInput, Toasts } from "@webpack/common";
 
 import { cl, settings } from "../index";
 import { exportPresets, ImportDecision, importPresets, savePreset } from "../utils/actions";
@@ -60,18 +60,26 @@ export function PresetManager({ userId }: { userId: string; }) {
         const trimmedName = presetName.trim();
         if (!trimmedName) return;
         setIsSaving(true);
-        await savePreset(trimmedName);
-        setPresetName("");
-        setIsSaving(false);
-        const newTotalPages = Math.ceil(presets.length / PRESETS_PER_PAGE);
-        handlePageChange(newTotalPages);
-        forceUpdate();
+        try {
+            await savePreset(trimmedName);
+            setPresetName("");
+            const newTotalPages = Math.ceil(presets.length / PRESETS_PER_PAGE);
+            handlePageChange(newTotalPages);
+            forceUpdate();
+        } catch (err) {
+            showToast("Failed to save profile.", Toasts.Type.FAILURE);
+        } finally {
+            setIsSaving(false);
+        }
     };
 
     const applyPreset = (index: number) => {
         setSelectedPreset(index);
         setCurrentPresetIndex(index);
-        loadPresetAsPending(presets[index]);
+        loadPresetAsPending(presets[index]).catch(() => {
+            showToast("Failed to load profile preset.", Toasts.Type.FAILURE);
+        });
+        showToast("Preset applied. Review and save in Settings.", Toasts.Type.SUCCESS);
         forceUpdate();
     };
 
@@ -212,8 +220,8 @@ export function PresetManager({ userId }: { userId: string; }) {
                                     onChange={e => {
                                         const { value } = e.target;
                                         setPageInput(value);
-                                        const num = parseInt(value);
-                                        if (!isNaN(num) && num >= 1 && num <= totalPages) {
+                                        const num = Number(value);
+                                        if (Number.isInteger(num) && num >= 1 && num <= totalPages) {
                                             setCurrentPage(num);
                                         }
                                     }}

--- a/src/equicordplugins/profileSets/components/presetManager.tsx
+++ b/src/equicordplugins/profileSets/components/presetManager.tsx
@@ -27,6 +27,7 @@ export function PresetManager({ userId }: { userId: string; }) {
     const [selectedPreset, setSelectedPreset] = React.useState<number>(-1);
     const [searchMode, setSearchMode] = React.useState(false);
     const lastRandomIndexRef = React.useRef<number>(-1);
+    const generationRef = React.useRef(0);
 
     React.useEffect(() => {
         let isActive = true;
@@ -76,10 +77,14 @@ export function PresetManager({ userId }: { userId: string; }) {
     const applyPreset = (index: number) => {
         setSelectedPreset(index);
         setCurrentPresetIndex(index);
-        loadPresetAsPending(presets[index]).catch(() => {
+        const gen = ++generationRef.current;
+        loadPresetAsPending(presets[index]).then(() => {
+            if (generationRef.current !== gen) return;
+            showToast("Preset applied. Review and save in Settings.", Toasts.Type.SUCCESS);
+        }).catch(() => {
+            if (generationRef.current !== gen) return;
             showToast("Failed to load profile preset.", Toasts.Type.FAILURE);
         });
-        showToast("Preset applied. Review and save in Settings.", Toasts.Type.SUCCESS);
         forceUpdate();
     };
 

--- a/src/equicordplugins/profileSets/components/presetManager.tsx
+++ b/src/equicordplugins/profileSets/components/presetManager.tsx
@@ -78,7 +78,7 @@ export function PresetManager({ userId }: { userId: string; }) {
         setSelectedPreset(index);
         setCurrentPresetIndex(index);
         const gen = ++generationRef.current;
-        loadPresetAsPending(presets[index]).then(() => {
+        loadPresetAsPending(presets[index], { generation: generationRef }).then(() => {
             if (generationRef.current !== gen) return;
             showToast("Preset applied. Review and save in Settings.", Toasts.Type.SUCCESS);
         }).catch(() => {

--- a/src/equicordplugins/profileSets/index.tsx
+++ b/src/equicordplugins/profileSets/index.tsx
@@ -14,7 +14,6 @@ import definePlugin, { OptionType } from "@utils/types";
 import { React, UserStore } from "@webpack/common";
 
 import { PresetManager } from "./components/presetManager";
-import { loadPresets } from "./utils/storage";
 
 export const cl = classNameFactory("vc-profile-presets-");
 
@@ -50,9 +49,7 @@ export default definePlugin({
             }
         }
     ],
-    start() {
-        loadPresets();
-    },
+    start() {}
     pushProfilesTab(userId: string, sections: { push: (entry: { text: string; section: string; }) => void; }) {
         if (userId !== UserStore.getCurrentUser()?.id) return;
         sections.push({ text: "Profiles", section: "PROFILES" });

--- a/src/equicordplugins/profileSets/index.tsx
+++ b/src/equicordplugins/profileSets/index.tsx
@@ -7,15 +7,17 @@
 import "./styles.css";
 
 import { definePluginSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
 import { EquicordDevs } from "@utils/constants";
 import { classNameFactory } from "@utils/css";
 import definePlugin, { OptionType } from "@utils/types";
-import { React } from "@webpack/common";
+import { React, UserStore } from "@webpack/common";
 
 import { PresetManager } from "./components/presetManager";
-import { loadPresets, PresetSection } from "./utils/storage";
+import { loadPresets } from "./utils/storage";
 
 export const cl = classNameFactory("vc-profile-presets-");
+
 export const settings = definePluginSettings({
     avatarSize: {
         type: OptionType.SLIDER,
@@ -27,31 +29,35 @@ export const settings = definePluginSettings({
 });
 
 export default definePlugin({
-    name: "ProfileSets",
-    description: "Allows you to save and load different profile presets, via the Profile Section in Settings.",
+    name: "Profiles",
+    description: "Save and load profile presets directly from your profile modal.",
     tags: ["Appearance", "Customisation", "Utility"],
-    authors: [EquicordDevs.omaw, EquicordDevs.justjxke],
+    authors: [EquicordDevs.Jahbas, EquicordDevs.omaw, EquicordDevs.justjxke],
     settings,
     patches: [
         {
-            find: "DefaultCustomizationSections: user cannot be undefined",
+            find: "#{intl::USER_PROFILE_ACTIVITY}",
             replacement: {
-                match: /return.{0,50}children:\[(?=.{0,50},\{placeholder:)/,
-                replace: "$&$self.renderPresetSection(\"main\"),"
+                match: /(\i)\.id!==\i\?\.id&&\i&&\(.{0,300}\.MUTUAL_GUILDS\}\)\)(?=,(\i))/,
+                replace: '$&,$self.pushProfilesTab($1.id,$2)',
             }
         },
         {
-            find: "USER_SETTINGS_GUILD_PROFILE)",
+            find: ".WIDGETS?",
             replacement: {
-                match: /guildId:(\i\.id),onChange:(\i)\}\)(?=.{0,25}profilePreviewTitle:)/,
-                replace: 'guildId:$1,onChange:$2}),$self.renderPresetSection("server",$1)'
+                match: /(\i)===\i\.\i\.WISHLIST/,
+                replace: '$1==="PROFILES"?$self.renderProfilesTab(arguments[0]):$&',
             }
         }
     ],
     start() {
-        loadPresets("main");
+        loadPresets();
     },
-    renderPresetSection(section: PresetSection, guildId?: string) {
-        return <PresetManager section={section} guildId={guildId} />;
-    }
+    pushProfilesTab(userId: string, sections: { push: (entry: { text: string; section: string; }) => void; }) {
+        if (userId !== UserStore.getCurrentUser()?.id) return;
+        sections.push({ text: "Profiles", section: "PROFILES" });
+    },
+    renderProfilesTab: ErrorBoundary.wrap((props: { user: { id: string; }; }) => {
+        return <PresetManager userId={props.user.id} />;
+    }, { noop: true }),
 });

--- a/src/equicordplugins/profileSets/index.tsx
+++ b/src/equicordplugins/profileSets/index.tsx
@@ -49,7 +49,7 @@ export default definePlugin({
             }
         }
     ],
-    start() {}
+    start() {},
     pushProfilesTab(userId: string, sections: { push: (entry: { text: string; section: string; }) => void; }) {
         if (userId !== UserStore.getCurrentUser()?.id) return;
         sections.push({ text: "Profiles", section: "PROFILES" });

--- a/src/equicordplugins/profileSets/styles.css
+++ b/src/equicordplugins/profileSets/styles.css
@@ -167,7 +167,7 @@
     box-shadow: 0 0 0 2px var(--brand-experiment-30a);
 }
 
-.vc-profile-presets-row.selected::before {
+.vc-profile-presets-row-selected::before {
     opacity: 0.7;
     background: var(--background-modifier-selected);
 }

--- a/src/equicordplugins/profileSets/styles.css
+++ b/src/equicordplugins/profileSets/styles.css
@@ -1,15 +1,6 @@
 .vc-profile-presets-section {
-    margin-bottom: 20px;
-    padding: 0;
-    background-color: transparent;
-    max-width: 660px;
+    padding: 16px 0;
     width: 100%;
-    min-width: 0;
-    align-self: flex-start;
-}
-
-.vc-profile-presets-section-server {
-    max-width: 660px;
 }
 
 .vc-profile-presets-heading {
@@ -24,7 +15,6 @@
 
 .vc-profile-presets-text-input {
     width: 100%;
-    max-width: 500px;
     min-width: 0;
     height: 38px;
     padding: 1px 12px;
@@ -59,7 +49,7 @@
 .vc-profile-presets-search {
     display: flex;
     gap: 8px;
-    margin-bottom: 12px;
+    margin-bottom: 4px;
     flex-wrap: wrap;
 }
 
@@ -73,11 +63,7 @@
     align-items: center;
     gap: 8px;
     margin-top: 12px;
-}
-
-.vc-profile-presets-section-server .vc-profile-presets-pagination {
-    width: 300px;
-    max-width: 100%;
+    width: 100%;
 }
 
 .vc-profile-presets-page {
@@ -130,14 +116,11 @@
     flex-direction: column;
     gap: 4px;
     margin-bottom: 12px;
-    padding: 12px;
+    padding: 12px 0;
     background-color: var(--background-secondary);
     border-radius: 8px;
     border: 2px solid var(--background-modifier-accent);
-    min-width: 0;
     width: 100%;
-    max-width: 660px;
-    align-self: flex-start;
 }
 
 .vc-profile-presets-row {
@@ -145,16 +128,33 @@
     justify-content: space-between;
     align-items: center;
     padding: 10px 12px;
-    background-color: var(--background-primary);
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.15s ease;
     border: 2px solid transparent;
     outline: none;
-    min-width: 0;
     width: 100%;
-    max-width: 300px;
-    align-self: flex-start;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    position: relative;
+    min-height: 50px;
+    overflow: hidden;
+}
+
+.vc-profile-presets-row::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: var(--background-primary);
+    opacity: 0.85;
+    border-radius: 6px;
+    z-index: 0;
+    transition: opacity 0.15s ease;
+}
+
+.vc-profile-presets-row:hover::before {
+    opacity: 0.55;
 }
 
 .vc-profile-presets-row:hover {
@@ -167,8 +167,14 @@
     box-shadow: 0 0 0 2px var(--brand-experiment-30a);
 }
 
-.vc-profile-presets-row.selected {
-    background-color: var(--background-modifier-selected);
+.vc-profile-presets-row.selected::before {
+    opacity: 0.7;
+    background: var(--background-modifier-selected);
+}
+
+.vc-profile-presets-row > * {
+    position: relative;
+    z-index: 1;
 }
 
 .vc-profile-presets-avatar {

--- a/src/equicordplugins/profileSets/utils/actions.ts
+++ b/src/equicordplugins/profileSets/utils/actions.ts
@@ -10,7 +10,7 @@ import { findStoreLazy } from "@webpack";
 import { showToast, Toasts } from "@webpack/common";
 
 import { getCurrentProfile } from "./profile";
-import { addPreset, movePresetInArray, presets, PresetSection, type ProfilePresetEx, removePreset, replaceAllPresets, savePresetsData, updatePreset } from "./storage";
+import { addPreset, movePresetInArray, presets, type ProfilePresetEx, removePreset, replaceAllPresets, savePresetsData, updatePreset } from "./storage";
 
 const UserProfileSettingsStore = findStoreLazy("UserProfileSettingsStore");
 
@@ -19,19 +19,17 @@ function isImageInput(value: unknown): value is string | { imageUri: string; } {
     return typeof value === "object" && isNonNullish(value) && "imageUri" in value && typeof (value as { imageUri: unknown }).imageUri === "string";
 }
 
-function getFreshPendingAvatar(section: PresetSection, guildId?: string): string | null {
-    const pending = (section === "server" && guildId
-        ? UserProfileSettingsStore.getPendingChanges?.(guildId)
-        : UserProfileSettingsStore.getPendingChanges?.()) ?? {};
+function getFreshPendingAvatar(): string | null {
+    const pending = UserProfileSettingsStore.getPendingChanges?.() ?? {};
     const pendingObj = pending as Record<string, unknown>;
     const selected = [pendingObj.pendingAvatar].find(isImageInput);
     if (!selected) return null;
     return typeof selected === "string" ? selected : selected.imageUri;
 }
 
-export async function savePreset(name: string, section: PresetSection, guildId?: string) {
-    const profile = await getCurrentProfile(guildId, { isGuildProfile: section === "server" });
-    const freshPendingAvatar = getFreshPendingAvatar(section, guildId);
+export async function savePreset(name: string) {
+    const profile = await getCurrentProfile();
+    const freshPendingAvatar = getFreshPendingAvatar();
     const effectiveAvatar = freshPendingAvatar ?? profile.avatarDataUrl ?? null;
 
     const newPreset: ProfilePresetEx = {
@@ -41,18 +39,15 @@ export async function savePreset(name: string, section: PresetSection, guildId?:
         avatarDataUrl: effectiveAvatar,
     };
     addPreset(newPreset);
-    await savePresetsData(section);
+    await savePresetsData();
 }
 
 export async function updatePresetField<K extends keyof Omit<ProfilePreset, "name" | "timestamp">>(
     index: number,
     field: K,
     value: Omit<ProfilePreset, "name" | "timestamp">[K],
-    section: PresetSection,
-    guildId?: string
 ) {
     if (index < 0 || index >= presets.length) return;
-    void guildId;
 
     const updatedPreset = {
         ...presets[index],
@@ -60,38 +55,35 @@ export async function updatePresetField<K extends keyof Omit<ProfilePreset, "nam
         timestamp: Date.now()
     };
     updatePreset(index, updatedPreset);
-    await savePresetsData(section);
+    await savePresetsData();
 }
 
-export async function deletePreset(index: number, section: PresetSection, guildId?: string) {
+export async function deletePreset(index: number) {
     if (index < 0 || index >= presets.length) return;
-
     removePreset(index);
-    await savePresetsData(section);
+    await savePresetsData();
 }
 
-export async function movePreset(fromIndex: number, toIndex: number, section: PresetSection, guildId?: string) {
+export async function movePreset(fromIndex: number, toIndex: number) {
     if (fromIndex < 0 || fromIndex >= presets.length || toIndex < 0 || toIndex >= presets.length) return;
-
     movePresetInArray(fromIndex, toIndex);
-    await savePresetsData(section);
+    await savePresetsData();
 }
 
-export async function renamePreset(index: number, newName: string, section: PresetSection, guildId?: string) {
+export async function renamePreset(index: number, newName: string) {
     if (index < 0 || index >= presets.length || !newName.trim()) return;
-
     const updatedPreset = { ...presets[index], name: newName.trim() };
     updatePreset(index, updatedPreset);
-    await savePresetsData(section);
+    await savePresetsData();
 }
 
-export function exportPresets(section: PresetSection) {
+export function exportPresets() {
     const dataStr = JSON.stringify(presets, null, 2);
     const dataBlob = new Blob([dataStr], { type: "application/json" });
     const url = URL.createObjectURL(dataBlob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = `profile-presets-${section}-${Date.now()}.json`;
+    link.download = `profiles-${Date.now()}.json`;
     link.click();
     URL.revokeObjectURL(url);
 }
@@ -101,8 +93,6 @@ export type ImportDecision = "override" | "merge" | "cancel";
 export async function importPresets(
     forceUpdate: () => void,
     onImportPrompt: (existingCount: number) => Promise<ImportDecision>,
-    section: PresetSection,
-    guildId?: string
 ) {
     const input = document.createElement("input");
     input.type = "file";
@@ -116,9 +106,7 @@ export async function importPresets(
             const text = await file.text();
             const importedPresets = JSON.parse(text);
 
-            if (!Array.isArray(importedPresets)) {
-                return;
-            }
+            if (!Array.isArray(importedPresets)) return;
 
             if (presets.length > 0) {
                 const decision = await onImportPrompt(presets.length);
@@ -133,7 +121,7 @@ export async function importPresets(
                 replaceAllPresets(importedPresets);
             }
 
-            await savePresetsData(section);
+            await savePresetsData();
             forceUpdate();
         } catch {
             showToast("Failed to import presets. The file might be invalid.", Toasts.Type.FAILURE);

--- a/src/equicordplugins/profileSets/utils/actions.ts
+++ b/src/equicordplugins/profileSets/utils/actions.ts
@@ -5,6 +5,7 @@
  */
 
 import { isNonNullish } from "@utils/guards";
+import { Logger } from "@utils/Logger";
 import { ProfilePreset } from "@vencord/discord-types";
 import { findStoreLazy } from "@webpack";
 import { showToast, Toasts } from "@webpack/common";
@@ -123,7 +124,8 @@ export async function importPresets(
 
             await savePresetsData();
             forceUpdate();
-        } catch {
+        } catch (err) {
+            new Logger("ProfilePresets").error("Failed to import presets", err);
             showToast("Failed to import presets. The file might be invalid.", Toasts.Type.FAILURE);
         }
     };

--- a/src/equicordplugins/profileSets/utils/profile.ts
+++ b/src/equicordplugins/profileSets/utils/profile.ts
@@ -42,6 +42,7 @@ export type LoadPresetOptions = {
     skipGlobalName?: boolean;
     skipBio?: boolean;
     skipPronouns?: boolean;
+    generation?: { current: number };
 };
 
 function dispatch(type: string, payload: Record<string, unknown>) {
@@ -291,9 +292,14 @@ function nameplateEq(a: { skuId?: string | number | null; asset?: string | null;
 }
 
 export async function loadPresetAsPending(preset: ProfilePreset, options: LoadPresetOptions = {}) {
+        const genSnapshot = options.generation?.current ?? 0;
+        const isStale = () => options.generation && options.generation.current !== genSnapshot;
+
         const current = await getCurrentProfile();
+        if (isStale()) return;
         const pendingChanges = UserProfileSettingsStore.getPendingChanges();
         const setPending = (payload: Record<string, unknown>) => {
+            if (isStale()) return;
             const cleanPayload = Object.fromEntries(Object.entries(payload).filter(([, v]) => v !== undefined));
             if (!Object.keys(cleanPayload).length) return;
             setPendingChanges(cleanPayload);
@@ -317,7 +323,7 @@ export async function loadPresetAsPending(preset: ProfilePreset, options: LoadPr
                     ? (avatarPayload as { imageUri?: unknown; }).imageUri
                     : null;
                 if (isNonEmptyString(avatarImageUri)) {
-                    openProfileImagePreview("AVATAR", { ...Object(avatarPayload), imageUri: avatarImageUri });
+                    if (!isStale()) openProfileImagePreview("AVATAR", { ...Object(avatarPayload), imageUri: avatarImageUri });
                 } else {
                     setPending({ pendingAvatar: avatarPayload });
                 }
@@ -337,7 +343,7 @@ export async function loadPresetAsPending(preset: ProfilePreset, options: LoadPr
                 ? (bannerPayload as { imageUri?: unknown; }).imageUri
                 : null;
             if (isNonEmptyString(bannerImageUri)) {
-                openProfileImagePreview("BANNER", { ...Object(bannerPayload), imageUri: bannerImageUri });
+                if (!isStale()) openProfileImagePreview("BANNER", { ...Object(bannerPayload), imageUri: bannerImageUri });
             } else {
                 setPending({ pendingBanner: bannerPayload });
             }
@@ -389,7 +395,7 @@ export async function loadPresetAsPending(preset: ProfilePreset, options: LoadPr
         }
 
         if (preset.customStatus && !customStatusEq(preset.customStatus, current.customStatus)) {
-            CustomStatusSettings?.updateSetting?.({
+            if (!isStale()) CustomStatusSettings?.updateSetting?.({
                 text: preset.customStatus?.text ?? "",
                 expiresAtMs: preset.customStatus?.expiresAtMs ?? "0",
                 emojiId: preset.customStatus?.emojiId ?? "0",

--- a/src/equicordplugins/profileSets/utils/profile.ts
+++ b/src/equicordplugins/profileSets/utils/profile.ts
@@ -38,36 +38,29 @@ type DisplayNameStylesLike = DisplayNameStyles & {
     effectId?: number;
 };
 
-type CurrentProfileOptions = {
-    isGuildProfile?: boolean;
-};
-
-type LoadPresetOptions = {
+export type LoadPresetOptions = {
     skipGlobalName?: boolean;
     skipBio?: boolean;
     skipPronouns?: boolean;
-    isGuildProfile?: boolean;
 };
 
 function dispatch(type: string, payload: Record<string, unknown>) {
     FluxDispatcher.dispatch({ type, ...payload });
 }
 
-function setPendingChanges(payload: Record<string, unknown>, guildId?: string) {
-    dispatch("USER_PROFILE_SETTINGS_SET_PENDING_CHANGES", guildId ? { guildId, ...payload } : payload);
+function setPendingChanges(payload: Record<string, unknown>) {
+    dispatch("USER_PROFILE_SETTINGS_SET_PENDING_CHANGES", payload);
 }
 
 function openProfileImagePreview(
     uploadType: "AVATAR" | "BANNER",
     image: Extract<ImageInput, { imageUri: string; }>,
-    guildId?: string
 ) {
     dispatch("PROFILE_CUSTOMIZATION_OPEN_PREVIEW_MODAL", {
         image,
         file: {},
         uploadType,
-        guildId,
-        analyticsSource: guildId ? "user settings guild profile" : "user settings user profile",
+        analyticsSource: "user settings user profile",
         isTryItOut: false
     });
 }
@@ -122,7 +115,7 @@ export async function imageUrlToBase64(url: string): Promise<string | null> {
     }
 }
 
-async function processImage(imageData: ImageInput, userId: string, type: "avatar" | "banner", guildId?: string, useGuildPath?: boolean): Promise<string | null> {
+async function processImage(imageData: ImageInput, userId: string, type: "avatar" | "banner"): Promise<string | null> {
     if (!imageData) return null;
 
     if (typeof imageData === "object" && isNonEmptyString(imageData?.imageUri)) {
@@ -138,46 +131,28 @@ async function processImage(imageData: ImageInput, userId: string, type: "avatar
         const isAnimated = imageData.startsWith("a_");
         const size = type === "banner" ? 1024 : 512;
         const urlPath = type === "banner" ? "banners" : "avatars";
-        const guildPath = guildId ? `guilds/${guildId}/users/${userId}/${type === "banner" ? "banners" : "avatars"}` : urlPath;
-        const guildUrl = `https://cdn.discordapp.com/${guildPath}/${imageData}.${isAnimated ? "gif" : "png"}?size=${size}`;
-        const globalUrl = `https://cdn.discordapp.com/${urlPath}/${userId}/${imageData}.${isAnimated ? "gif" : "png"}?size=${size}`;
-        if (useGuildPath && guildId) {
-            const guildResult = await imageUrlToBase64(guildUrl);
-            if (guildResult) return guildResult;
-        }
-        return await imageUrlToBase64(globalUrl);
+        const url = `https://cdn.discordapp.com/${urlPath}/${userId}/${imageData}.${isAnimated ? "gif" : "png"}?size=${size}`;
+        return await imageUrlToBase64(url);
     }
 
     return null;
 }
 
-export async function getCurrentProfile(guildId?: string, options: CurrentProfileOptions = {}): Promise<Omit<ProfilePreset, "name" | "timestamp">> {
+export async function getCurrentProfile(): Promise<Omit<ProfilePreset, "name" | "timestamp">> {
     const currentUser = UserStore.getCurrentUser();
     const baseProfile = UserProfileStore.getUserProfile(currentUser.id);
-    const isGuildProfile = options.isGuildProfile ?? Boolean(guildId);
-    const effectiveGuildId = isGuildProfile ? guildId : undefined;
-    const guildProfile = effectiveGuildId ? UserProfileStore.getGuildMemberProfile(currentUser.id, effectiveGuildId) : null;
-    const userProfile = guildProfile ?? baseProfile;
     const userAny = currentUser;
-    const guildMember = effectiveGuildId ? GuildMemberStore.getMember(effectiveGuildId, currentUser.id) : null;
 
-    const pendingChangesDefault: PendingChanges = UserProfileSettingsStore.getPendingChanges() ?? {};
-    const pendingChangesForGuild: PendingChanges = UserProfileSettingsStore.getPendingChanges(effectiveGuildId) ?? {};
-    const pendingChanges: PendingChanges = isGuildProfile && Object.keys(pendingChangesForGuild).length > 0
-        ? pendingChangesForGuild
-        : pendingChangesDefault;
+    const pendingChanges: PendingChanges = UserProfileSettingsStore.getPendingChanges() ?? {};
     const customStatusSetting = CustomStatusSettings.getSetting();
-    const customStatus = isGuildProfile
-        ? null
-        : {
-            text: customStatusSetting?.text ?? "",
-            emojiId: customStatusSetting?.emojiId ?? "0",
-            emojiName: customStatusSetting?.emojiName ?? "",
-            expiresAtMs: customStatusSetting?.expiresAtMs ?? "0"
-        };
+    const customStatus = {
+        text: customStatusSetting?.text ?? "",
+        emojiId: customStatusSetting?.emojiId ?? "0",
+        emojiName: customStatusSetting?.emojiName ?? "",
+        expiresAtMs: customStatusSetting?.expiresAtMs ?? "0"
+    };
 
-    const avatarDecorationSource = pendingChanges.pendingAvatarDecoration
-        ?? (isGuildProfile ? guildMember?.avatarDecoration : userAny.avatarDecorationData);
+    const avatarDecorationSource = pendingChanges.pendingAvatarDecoration ?? userAny.avatarDecorationData;
     const avatarDecoration = hasAvatarDecoration(avatarDecorationSource)
         ? {
             ...avatarDecorationSource,
@@ -187,7 +162,7 @@ export async function getCurrentProfile(guildId?: string, options: CurrentProfil
         : null;
 
     let profileEffect: ProfileEffect | null = null;
-    const effectToUse = pendingChanges.pendingProfileEffect ?? userProfile?.profileEffect;
+    const effectToUse = pendingChanges.pendingProfileEffect ?? baseProfile?.profileEffect;
 
     if (effectToUse) {
         if (effectToUse.skuId && effectToUse.effects) {
@@ -204,7 +179,7 @@ export async function getCurrentProfile(guildId?: string, options: CurrentProfil
                 type: effectToUse.type || 1
             };
         } else if (effectToUse.skuId) {
-            const collectibles = userProfile?.collectibles;
+            const collectibles = baseProfile?.collectibles;
             const collectible = collectibles?.find(c => c?.skuId === effectToUse.skuId);
             if (collectible) {
                 profileEffect = {
@@ -223,8 +198,7 @@ export async function getCurrentProfile(guildId?: string, options: CurrentProfil
         }
     }
 
-    const nameplateToUse = pendingChanges.pendingNameplate
-        ?? (isGuildProfile ? guildMember?.collectibles?.nameplate : userAny.collectibles?.nameplate);
+    const nameplateToUse = pendingChanges.pendingNameplate ?? userAny.collectibles?.nameplate;
     const nameplate = nameplateToUse ? {
         skuId: nameplateToUse.skuId,
         asset: nameplateToUse.asset,
@@ -233,49 +207,40 @@ export async function getCurrentProfile(guildId?: string, options: CurrentProfil
         type: nameplateToUse.type || 2
     } : null;
 
-    const savedDisplayNameStyles = isGuildProfile
-        ? (guildMember?.displayNameStyles ?? userAny.displayNameStyles)
-        : userAny.displayNameStyles;
+    const savedDisplayNameStyles = userAny.displayNameStyles;
     const displayNameStylesToUse = pendingChanges.pendingDisplayNameStyles ?? savedDisplayNameStyles;
     const displayNameStyles = normalizeDisplayNameStyles(displayNameStylesToUse);
 
     const { pendingAvatar } = pendingChanges;
     const avatarToUse: ImageInput = hasImageInput(pendingAvatar)
         ? pendingAvatar
-        : (isGuildProfile ? (guildMember?.avatar ?? currentUser.avatar ?? null) : (currentUser.avatar ?? null));
-
-    const useGuildAvatar = !!(effectiveGuildId && isGuildProfile && guildMember?.avatar && avatarToUse === guildMember.avatar);
+        : (currentUser.avatar ?? null);
 
     const avatarInput: ImageInput = hasImageInput(avatarToUse)
         ? avatarToUse
         : IconUtils.getUserAvatarURL(currentUser, true, 512);
-    const avatarDataUrl = await processImage(avatarInput, currentUser.id, "avatar", effectiveGuildId, useGuildAvatar);
+    const avatarDataUrl = await processImage(avatarInput, currentUser.id, "avatar");
     const resolvedAvatarDataUrl = avatarDataUrl ?? IconUtils.getDefaultAvatarURL(currentUser.id);
 
     const { pendingBanner } = pendingChanges;
     const bannerToUse: ImageInput = hasImageInput(pendingBanner)
         ? pendingBanner
-        : (isGuildProfile ? (guildProfile?.banner ?? baseProfile?.banner) : baseProfile?.banner);
-    const useGuildBanner = !!(effectiveGuildId && isGuildProfile && guildProfile?.banner && bannerToUse === guildProfile?.banner);
+        : baseProfile?.banner;
 
-    const bannerDataUrl = await processImage(bannerToUse, currentUser.id, "banner", effectiveGuildId, useGuildBanner);
+    const bannerDataUrl = await processImage(bannerToUse, currentUser.id, "banner");
 
     return {
         avatarDataUrl: resolvedAvatarDataUrl,
         bannerDataUrl,
-        bio: pendingChanges.pendingBio ?? userProfile?.bio ?? null,
-        accentColor: pendingChanges.pendingAccentColor ?? userProfile?.accentColor ?? null,
-        themeColors: pendingChanges.pendingThemeColors ?? userProfile?.themeColors ?? null,
-        globalName: isGuildProfile
-            ? (pendingChanges.pendingNickname ?? guildMember?.nick ?? null)
-            : (pendingChanges.pendingGlobalName ?? currentUser.globalName ?? null),
-        pronouns: pendingChanges.pendingPronouns ?? userProfile?.pronouns ?? null,
+        bio: pendingChanges.pendingBio ?? baseProfile?.bio ?? null,
+        accentColor: pendingChanges.pendingAccentColor ?? baseProfile?.accentColor ?? null,
+        themeColors: pendingChanges.pendingThemeColors ?? baseProfile?.themeColors ?? null,
+        globalName: pendingChanges.pendingGlobalName ?? currentUser.globalName ?? null,
+        pronouns: pendingChanges.pendingPronouns ?? baseProfile?.pronouns ?? null,
         avatarDecoration,
         profileEffect,
         nameplate,
-        primaryGuildId: isGuildProfile
-            ? null
-            : (pendingChanges.pendingPrimaryGuildId ?? userAny.primaryGuild?.identityGuildId ?? null),
+        primaryGuildId: pendingChanges.pendingPrimaryGuildId ?? userAny.primaryGuild?.identityGuildId ?? null,
         customStatus,
         displayNameStyles
     };
@@ -296,7 +261,6 @@ function customStatusEq(a: CustomStatus | null | undefined, b: CustomStatus | nu
 
 function resolvePendingAvatar(pendingChanges: PendingChanges | null): ImageInput {
     if (!pendingChanges) return null;
-
     return hasImageInput(pendingChanges.pendingAvatar) ? pendingChanges.pendingAvatar : null;
 }
 
@@ -324,20 +288,14 @@ function nameplateEq(a: { skuId?: string | number | null; asset?: string | null;
     return String(a.skuId ?? "") === String(b.skuId ?? "") && String(a.asset ?? "") === String(b.asset ?? "");
 }
 
-export async function loadPresetAsPending(preset: ProfilePreset, guildId?: string, options: LoadPresetOptions = {}) {
+export async function loadPresetAsPending(preset: ProfilePreset, options: LoadPresetOptions = {}) {
     try {
-        const isGuild = options.isGuildProfile ?? Boolean(guildId);
-        if (isGuild && !guildId) return;
-        const current = await getCurrentProfile(guildId, {
-            isGuildProfile: isGuild
-        });
-        const pendingChanges = (isGuild && guildId
-            ? UserProfileSettingsStore.getPendingChanges(guildId)
-            : UserProfileSettingsStore.getPendingChanges());
+        const current = await getCurrentProfile();
+        const pendingChanges = UserProfileSettingsStore.getPendingChanges();
         const setPending = (payload: Record<string, unknown>) => {
             const cleanPayload = Object.fromEntries(Object.entries(payload).filter(([, v]) => v !== undefined));
             if (!Object.keys(cleanPayload).length) return;
-            setPendingChanges(cleanPayload, isGuild ? guildId : undefined);
+            setPendingChanges(cleanPayload);
         };
 
         if ("avatarDataUrl" in preset) {
@@ -358,7 +316,7 @@ export async function loadPresetAsPending(preset: ProfilePreset, guildId?: strin
                     ? (avatarPayload as { imageUri?: unknown; }).imageUri
                     : null;
                 if (isNonEmptyString(avatarImageUri)) {
-                    openProfileImagePreview("AVATAR", { ...Object(avatarPayload), imageUri: avatarImageUri }, guildId);
+                    openProfileImagePreview("AVATAR", { ...Object(avatarPayload), imageUri: avatarImageUri });
                 } else {
                     setPending({ pendingAvatar: avatarPayload });
                 }
@@ -378,7 +336,7 @@ export async function loadPresetAsPending(preset: ProfilePreset, guildId?: strin
                 ? (bannerPayload as { imageUri?: unknown; }).imageUri
                 : null;
             if (isNonEmptyString(bannerImageUri)) {
-                openProfileImagePreview("BANNER", { ...Object(bannerPayload), imageUri: bannerImageUri }, guildId);
+                openProfileImagePreview("BANNER", { ...Object(bannerPayload), imageUri: bannerImageUri });
             } else {
                 setPending({ pendingBanner: bannerPayload });
             }
@@ -393,7 +351,7 @@ export async function loadPresetAsPending(preset: ProfilePreset, guildId?: strin
         }
 
         if (!options.skipGlobalName && preset?.globalName !== current?.globalName) {
-            setPending(isGuild ? { pendingNickname: preset.globalName } : { pendingGlobalName: preset.globalName });
+            setPending({ pendingGlobalName: preset.globalName });
         }
 
         if (preset.avatarDecoration !== undefined && !avatarDecorationEq(preset.avatarDecoration, current.avatarDecoration)) {
@@ -425,11 +383,11 @@ export async function loadPresetAsPending(preset: ProfilePreset, guildId?: strin
             setPending({ pendingThemeColors: preset.themeColors });
         }
 
-        if (preset.primaryGuildId && !isGuild && preset.primaryGuildId !== current.primaryGuildId) {
+        if (preset.primaryGuildId && preset.primaryGuildId !== current.primaryGuildId) {
             setPending({ pendingPrimaryGuildId: preset.primaryGuildId });
         }
 
-        if (preset.customStatus && !isGuild && !customStatusEq(preset.customStatus, current.customStatus)) {
+        if (preset.customStatus && !customStatusEq(preset.customStatus, current.customStatus)) {
             CustomStatusSettings.updateSetting({
                 text: preset.customStatus?.text ?? "",
                 expiresAtMs: preset.customStatus?.expiresAtMs ?? "0",

--- a/src/equicordplugins/profileSets/utils/profile.ts
+++ b/src/equicordplugins/profileSets/utils/profile.ts
@@ -10,7 +10,7 @@ import { findStoreLazy } from "@webpack";
 import { FluxDispatcher, GuildMemberStore, IconUtils, UserProfileStore, UserStore } from "@webpack/common";
 
 const UserProfileSettingsStore = findStoreLazy("UserProfileSettingsStore");
-const CustomStatusSettings = getUserSettingLazy("status", "customStatus")!;
+const CustomStatusSettings = getUserSettingLazy("status", "customStatus");
 
 type PendingChanges = Record<string, unknown> & {
     pendingAvatar?: ImageInput;
@@ -72,7 +72,7 @@ function isNonEmptyString(value: unknown): value is string {
 function hasImageInput(value: ImageInput): boolean {
     if (!value) return false;
     if (typeof value === "string") return value.length > 0;
-    return typeof value === "object" && isNonEmptyString(value?.imageUri);
+    return typeof value === "object" && isNonEmptyString(value.imageUri);
 }
 
 function hasAvatarDecoration(value: unknown): value is AvatarDecorationLike {
@@ -110,7 +110,8 @@ export async function imageUrlToBase64(url: string): Promise<string | null> {
             reader.onerror = reject;
             reader.readAsDataURL(blob);
         });
-    } catch {
+    } catch (err) {
+        new Logger("ProfilePresets").warn("Failed to convert image URL to base64", err);
         return null;
     }
 }
@@ -140,11 +141,12 @@ async function processImage(imageData: ImageInput, userId: string, type: "avatar
 
 export async function getCurrentProfile(): Promise<Omit<ProfilePreset, "name" | "timestamp">> {
     const currentUser = UserStore.getCurrentUser();
-    const baseProfile = UserProfileStore.getUserProfile(currentUser.id);
-    const userAny = currentUser;
+    if (!currentUser) throw new Error("No authenticated user");
 
-    const pendingChanges: PendingChanges = UserProfileSettingsStore.getPendingChanges() ?? {};
-    const customStatusSetting = CustomStatusSettings.getSetting();
+    const baseProfile = UserProfileStore.getUserProfile(currentUser.id);
+
+    const pendingChanges: PendingChanges = UserProfileSettingsStore.getPendingChanges?.() ?? {};
+    const customStatusSetting = CustomStatusSettings?.getSetting?.();
     const customStatus = {
         text: customStatusSetting?.text ?? "",
         emojiId: customStatusSetting?.emojiId ?? "0",
@@ -152,7 +154,7 @@ export async function getCurrentProfile(): Promise<Omit<ProfilePreset, "name" | 
         expiresAtMs: customStatusSetting?.expiresAtMs ?? "0"
     };
 
-    const avatarDecorationSource = pendingChanges.pendingAvatarDecoration ?? userAny.avatarDecorationData;
+    const avatarDecorationSource = pendingChanges.pendingAvatarDecoration ?? currentUser.avatarDecorationData;
     const avatarDecoration = hasAvatarDecoration(avatarDecorationSource)
         ? {
             ...avatarDecorationSource,
@@ -198,7 +200,7 @@ export async function getCurrentProfile(): Promise<Omit<ProfilePreset, "name" | 
         }
     }
 
-    const nameplateToUse = pendingChanges.pendingNameplate ?? userAny.collectibles?.nameplate;
+    const nameplateToUse = pendingChanges.pendingNameplate ?? currentUser.collectibles?.nameplate;
     const nameplate = nameplateToUse ? {
         skuId: nameplateToUse.skuId,
         asset: nameplateToUse.asset,
@@ -207,7 +209,7 @@ export async function getCurrentProfile(): Promise<Omit<ProfilePreset, "name" | 
         type: nameplateToUse.type || 2
     } : null;
 
-    const savedDisplayNameStyles = userAny.displayNameStyles;
+    const savedDisplayNameStyles = currentUser.displayNameStyles;
     const displayNameStylesToUse = pendingChanges.pendingDisplayNameStyles ?? savedDisplayNameStyles;
     const displayNameStyles = normalizeDisplayNameStyles(displayNameStylesToUse);
 
@@ -240,7 +242,7 @@ export async function getCurrentProfile(): Promise<Omit<ProfilePreset, "name" | 
         avatarDecoration,
         profileEffect,
         nameplate,
-        primaryGuildId: pendingChanges.pendingPrimaryGuildId ?? userAny.primaryGuild?.identityGuildId ?? null,
+        primaryGuildId: pendingChanges.pendingPrimaryGuildId ?? currentUser.primaryGuild?.identityGuildId ?? null,
         customStatus,
         displayNameStyles
     };
@@ -289,7 +291,6 @@ function nameplateEq(a: { skuId?: string | number | null; asset?: string | null;
 }
 
 export async function loadPresetAsPending(preset: ProfilePreset, options: LoadPresetOptions = {}) {
-    try {
         const current = await getCurrentProfile();
         const pendingChanges = UserProfileSettingsStore.getPendingChanges();
         const setPending = (payload: Record<string, unknown>) => {
@@ -388,14 +389,11 @@ export async function loadPresetAsPending(preset: ProfilePreset, options: LoadPr
         }
 
         if (preset.customStatus && !customStatusEq(preset.customStatus, current.customStatus)) {
-            CustomStatusSettings.updateSetting({
+            CustomStatusSettings?.updateSetting?.({
                 text: preset.customStatus?.text ?? "",
                 expiresAtMs: preset.customStatus?.expiresAtMs ?? "0",
                 emojiId: preset.customStatus?.emojiId ?? "0",
                 emojiName: preset.customStatus?.emojiName ?? ""
             });
         }
-    } catch (err) {
-        throw err;
-    }
 }

--- a/src/equicordplugins/profileSets/utils/storage.ts
+++ b/src/equicordplugins/profileSets/utils/storage.ts
@@ -48,12 +48,6 @@ async function migrateLegacyPresets(userId: string, targetKey: string): Promise<
         await DataStore.del(datasetKey);
         return true;
     }
-    const bareStored = await DataStore.get(LEGACY_DATASET_KEY);
-    if (bareStored && Array.isArray(bareStored) && bareStored.length > 0) {
-        await DataStore.set(targetKey, bareStored);
-        await DataStore.del(LEGACY_DATASET_KEY);
-        return true;
-    }
     return false;
 }
 

--- a/src/equicordplugins/profileSets/utils/storage.ts
+++ b/src/equicordplugins/profileSets/utils/storage.ts
@@ -31,18 +31,27 @@ function getPresetsKey(userId: string) {
 }
 
 async function migrateLegacyPresets(userId: string, targetKey: string): Promise<boolean> {
+    const existing = await DataStore.get(targetKey);
+    if (existing && Array.isArray(existing) && existing.length > 0) return false;
+
     const v2Key = `${LEGACY_MAIN_KEY}:${userId}`;
     const stored = await DataStore.get(v2Key);
-    if (stored && Array.isArray(stored)) {
+    if (stored && Array.isArray(stored) && stored.length > 0) {
         await DataStore.set(targetKey, stored);
         await DataStore.del(v2Key);
         return true;
     }
     const datasetKey = `${LEGACY_DATASET_KEY}:${userId}:main`;
     const datasetStored = await DataStore.get(datasetKey);
-    if (datasetStored && Array.isArray(datasetStored)) {
+    if (datasetStored && Array.isArray(datasetStored) && datasetStored.length > 0) {
         await DataStore.set(targetKey, datasetStored);
         await DataStore.del(datasetKey);
+        return true;
+    }
+    const bareStored = await DataStore.get(LEGACY_DATASET_KEY);
+    if (bareStored && Array.isArray(bareStored) && bareStored.length > 0) {
+        await DataStore.set(targetKey, bareStored);
+        await DataStore.del(LEGACY_DATASET_KEY);
         return true;
     }
     return false;
@@ -117,4 +126,5 @@ export function movePresetInArray(fromIndex: number, toIndex: number) {
 
 export function replaceAllPresets(newPresets: ProfilePresetEx[]) {
     presets = newPresets;
+    currentPresetIndex = -1;
 }

--- a/src/equicordplugins/profileSets/utils/storage.ts
+++ b/src/equicordplugins/profileSets/utils/storage.ts
@@ -10,11 +10,9 @@ import { ProfilePreset } from "@vencord/discord-types";
 import { UserStore } from "@webpack/common";
 
 const logger = new Logger("ProfilePresets");
-const LEGACY_PRESETS_KEY = "ProfileDataset";
-const MAIN_PRESETS_KEY = "ProfilePresets_v2_Main";
-const SERVER_PRESETS_KEY = "ProfilePresets_v2_Server";
-
-export type PresetSection = "main" | "server";
+const PRESETS_KEY = "Profiles_v1";
+const LEGACY_MAIN_KEY = "ProfilePresets_v2_Main";
+const LEGACY_DATASET_KEY = "ProfileDataset";
 
 export type ProfilePresetEx = ProfilePreset & {
     avatarRaw?: string | null;
@@ -22,46 +20,49 @@ export type ProfilePresetEx = ProfilePreset & {
 
 export let presets: ProfilePresetEx[] = [];
 export let currentPresetIndex = -1;
-let activeScopeKey: string | null = null;
 
 function resetPresets(nextPresets: ProfilePresetEx[] = []) {
     presets = nextPresets;
     currentPresetIndex = -1;
 }
 
-function getPresetsKey(section: PresetSection, userId: string) {
-    const baseKey = section === "main" ? MAIN_PRESETS_KEY : SERVER_PRESETS_KEY;
-    return `${baseKey}:${userId}`;
+function getPresetsKey(userId: string) {
+    return `${PRESETS_KEY}:${userId}`;
 }
 
-function getLegacyKey(userId: string) {
-    return `${LEGACY_PRESETS_KEY}:${userId}:main`;
+async function migrateLegacyPresets(userId: string, targetKey: string): Promise<boolean> {
+    const v2Key = `${LEGACY_MAIN_KEY}:${userId}`;
+    const stored = await DataStore.get(v2Key);
+    if (stored && Array.isArray(stored)) {
+        await DataStore.set(targetKey, stored);
+        await DataStore.del(v2Key);
+        return true;
+    }
+    const datasetKey = `${LEGACY_DATASET_KEY}:${userId}:main`;
+    const datasetStored = await DataStore.get(datasetKey);
+    if (datasetStored && Array.isArray(datasetStored)) {
+        await DataStore.set(targetKey, datasetStored);
+        await DataStore.del(datasetKey);
+        return true;
+    }
+    return false;
 }
 
-export async function loadPresets(section: PresetSection) {
+export async function loadPresets() {
     try {
         const currentUser = UserStore.getCurrentUser();
-        const userId = currentUser!.id;
-        const key = getPresetsKey(section, userId);
-        activeScopeKey = key;
+        if (!currentUser) return;
+        const key = getPresetsKey(currentUser.id);
         const stored = await DataStore.get(key);
         if (stored && Array.isArray(stored)) {
             resetPresets(stored);
             return;
         }
-
-        if (section === "main") {
-            const legacyKey = getLegacyKey(userId);
-            const legacyStored = await DataStore.get(legacyKey);
-            const legacyBaseStored = await DataStore.get(LEGACY_PRESETS_KEY);
-            const legacyToUse = Array.isArray(legacyStored)
-                ? legacyStored
-                : (Array.isArray(legacyBaseStored) ? legacyBaseStored : null);
-            if (legacyToUse) {
-                resetPresets(legacyToUse);
-                await DataStore.set(key, legacyToUse);
-                await DataStore.del(legacyKey);
-                await DataStore.del(LEGACY_PRESETS_KEY);
+        const migrated = await migrateLegacyPresets(currentUser.id, key);
+        if (migrated) {
+            const migratedData = await DataStore.get(key);
+            if (migratedData && Array.isArray(migratedData)) {
+                resetPresets(migratedData);
                 return;
             }
         }
@@ -72,12 +73,11 @@ export async function loadPresets(section: PresetSection) {
     }
 }
 
-export async function savePresetsData(section?: PresetSection) {
+export async function savePresetsData() {
     try {
-        if (!activeScopeKey && !section) return;
         const currentUser = UserStore.getCurrentUser();
-        const userId = currentUser!.id;
-        const key = section ? getPresetsKey(section, userId) : activeScopeKey!;
+        if (!currentUser) return;
+        const key = getPresetsKey(currentUser.id);
         await DataStore.set(key, presets);
     } catch (err) {
         logger.error("Failed to save presets", err);


### PR DESCRIPTION
Rename ProfileSets to Profiles and move the preset manager from the Settings page to the user profile modal for easier, more intuitive access.

## Changes

- **New location**: Preset manager now lives as a tab in the user profile modal (clicking any user's avatar), instead of buried in Settings
- **Added Jahbas as co-author** alongside omaw and justjxke
- **Simplified to main profile only** (removed server/guild profile support — cleaner UX)
- **Data migration** from legacy `ProfilePresets_v2_Main` and `ProfileDataset` keys to new `Profiles_v1` key
- **Net -86 lines** across 7 files

## Files changed

| File | Change |
|------|--------|
| `index.tsx` | New patches targeting profile modal, new name/description, added Jahbas as author |
| `styles.css` | Added banner background-image overlay on preset rows |
| `utils/storage.ts` | Single-scope key, added legacy data migration |
| `utils/actions.ts` | Removed section/guildId params |
| `utils/profile.ts` | Removed guild profile branching |
| `components/presetManager.tsx` | Uses userId prop instead of section/guildId |
| `components/presetList.tsx` | Banner bg support, removed section/guildId |
| `components/confirmModal.tsx` | No changes |