### PR TITLE
feat(plugin): add callParticipants

### DIFF
--- a/src/equicordplugins/callParticipants/index.tsx
+++ b/src/equicordplugins/callParticipants/index.tsx
@@ -1,0 +1,42 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { classNameFactory } from "@utils/css";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import { MessageType } from "@vencord/discord-types/enums";
+import { ChannelStore, UserStore, UserSummaryItem } from "@webpack/common";
+
+const cl = classNameFactory("vc-callParticipants-");
+
+export default definePlugin({
+    name: "CallParticipants",
+    description: "Shows the participants of a call next to the call message.",
+    authors: [EquicordDevs.qdnx],
+
+    renderMessageAccessory({ message }) {
+        if (message.type !== MessageType.CALL || !message.call) return null;
+
+        const users = message.call.participants
+            .map(id => UserStore.getUser(id))
+            .filter(Boolean);
+
+        if (!users.length) return null;
+
+        return (
+            <div className={cl("root")}>
+                <UserSummaryItem
+                    users={users}
+                    guildId={ChannelStore.getChannel(message.channel_id)?.guild_id}
+                    renderIcon={false}
+                    max={5}
+                    showDefaultAvatarsForNullUsers
+                    showUserPopout
+                />
+            </div>
+        );
+    },
+});

--- a/src/equicordplugins/callParticipants/index.tsx
+++ b/src/equicordplugins/callParticipants/index.tsx
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-import { classNameFactory } from "@utils/css";
 import { EquicordDevs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
 import definePlugin from "@utils/types";
 import { MessageType } from "@vencord/discord-types/enums";
 import { ChannelStore, UserStore, UserSummaryItem } from "@webpack/common";

--- a/src/equicordplugins/callParticipants/style.css
+++ b/src/equicordplugins/callParticipants/style.css
@@ -1,0 +1,18 @@
+.vc-callParticipants-root {
+    display: flex;
+    align-items: center;
+    margin-top: -4px;
+}
+
+.vc-callParticipants-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 2px solid var(--background-primary);
+    margin-left: -8px;
+    box-sizing: content-box;
+}
+
+.vc-callParticipants-avatar:first-child {
+    margin-left: 0;
+}

--- a/src/equicordplugins/callParticipants/style.css
+++ b/src/equicordplugins/callParticipants/style.css
@@ -3,16 +3,3 @@
     align-items: center;
     margin-top: -4px;
 }
-
-.vc-callParticipants-avatar {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    border: 2px solid var(--background-primary);
-    margin-left: -8px;
-    box-sizing: content-box;
-}
-
-.vc-callParticipants-avatar:first-child {
-    margin-left: 0;
-}


### PR DESCRIPTION
## Describe your Changes
This is a plugin that show participants of a group call.
<img width="308" height="56" alt="image" src="https://github.com/user-attachments/assets/f9e05f22-9583-42ae-b1a8-9875da4d7ca3" />
The participants were available in the raw message data but never used.

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
