### PR TITLE
Keyword notify ignore unselected

### DIFF
--- a/src/equicordplugins/keywordNotify/index.tsx
+++ b/src/equicordplugins/keywordNotify/index.tsx
@@ -141,12 +141,12 @@ const settings = definePluginSettings({
     },
     ignoreUnselected: {
         type: OptionType.BOOLEAN,
-        description: "Ignore messages in unselected channels (from Channels & Roles)",
+        description: "Ignore messages in unselected channels (from Channels & Roles).",
         default: true,
     },
     ignoreNothing: {
         type: OptionType.BOOLEAN,
-        description: "Ignore messages in channels with Notification Settings set to Nothing",
+        description: "Ignore messages in channels with Notification Settings set to Nothing.",
         default: true,
     },
     amountToKeep: {
@@ -164,25 +164,18 @@ const settings = definePluginSettings({
 const NO_MESSAGES = 2;
 
 function isChannelUnselected(channel: Channel): boolean {
-    if (!channel?.guild_id) return false;
+    if (!channel.guild_id) return false;
     if (!UserGuildSettingsStore.isOptInEnabled(channel.guild_id)) return false;
     return !UserGuildSettingsStore.isChannelOrParentOptedIn(channel.guild_id, channel.id);
 }
 
 function isChannelSetToNothing(channel: Channel): boolean {
-    if (!channel?.guild_id) return false;
+    if (!channel.guild_id) return false;
 
     const override = UserGuildSettingsStore.getChannelMessageNotifications(channel.guild_id, channel.id);
     if (override === NO_MESSAGES) return true;
 
-    if (UserGuildSettingsStore.resolvedMessageNotifications(channel) === NO_MESSAGES) return true;
-
-    const guildSettings = UserGuildSettingsStore.getAllSettings?.()?.userGuildSettings?.[channel.guild_id];
-    if (guildSettings?.channel_overrides?.[channel.id]?.message_notifications === NO_MESSAGES) {
-        return true;
-    }
-
-    return false;
+    return UserGuildSettingsStore.resolvedMessageNotifications(channel) === NO_MESSAGES;
 }
 
 export default definePlugin({

--- a/src/equicordplugins/keywordNotify/index.tsx
+++ b/src/equicordplugins/keywordNotify/index.tsx
@@ -24,6 +24,7 @@ import {
     TabBar,
     Tooltip,
     useRef,
+    UserGuildSettingsStore,
     UserStore,
     useState
 } from "@webpack/common";
@@ -138,6 +139,11 @@ const settings = definePluginSettings({
         default: true,
         hidden: true,
     },
+    ignoreUnselected: {
+        type: OptionType.BOOLEAN,
+        description: "Ignore messages in unselected channels (from Channels & Roles)",
+        default: true,
+    },
     amountToKeep: {
         type: OptionType.NUMBER,
         description: "Amount of messages to keep in the log",
@@ -152,7 +158,7 @@ const settings = definePluginSettings({
 
 export default definePlugin({
     name: "KeywordNotify",
-    authors: [EquicordDevs.camila314, EquicordDevs.x3rt, EquicordDevs.benjas333],
+    authors: [EquicordDevs.camila314, EquicordDevs.x3rt, EquicordDevs.benjas333, EquicordDevs.tt],
     description: "Sends a notification if a given message matches certain keywords or regexes",
     settings,
     patches: [
@@ -228,6 +234,17 @@ export default definePlugin({
     },
 
     applyKeywordEntries(m: Message) {
+        if (!m?.channel_id) return;
+
+        if (settings.store.ignoreUnselected) {
+            const channel = ChannelStore.getChannel(m.channel_id);
+            if (channel?.guild_id && UserGuildSettingsStore.isOptInEnabled(channel.guild_id)) {
+                if (!UserGuildSettingsStore.isChannelOrParentOptedIn(channel.guild_id, channel.id)) {
+                    return;
+                }
+            }
+        }
+
         let matches = false;
 
         for (const entry of keywordEntries) {

--- a/src/equicordplugins/keywordNotify/index.tsx
+++ b/src/equicordplugins/keywordNotify/index.tsx
@@ -144,6 +144,11 @@ const settings = definePluginSettings({
         description: "Ignore messages in unselected channels (from Channels & Roles)",
         default: true,
     },
+    ignoreNothing: {
+        type: OptionType.BOOLEAN,
+        description: "Ignore messages in channels with Notification Settings set to Nothing",
+        default: true,
+    },
     amountToKeep: {
         type: OptionType.NUMBER,
         description: "Amount of messages to keep in the log",
@@ -236,12 +241,21 @@ export default definePlugin({
     applyKeywordEntries(m: Message) {
         if (!m?.channel_id) return;
 
+        const channel = ChannelStore.getChannel(m.channel_id);
+
         if (settings.store.ignoreUnselected) {
-            const channel = ChannelStore.getChannel(m.channel_id);
             if (channel?.guild_id && UserGuildSettingsStore.isOptInEnabled(channel.guild_id)) {
                 if (!UserGuildSettingsStore.isChannelOrParentOptedIn(channel.guild_id, channel.id)) {
                     return;
                 }
+            }
+        }
+
+        if (settings.store.ignoreNothing && channel) {
+            const notifications = UserGuildSettingsStore.resolvedMessageNotifications?.(channel)
+                ?? (channel.guild_id ? UserGuildSettingsStore.getChannelMessageNotifications?.(channel.guild_id, channel.id) : null);
+            if (notifications === 2 || UserGuildSettingsStore.allowNoMessages?.(channel)) {
+                return;
             }
         }
 

--- a/src/equicordplugins/keywordNotify/index.tsx
+++ b/src/equicordplugins/keywordNotify/index.tsx
@@ -15,7 +15,7 @@ import { EquicordDevs } from "@utils/constants";
 import { classNameFactory } from "@utils/css";
 import { classes } from "@utils/misc";
 import definePlugin, { OptionType } from "@utils/types";
-import { Message, ScrollerBaseRef } from "@vencord/discord-types";
+import { Channel, Message, ScrollerBaseRef } from "@vencord/discord-types";
 import { findByCodeLazy, findCssClassesLazy } from "@webpack";
 import {
     ChannelStore,
@@ -161,6 +161,30 @@ const settings = definePluginSettings({
     }
 });
 
+const NO_MESSAGES = 2;
+
+function isChannelUnselected(channel: Channel): boolean {
+    if (!channel?.guild_id) return false;
+    if (!UserGuildSettingsStore.isOptInEnabled(channel.guild_id)) return false;
+    return !UserGuildSettingsStore.isChannelOrParentOptedIn(channel.guild_id, channel.id);
+}
+
+function isChannelSetToNothing(channel: Channel): boolean {
+    if (!channel?.guild_id) return false;
+
+    const override = UserGuildSettingsStore.getChannelMessageNotifications(channel.guild_id, channel.id);
+    if (override === NO_MESSAGES) return true;
+
+    if (UserGuildSettingsStore.resolvedMessageNotifications(channel) === NO_MESSAGES) return true;
+
+    const guildSettings = UserGuildSettingsStore.getAllSettings?.()?.userGuildSettings?.[channel.guild_id];
+    if (guildSettings?.channel_overrides?.[channel.id]?.message_notifications === NO_MESSAGES) {
+        return true;
+    }
+
+    return false;
+}
+
 export default definePlugin({
     name: "KeywordNotify",
     authors: [EquicordDevs.camila314, EquicordDevs.x3rt, EquicordDevs.benjas333, EquicordDevs.tt],
@@ -243,18 +267,12 @@ export default definePlugin({
 
         const channel = ChannelStore.getChannel(m.channel_id);
 
-        if (settings.store.ignoreUnselected) {
-            if (channel?.guild_id && UserGuildSettingsStore.isOptInEnabled(channel.guild_id)) {
-                if (!UserGuildSettingsStore.isChannelOrParentOptedIn(channel.guild_id, channel.id)) {
-                    return;
-                }
+        if (channel) {
+            if (settings.store.ignoreUnselected && isChannelUnselected(channel)) {
+                return;
             }
-        }
 
-        if (settings.store.ignoreNothing && channel) {
-            const notifications = UserGuildSettingsStore.resolvedMessageNotifications?.(channel)
-                ?? (channel.guild_id ? UserGuildSettingsStore.getChannelMessageNotifications?.(channel.guild_id, channel.id) : null);
-            if (notifications === 2 || UserGuildSettingsStore.allowNoMessages?.(channel)) {
+            if (settings.store.ignoreNothing && isChannelSetToNothing(channel)) {
                 return;
             }
         }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -777,6 +777,10 @@ export const EquicordDevs = Object.freeze({
         name: "Balaclava",
         id: 854886148455399436n
     },
+    tt: {
+        name: "_.tt",
+        id: 497966466617049089n
+    },
     dat_insanity: {
         name: "dat_insanity",
         id: 0n


### PR DESCRIPTION
## Changes

Adds 2 new toggles in the KeywordNotify plugin settings, one to ignore unselected channels and another to ignore channels which have notification settings set to none. 

## Screenshots (if applicable)
<img width="668" height="173" alt="image" src="https://github.com/user-attachments/assets/e4b3b083-356c-4b13-8f0a-8bbd7101abce" />

Requested in : https://discord.com/channels/1173279886065029291/1538808660417843241

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
