### PR TITLE
Add AutoJumpToMessage plugin

### DIFF
--- a/src/equicordplugins/autoJumpToMessage/index.ts
+++ b/src/equicordplugins/autoJumpToMessage/index.ts
@@ -1,0 +1,56 @@
+import { definePluginSettings } from "@api/Settings";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { ChannelRouter, FluxDispatcher } from "@webpack/common";
+
+const settings = definePluginSettings({
+    onlyWhenUnfocused: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description:
+            "Only automatically jump to messages when Discord's window is unfocused.",
+    },
+});
+
+export default definePlugin({
+    name: "AutoJumpToMessage",
+    description:
+        "Automatically opens the channel from new messages. Muted channels are ignored. Made for those who keep Discord on another monitor.",
+    tags: ["Chat", "Utility"],
+    searchTerms: ["jump", "message", "auto", "notification", "focus", "unfocused"],
+    authors: [EquicordDevs.k304, EquicordDevs.k304],
+    settings,
+
+    handleNotification(payload: any) {
+        if (!payload) return;
+
+        if (payload.type === "RPC_NOTIFICATION_CREATE") {
+            // Dont do anything if discord is in focus
+            if (settings.store.onlyWhenUnfocused && document.hasFocus()) {
+                return;
+            }
+
+            const channelId = payload.channelId;
+
+            if (channelId) {
+                ChannelRouter.transitionToChannel(channelId);
+            }
+        }
+    },
+
+    start() {
+        FluxDispatcher.subscribe(
+            "RPC_NOTIFICATION_CREATE",
+            this.handleNotification,
+        );
+        console.log("AutoJumpToMessage plugin is UP!.");
+    },
+
+    stop() {
+        FluxDispatcher.unsubscribe(
+            "RPC_NOTIFICATION_CREATE",
+            this.handleNotification,
+        );
+        console.log("AutoJumpToMessage plugin stoped.");
+    },
+});

--- a/src/equicordplugins/autoJumpToMessage/index.ts
+++ b/src/equicordplugins/autoJumpToMessage/index.ts
@@ -1,3 +1,9 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import { definePluginSettings } from "@api/Settings";
 import { EquicordDevs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";

--- a/src/equicordplugins/autoJumpToMessage/index.ts
+++ b/src/equicordplugins/autoJumpToMessage/index.ts
@@ -49,7 +49,6 @@ export default definePlugin({
             "RPC_NOTIFICATION_CREATE",
             this.handleNotification,
         );
-        console.log("AutoJumpToMessage plugin is UP!.");
     },
 
     stop() {
@@ -57,6 +56,5 @@ export default definePlugin({
             "RPC_NOTIFICATION_CREATE",
             this.handleNotification,
         );
-        console.log("AutoJumpToMessage plugin stoped.");
     },
 });

--- a/src/equicordplugins/autoJumpToMessage/index.ts
+++ b/src/equicordplugins/autoJumpToMessage/index.ts
@@ -7,54 +7,28 @@
 import { definePluginSettings } from "@api/Settings";
 import { EquicordDevs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
-import { ChannelRouter, FluxDispatcher } from "@webpack/common";
+import { ChannelRouter, ChannelStore, UserGuildSettingsStore } from "@webpack/common";
 
 const settings = definePluginSettings({
     onlyWhenUnfocused: {
         type: OptionType.BOOLEAN,
         default: true,
-        description:
-            "Only automatically jump to messages when Discord's window is unfocused.",
+        description: "Only automatically jump to messages when Discord's window is unfocused.",
     },
 });
 
 export default definePlugin({
     name: "AutoJumpToMessage",
-    description:
-        "Automatically opens the channel from new messages. Muted channels are ignored. Made for those who keep Discord on another monitor.",
+    description: "Automatically opens the channel from new messages.",
     tags: ["Chat", "Utility"],
     searchTerms: ["jump", "message", "auto", "notification", "focus", "unfocused"],
     authors: [EquicordDevs.k304],
     settings,
-
-    handleNotification(payload: any) {
-        if (!payload) return;
-
-        if (payload.type === "RPC_NOTIFICATION_CREATE") {
-            // Dont do anything if discord is in focus
-            if (settings.store.onlyWhenUnfocused && document.hasFocus()) {
-                return;
-            }
-
-            const channelId = payload.channelId;
-
-            if (channelId) {
-                ChannelRouter.transitionToChannel(channelId);
-            }
+    flux: {
+        RPC_NOTIFICATION_CREATE({ channelId }) {
+            if (!channelId || settings.store.onlyWhenUnfocused && document.hasFocus()
+                || UserGuildSettingsStore.isGuildOrCategoryOrChannelMuted(ChannelStore.getChannel(channelId)?.guild_id, channelId)) return;
+            ChannelRouter.transitionToChannel(channelId);
         }
-    },
-
-    start() {
-        FluxDispatcher.subscribe(
-            "RPC_NOTIFICATION_CREATE",
-            this.handleNotification,
-        );
-    },
-
-    stop() {
-        FluxDispatcher.unsubscribe(
-            "RPC_NOTIFICATION_CREATE",
-            this.handleNotification,
-        );
     },
 });

--- a/src/equicordplugins/autoJumpToMessage/index.ts
+++ b/src/equicordplugins/autoJumpToMessage/index.ts
@@ -18,7 +18,7 @@ export default definePlugin({
         "Automatically opens the channel from new messages. Muted channels are ignored. Made for those who keep Discord on another monitor.",
     tags: ["Chat", "Utility"],
     searchTerms: ["jump", "message", "auto", "notification", "focus", "unfocused"],
-    authors: [EquicordDevs.k304, EquicordDevs.k304],
+    authors: [EquicordDevs.k304],
     settings,
 
     handleNotification(payload: any) {

--- a/src/equicordplugins/autoJumpToMessage/index.ts
+++ b/src/equicordplugins/autoJumpToMessage/index.ts
@@ -21,7 +21,6 @@ export default definePlugin({
     name: "AutoJumpToMessage",
     description: "Automatically opens the channel from new messages.",
     tags: ["Chat", "Utility"],
-    searchTerms: ["jump", "message", "auto", "notification", "focus", "unfocused"],
     authors: [EquicordDevs.k304],
     settings,
     flux: {

--- a/src/equicordplugins/pingNotifications/index.tsx
+++ b/src/equicordplugins/pingNotifications/index.tsx
@@ -10,7 +10,6 @@ import { EquicordDevs } from "@utils/constants";
 import definePlugin, { OptionType } from "@utils/types";
 import {
     ChannelStore,
-    GuildStore,
     NavigationRouter,
     PresenceStore,
     RelationshipStore,
@@ -70,7 +69,6 @@ function checkIfMuted(channel) {
     }
 
     if (channel.guild_id) {
-        const guild = GuildStore.getGuild(channel.guild_id);
         if (UserGuildSettingsStore.isMuted(channel.guild_id)) return true;
 
         if (UserGuildSettingsStore.isMuted(channel.guild_id)) return true;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1410,6 +1410,10 @@ export const EquicordDevs = Object.freeze({
         name: "benjas333",
         id: 456577284464443394n,
     },
+    k304: {
+        name: "k304",
+        id: 255004979637649408n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Describe your Changes

This plugin is a quality-of-life improvement for anyone who keeps Discord open on a second monitor.

I often find myself having to stop what I'm doing just to click on Discord, switch chats, and view a message I've received. This frequently happens when someone I'm on a call with wants to show me something, like: "Hey, I sent a screenshot/something to your chat."

I'm tired of that.

With this plugin, when someone sends me a message, the plugin automatically switches the active chat to the one containing this new message. It's a bit niche, but I know a lot of people who keep Discord on a second monitor will like it.

I tried to make the plugin as user-friendly as possible. By default, it only performs these switches when the Discord window isn't in focus (though this is configurable); we don't want to take control away from the user.

Also, muted channels gonna be ignored. I see no point in jumping to every single message from every server I'm in, lol.

The trick I used to build this plugin is simple: the behavior hooks into Discord's own notification-generation event.

### This is my first plugin and actually my first time using TypeScript too. I’m open to suggestions for improving the code if needed. I also had a hard time choosing a name for the plugin, so I’m open to name suggestions as well, or I might just stick with the current name.

## Preview 

Discord is open on my second monitor and is **currently unfocused**. 
When a new message arrives, the plugin automatically switches to the corresponding channel.

[video.webm](https://github.com/user-attachments/assets/1098a65a-8c57-43a6-80b2-c4dd4058f0e0)

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
