### PR TITLE
songLink: make the silly button width less wide

### DIFF
--- a/src/equicordplugins/songLink.desktop/index.tsx
+++ b/src/equicordplugins/songLink.desktop/index.tsx
@@ -113,7 +113,8 @@ function SongLinkerList({ urls }: { urls: string[]; }) {
         display: "flex",
         flexDirection: "column",
         gap: "10px",
-        marginTop: "7px"
+        marginTop: "7px",
+        width: "fit-content"
     }}>
         {dedupedUrls.map(url => (
             <SongLinker key={url} url={url} onResolved={onResolved} />


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
-->
The fat width of buttons kept bugging me so I decided to make this one line change
or do I pr this to nin0's repo? 😨

Before:
<img width="1399" height="308" alt="image" src="https://github.com/user-attachments/assets/dc4b0522-5b47-4a66-990f-50f3632eb594" />


After:
<img width="1328" height="310" alt="image" src="https://github.com/user-attachments/assets/f0c2b86d-e24a-4ded-b97f-5a432436de4b" />


## Describe your Changes

## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
