### PR TITLE
feat: add MessageFollowUp plugin

### DIFF
--- a/src/equicordplugins/messageFollowUp/index.tsx
+++ b/src/equicordplugins/messageFollowUp/index.tsx
@@ -23,10 +23,7 @@ interface Reminder {
     time: number;
 }
 
-const BASE_STORAGE_KEY = "MessageFollowUp_reminders";
-
-const getCurrentUserId = () => UserStore.getCurrentUser()?.id;
-const getStorageKey = (userId: string) => `${BASE_STORAGE_KEY}_${userId}`;
+const BASE_STORAGE_KEY = "MessageFollowUp_reminders_";
 
 const DURATIONS = [
     { id: "30s", label: "In 30 Seconds", ms: 30 * 1000 },
@@ -44,59 +41,75 @@ const DURATIONS = [
 
 let reminders: Reminder[] = [];
 let checkInterval: NodeJS.Timeout;
-let loadedUserId: string | null = null;
-let loadPromise: Promise<void> | null = null;
 
-async function loadReminders() {
+// Tracking state variables for account management & async handling
+let loadedUserId: string | null = null;
+let loadingUserId: string | null = null;
+let loadPromise: Promise<void> | null = null;
+let loadGeneration = 0;
+
+function getStorageKey(userId: string) {
+    return `${BASE_STORAGE_KEY}${userId}`;
+}
+
+function getCurrentUserId(): string | null {
+    return UserStore.getCurrentUser()?.id ?? null;
+}
+
+async function loadReminders(): Promise<void> {
     const userId = getCurrentUserId();
 
     if (!userId) {
         reminders = [];
         loadedUserId = null;
-        loadPromise = null;
+        loadingUserId = null;
         return;
     }
 
-    if (loadedUserId !== userId) {
-        reminders = [];
-        loadedUserId = userId;
-        loadPromise = null;
-    }
+    // Already loaded for this user
+    if (loadedUserId === userId) return;
 
-    if (loadPromise) {
+    // Reuse existing loading promise if we're currently fetching for the exact same user
+    if (loadPromise && loadingUserId === userId) {
         await loadPromise;
         return;
     }
 
-    const key = getStorageKey(userId);
+    const currentGen = ++loadGeneration;
+    loadingUserId = userId;
 
-    const promise = (async () => {
-        const loaded = (await DataStore.get<Reminder[]>(key)) ?? [];
+    loadPromise = (async () => {
+        try {
+            const data = await DataStore.get<Reminder[]>(getStorageKey(userId));
 
-        if (getCurrentUserId() === userId) {
-            reminders = loaded;
+            // Only commit the data if we're still on the exact same load attempt and user
+            if (currentGen === loadGeneration && getCurrentUserId() === userId) {
+                reminders = data ?? [];
+                loadedUserId = userId;
+            }
+        } catch (err) {
+            console.error("[MessageFollowUp] Failed to load reminders from DataStore:", err);
+            if (currentGen === loadGeneration && getCurrentUserId() === userId) {
+                reminders = [];
+            }
+        } finally {
+            if (currentGen === loadGeneration) {
+                loadingUserId = null;
+                loadPromise = null;
+            }
         }
     })();
 
-    loadPromise = promise;
-
-    try {
-        await promise;
-    } catch {
-        if (getCurrentUserId() === userId) {
-            reminders = [];
-            loadedUserId = null;
-        }
-    } finally {
-        if (loadPromise === promise) {
-            loadPromise = null;
-        }
-    }
+    await loadPromise;
 }
 
-async function saveReminders(userId: string) {
-    const snapshot = [...reminders];
-    await DataStore.set(getStorageKey(userId), snapshot);
+async function saveReminders(userId: string): Promise<void> {
+    try {
+        const snapshot = [...reminders];
+        await DataStore.set(getStorageKey(userId), snapshot);
+    } catch (err) {
+        console.error("[MessageFollowUp] Failed to save reminders:", err);
+    }
 }
 
 async function addReminder(msg: Message, ms: number) {
@@ -105,6 +118,7 @@ async function addReminder(msg: Message, ms: number) {
 
     await loadReminders();
 
+    // Verify context is still valid post-async operation
     if (getCurrentUserId() !== userId || loadedUserId !== userId) return;
 
     reminders.push({
@@ -123,10 +137,12 @@ async function addReminder(msg: Message, ms: number) {
 }
 
 async function checkReminders() {
+    const userId = getCurrentUserId();
+    if (!userId) return;
+
     await loadReminders();
 
-    const userId = getCurrentUserId();
-    if (!userId || loadedUserId !== userId) return;
+    if (loadedUserId !== userId || !reminders.length) return;
 
     const now = Date.now();
     const due = reminders.filter(r => r.time <= now);
@@ -146,7 +162,7 @@ async function checkReminders() {
                 NavigationRouter.transitionTo(path);
 
                 setTimeout(() => {
-                    jumper.jumpToMessage({
+                    jumper?.jumpToMessage({
                         channelId: r.chanId,
                         messageId: r.msgId,
                         flash: true
@@ -176,7 +192,7 @@ export default definePlugin({
                             key={id}
                             id={`message-follow-up-${id}`}
                             label={label}
-                            action={() => addReminder(message, ms)}
+                            action={() => void addReminder(message, ms)}
                         />
                     ))}
                 </Menu.MenuItem>
@@ -188,7 +204,10 @@ export default definePlugin({
         CONNECTION_OPEN() {
             reminders = [];
             loadedUserId = null;
+            loadingUserId = null;
             loadPromise = null;
+            loadGeneration++;
+
             void loadReminders();
         }
     },
@@ -201,8 +220,11 @@ export default definePlugin({
 
     stop() {
         clearInterval(checkInterval);
+
         reminders = [];
         loadedUserId = null;
+        loadingUserId = null;
         loadPromise = null;
+        loadGeneration++;
     }
 });

--- a/src/equicordplugins/messageFollowUp/index.tsx
+++ b/src/equicordplugins/messageFollowUp/index.tsx
@@ -6,22 +6,29 @@
 
 import * as DataStore from "@api/DataStore";
 import { showNotification } from "@api/Notifications";
+import { EquicordDevs } from "@utils/constants";
 import definePlugin from "@utils/types";
 import { Message } from "@vencord/discord-types";
 import { findByPropsLazy } from "@webpack";
-import { Menu, NavigationRouter } from "@webpack/common";
+import { Menu, NavigationRouter, UserStore } from "@webpack/common";
 
-const jumper: any = findByPropsLazy("jumpToMessage");
+const jumper = findByPropsLazy<{
+    jumpToMessage: (opts: { channelId: string; messageId: string; flash?: boolean }) => void;
+}>("jumpToMessage");
 
 interface Reminder {
     msgId: string;
     chanId: string;
     guildId?: string;
-    text: string;
     time: number;
 }
 
-const STORAGE_KEY = "MessageFollowUp_reminders";
+const BASE_STORAGE_KEY = "MessageFollowUp_reminders";
+
+const getStorageKey = () => {
+    const userId = UserStore.getCurrentUser()?.id;
+    return userId ? `${BASE_STORAGE_KEY}_${userId}` : BASE_STORAGE_KEY;
+};
 
 const DURATIONS = [
     { id: "30s", label: "In 30 Seconds", ms: 30 * 1000 },
@@ -39,21 +46,30 @@ const DURATIONS = [
 
 let reminders: Reminder[] = [];
 let checkInterval: NodeJS.Timeout;
+let loadPromise: Promise<void> | null = null;
 
-async function loadReminders() {
-    reminders = await DataStore.get<Reminder[]>(STORAGE_KEY) ?? [];
+function loadReminders() {
+    if (loadPromise) return loadPromise;
+
+    loadPromise = (async () => {
+        const key = getStorageKey();
+        reminders = (await DataStore.get<Reminder[]>(key)) ?? [];
+    })();
+
+    return loadPromise;
 }
-
 async function saveReminders() {
-    await DataStore.set(STORAGE_KEY, reminders);
+    const key = getStorageKey();
+    await DataStore.set(key, reminders);
 }
 
 async function addReminder(msg: Message, ms: number) {
+    await loadReminders();
+
     reminders.push({
         msgId: msg.id,
         chanId: msg.channel_id,
         guildId: msg.guild_id,
-        text: msg.content || "Message reminder",
         time: Date.now() + ms
     });
 
@@ -74,7 +90,7 @@ async function checkReminders() {
     for (const r of due) {
         showNotification({
     title: "Message Follow Up",
-    body: r.text.length > 100 ? `${r.text.slice(0, 100)}...` : r.text,
+    body: "Click to jump back to the message",
     dismissOnClick: true,
   onClick: () => {
     const path = r.guildId ? `/channels/${r.guildId}/${r.chanId}` : `/channels/@me/${r.chanId}`;
@@ -98,7 +114,7 @@ async function checkReminders() {
 export default definePlugin({
     name: "MessageFollowUp",
     description: "Set reminders for Discord messages and jump back to them later.",
-    authors: [{ name: "noxify", id: 1167135976209002508n }],
+    authors: [EquicordDevs.noxify],
 
     contextMenus: {
         "message"(children, { message }: { message: Message }) {
@@ -116,6 +132,13 @@ export default definePlugin({
                     ))}
                 </Menu.MenuItem>
             );
+        }
+    },
+    flux: {
+        CONNECTION_OPEN() {
+            reminders = [];
+            loadPromise = null;
+            void loadReminders();
         }
     },
 

--- a/src/equicordplugins/messageFollowUp/index.tsx
+++ b/src/equicordplugins/messageFollowUp/index.tsx
@@ -25,10 +25,8 @@ interface Reminder {
 
 const BASE_STORAGE_KEY = "MessageFollowUp_reminders";
 
-const getStorageKey = () => {
-    const userId = UserStore.getCurrentUser()?.id;
-    return userId ? `${BASE_STORAGE_KEY}_${userId}` : BASE_STORAGE_KEY;
-};
+const getCurrentUserId = () => UserStore.getCurrentUser()?.id;
+const getStorageKey = (userId: string) => `${BASE_STORAGE_KEY}_${userId}`;
 
 const DURATIONS = [
     { id: "30s", label: "In 30 Seconds", ms: 30 * 1000 },
@@ -46,25 +44,68 @@ const DURATIONS = [
 
 let reminders: Reminder[] = [];
 let checkInterval: NodeJS.Timeout;
+let loadedUserId: string | null = null;
 let loadPromise: Promise<void> | null = null;
 
-function loadReminders() {
-    if (loadPromise) return loadPromise;
+async function loadReminders() {
+    const userId = getCurrentUserId();
 
-    loadPromise = (async () => {
-        const key = getStorageKey();
-        reminders = (await DataStore.get<Reminder[]>(key)) ?? [];
+    if (!userId) {
+        reminders = [];
+        loadedUserId = null;
+        loadPromise = null;
+        return;
+    }
+
+    if (loadedUserId !== userId) {
+        reminders = [];
+        loadedUserId = userId;
+        loadPromise = null;
+    }
+
+    if (loadPromise) {
+        await loadPromise;
+        return;
+    }
+
+    const key = getStorageKey(userId);
+
+    const promise = (async () => {
+        const loaded = (await DataStore.get<Reminder[]>(key)) ?? [];
+
+        if (getCurrentUserId() === userId) {
+            reminders = loaded;
+        }
     })();
 
-    return loadPromise;
+    loadPromise = promise;
+
+    try {
+        await promise;
+    } catch {
+        if (getCurrentUserId() === userId) {
+            reminders = [];
+            loadedUserId = null;
+        }
+    } finally {
+        if (loadPromise === promise) {
+            loadPromise = null;
+        }
+    }
 }
-async function saveReminders() {
-    const key = getStorageKey();
-    await DataStore.set(key, reminders);
+
+async function saveReminders(userId: string) {
+    const snapshot = [...reminders];
+    await DataStore.set(getStorageKey(userId), snapshot);
 }
 
 async function addReminder(msg: Message, ms: number) {
+    const userId = getCurrentUserId();
+    if (!userId) return;
+
     await loadReminders();
+
+    if (getCurrentUserId() !== userId || loadedUserId !== userId) return;
 
     reminders.push({
         msgId: msg.id,
@@ -73,7 +114,7 @@ async function addReminder(msg: Message, ms: number) {
         time: Date.now() + ms
     });
 
-    await saveReminders();
+    await saveReminders(userId);
 
     showNotification({
         title: "Reminder Set",
@@ -82,6 +123,11 @@ async function addReminder(msg: Message, ms: number) {
 }
 
 async function checkReminders() {
+    await loadReminders();
+
+    const userId = getCurrentUserId();
+    if (!userId || loadedUserId !== userId) return;
+
     const now = Date.now();
     const due = reminders.filter(r => r.time <= now);
 
@@ -89,26 +135,29 @@ async function checkReminders() {
 
     for (const r of due) {
         showNotification({
-    title: "Message Follow Up",
-    body: "Click to jump back to the message",
-    dismissOnClick: true,
-  onClick: () => {
-    const path = r.guildId ? `/channels/${r.guildId}/${r.chanId}` : `/channels/@me/${r.chanId}`;
-    NavigationRouter.transitionTo(path);
+            title: "Message Follow Up",
+            body: "Click to jump back to the message",
+            dismissOnClick: true,
+            onClick: () => {
+                const path = r.guildId
+                    ? `/channels/${r.guildId}/${r.chanId}`
+                    : `/channels/@me/${r.chanId}`;
 
-    setTimeout(() => {
-        jumper.jumpToMessage({
-            channelId: r.chanId,
-            messageId: r.msgId,
-            flash: true
+                NavigationRouter.transitionTo(path);
+
+                setTimeout(() => {
+                    jumper.jumpToMessage({
+                        channelId: r.chanId,
+                        messageId: r.msgId,
+                        flash: true
+                    });
+                }, 300);
+            }
         });
-    }, 300);
-}
-});
     }
 
     reminders = reminders.filter(r => r.time > now);
-    await saveReminders();
+    await saveReminders(userId);
 }
 
 export default definePlugin({
@@ -134,9 +183,11 @@ export default definePlugin({
             );
         }
     },
+
     flux: {
         CONNECTION_OPEN() {
             reminders = [];
+            loadedUserId = null;
             loadPromise = null;
             void loadReminders();
         }
@@ -150,5 +201,8 @@ export default definePlugin({
 
     stop() {
         clearInterval(checkInterval);
+        reminders = [];
+        loadedUserId = null;
+        loadPromise = null;
     }
 });

--- a/src/equicordplugins/messageFollowUp/index.tsx
+++ b/src/equicordplugins/messageFollowUp/index.tsx
@@ -1,0 +1,131 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import * as DataStore from "@api/DataStore";
+import { showNotification } from "@api/Notifications";
+import definePlugin from "@utils/types";
+import { Message } from "@vencord/discord-types";
+import { findByPropsLazy } from "@webpack";
+import { Menu, NavigationRouter } from "@webpack/common";
+
+const jumper: any = findByPropsLazy("jumpToMessage");
+
+interface Reminder {
+    msgId: string;
+    chanId: string;
+    guildId?: string;
+    text: string;
+    time: number;
+}
+
+const STORAGE_KEY = "MessageFollowUp_reminders";
+
+const DURATIONS = [
+    { id: "30s", label: "In 30 Seconds", ms: 30 * 1000 },
+    { id: "5m", label: "In 5 Minutes", ms: 5 * 60 * 1000 },
+    { id: "15m", label: "In 15 Minutes", ms: 15 * 60 * 1000 },
+    { id: "30m", label: "In 30 Minutes", ms: 30 * 60 * 1000 },
+    { id: "1h", label: "In 1 Hour", ms: 60 * 60 * 1000 },
+    { id: "3h", label: "In 3 Hours", ms: 3 * 60 * 60 * 1000 },
+    { id: "6h", label: "In 6 Hours", ms: 6 * 60 * 60 * 1000 },
+    { id: "12h", label: "In 12 Hours", ms: 12 * 60 * 60 * 1000 },
+    { id: "tomorrow", label: "Tomorrow", ms: 24 * 60 * 60 * 1000 },
+    { id: "3d", label: "In 3 Days", ms: 3 * 24 * 60 * 60 * 1000 },
+    { id: "1w", label: "In 1 Week", ms: 7 * 24 * 60 * 60 * 1000 }
+];
+
+let reminders: Reminder[] = [];
+let checkInterval: NodeJS.Timeout;
+
+async function loadReminders() {
+    reminders = await DataStore.get<Reminder[]>(STORAGE_KEY) ?? [];
+}
+
+async function saveReminders() {
+    await DataStore.set(STORAGE_KEY, reminders);
+}
+
+async function addReminder(msg: Message, ms: number) {
+    reminders.push({
+        msgId: msg.id,
+        chanId: msg.channel_id,
+        guildId: msg.guild_id,
+        text: msg.content || "Message reminder",
+        time: Date.now() + ms
+    });
+
+    await saveReminders();
+
+    showNotification({
+        title: "Reminder Set",
+        body: "Will remind you about this message."
+    });
+}
+
+async function checkReminders() {
+    const now = Date.now();
+    const due = reminders.filter(r => r.time <= now);
+
+    if (!due.length) return;
+
+    for (const r of due) {
+        showNotification({
+    title: "Message Follow Up",
+    body: r.text.length > 100 ? `${r.text.slice(0, 100)}...` : r.text,
+    dismissOnClick: true,
+  onClick: () => {
+    const path = r.guildId ? `/channels/${r.guildId}/${r.chanId}` : `/channels/@me/${r.chanId}`;
+    NavigationRouter.transitionTo(path);
+
+    setTimeout(() => {
+        jumper.jumpToMessage({
+            channelId: r.chanId,
+            messageId: r.msgId,
+            flash: true
+        });
+    }, 300);
+}
+});
+    }
+
+    reminders = reminders.filter(r => r.time > now);
+    await saveReminders();
+}
+
+export default definePlugin({
+    name: "MessageFollowUp",
+    description: "Set reminders for Discord messages and jump back to them later.",
+    authors: [{ name: "noxify", id: 1167135976209002508n }],
+
+    contextMenus: {
+        "message"(children, { message }: { message: Message }) {
+            if (!message) return;
+
+            children.push(
+                <Menu.MenuItem id="message-follow-up" label="Follow Up">
+                    {DURATIONS.map(({ id, label, ms }) => (
+                        <Menu.MenuItem
+                            key={id}
+                            id={`message-follow-up-${id}`}
+                            label={label}
+                            action={() => addReminder(message, ms)}
+                        />
+                    ))}
+                </Menu.MenuItem>
+            );
+        }
+    },
+
+    async start() {
+        await loadReminders();
+        await checkReminders();
+        checkInterval = setInterval(() => void checkReminders(), 30000);
+    },
+
+    stop() {
+        clearInterval(checkInterval);
+    }
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -697,6 +697,10 @@ export const EquicordDevs = Object.freeze({
         name: "nobody",
         id: 0n
     },
+    noxify: {
+        name: "noxify",
+        id: 1167135976209002508n
+    },
     thororen: {
         name: "thororen",
         id: 848339671629299742n


### PR DESCRIPTION
The MessageFollowUp Plugin lets users set local reminders for discord messages from the message context menu, And reminders times are 30 seconds, 5 minutes, 15 minutes, 30 minutes, 1 hour, 3 hours, 6 hours, 12 hours, tomorrow, 3 days, 1 week, When a reminder comes u can click on it and let's u back into the followed up message.

Note : reminders are stored locally

- [x] I have read the CONTRIBUTING.md file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
<img width="401" height="607" alt="Screenshot 2026-08-17 042722" src="https://github.com/user-attachments/assets/dc286ba4-b78c-4ef7-8997-23da2a2c2d0b" />
