### PR TITLE
feat: add StreamProof plugin

### DIFF
--- a/src/equicordplugins/streamProof/StreamProof.tsx
+++ b/src/equicordplugins/streamProof/StreamProof.tsx
@@ -54,10 +54,11 @@ const settings = definePluginSettings({
         description: "Automatically enable StreamProof when you start streaming",
         default: false,
         onChange(value) {
-            if (value && isStreaming()) {
-                enableStreamProof();
-            }
-        }
+    if (value && isStreaming() && !settings.store.enabled) {
+        enableStreamProof();
+        autoEnabledStreamProof = true;
+    }
+}
     }
 });
 
@@ -304,12 +305,14 @@ export default definePlugin({
     },
 
     start() {
-        if (settings.store.autoStreamProof && isStreaming()) {
-            enableStreamProof();
-        }
-    },
+    if (settings.store.autoStreamProof && isStreaming() && !settings.store.enabled) {
+        enableStreamProof();
+        autoEnabledStreamProof = true;
+    }
+},
 
     stop() {
-        disableStreamProof();
-    }
+    autoEnabledStreamProof = false;
+    disableStreamProof();
+}
 });

--- a/src/equicordplugins/streamProof/StreamProof.tsx
+++ b/src/equicordplugins/streamProof/StreamProof.tsx
@@ -61,6 +61,7 @@ const settings = definePluginSettings({
     }
 });
 
+let autoEnabledStreamProof = false;
 function isStreaming(): boolean {
     const user = UserStore.getCurrentUser();
     if (!user) return false;
@@ -72,9 +73,13 @@ function handleStreamChange() {
     if (!settings.store.autoStreamProof) return;
 
     if (isStreaming()) {
-        enableStreamProof();
-    } else {
+        if (!settings.store.enabled) {
+            enableStreamProof();
+            autoEnabledStreamProof = true;
+        }
+    } else if (autoEnabledStreamProof) {
         disableStreamProof();
+        autoEnabledStreamProof = false;
     }
 }
 

--- a/src/equicordplugins/streamProof/StreamProof.tsx
+++ b/src/equicordplugins/streamProof/StreamProof.tsx
@@ -1,0 +1,192 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./styles.css";
+
+import { ChatBarButton, ChatBarButtonFactory } from "@api/ChatButtons";
+import { definePluginSettings } from "@api/Settings";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin, { OptionType } from "@utils/types";
+import { findByPropsLazy } from "@webpack";
+import { React, UserStore, useState, useStateFromStores } from "@webpack/common";
+
+const StreamStore = findByPropsLazy("getActiveStreamForUser", "getAllActiveStreams");
+
+const settings = definePluginSettings({
+    autoStreamProof: {
+        type: OptionType.BOOLEAN,
+        description: "Automatically enable StreamProof when you start streaming",
+        default: false,
+        onChange(value) {
+            if (value && isStreaming()) {
+                enableStreamProof();
+            }
+        }
+    }
+});
+
+let clickHandler: ((e: MouseEvent) => void) | null = null;
+let streamProofActive = false;
+
+function isStreaming(): boolean {
+    const user = UserStore.getCurrentUser();
+    if (!user) return false;
+
+    if (StreamStore.getActiveStreamForUser(user.id)) return true;
+
+    const streams = StreamStore.getAllActiveStreams();
+    return streams?.some((s: any) => s.ownerId === user.id) ?? false;
+}
+function handleStreamChange() {
+    if (!settings.store.autoStreamProof) return;
+
+    if (isStreaming()) {
+        enableStreamProof();
+    } else {
+        disableStreamProof();
+    }
+}
+
+function enableStreamProof() {
+    if (streamProofActive) return;
+    streamProofActive = true;
+
+    document.body.classList.add("stream-proof-enabled");
+
+    if (!clickHandler) {
+        clickHandler = e => {
+            const target = e.target as HTMLElement | null;
+            if (!target) return;
+
+            const selectors = [
+                '[class*="messageContent_"]',
+                '[class*="markup_"]',
+                '[class*="imageWrapper_"]',
+                '[class*="embedWrapper_"]',
+                '[id^="message-accessories-"] article',
+                '[class*="attachment_"]',
+                '[class*="video_"]',
+                '[class*="voiceMessage_"]',
+                '[class*="wrapperPaused_"]',
+                '[class*="wrapperPlaying_"]',
+                '[class*="audioAttachment_"]',
+                '[class*="fileUpload_"]',
+                '[class*="wrapperAudio_"]',
+                '[class*="mediaBarInteraction_"]',
+                '[class*="newMosaicStyle_"]',
+                '[class*="stickerAsset_"]',
+                '[class*="channel_"][class*="interactive_"]'
+            ].join(", ");
+
+            const targetElement = target.closest(selectors);
+            if (targetElement && !targetElement.classList.contains("stream-proof-revealed")) {
+                targetElement.classList.add("stream-proof-revealed");
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        };
+
+        document.addEventListener("click", clickHandler, true);
+    }
+}
+
+function disableStreamProof() {
+    if (!streamProofActive) return;
+    streamProofActive = false;
+
+    document.body.classList.remove("stream-proof-enabled");
+
+    if (clickHandler) {
+        document.removeEventListener("click", clickHandler, true);
+        clickHandler = null;
+    }
+
+    document.querySelectorAll(".stream-proof-revealed").forEach(el => {
+        el.classList.remove("stream-proof-revealed");
+    });
+}
+
+function EyeIcon() {
+    return (
+        <svg aria-hidden="true" width="20" height="20" fill="none" viewBox="0 0 24 24">
+            <path
+                fill="currentColor"
+                d="M12 5C5.648 5 1 12 1 12s4.648 7 11 7 11-7 11-7-4.648-7-11-7Zm0 12a5 5 0 1 1 0-10 5 5 0 0 1 0 10Zm0-8a3 3 0 1 0 0 6 3 3 0 0 0 0-6Z"
+            />
+        </svg>
+    );
+}
+
+function EyeSlashIcon() {
+    return (
+        <svg aria-hidden="true" width="20" height="20" fill="none" viewBox="0 0 24 24">
+            <path
+                fill="currentColor"
+                d="M2.22 2.22a.75.75 0 0 1 1.06 0l18.5 18.5a.75.75 0 1 1-1.06 1.06l-3.56-3.56A11.18 11.18 0 0 1 12 19C5.648 19 1 12 1 12s1.81-2.73 4.69-4.95L2.22 3.28a.75.75 0 0 1 0-1.06ZM7.1 8.52A8.87 8.87 0 0 0 3.07 12 9.57 9.57 0 0 0 12 17c1.47 0 2.85-.34 4.1-.93l-1.7-1.7A3 3 0 0 1 10.63 10.6L7.1 8.52ZM12 5c1.92 0 3.7.52 5.25 1.37l-1.5 1.5A8.87 8.87 0 0 0 20.93 12a9.57 9.57 0 0 1-3.37 3.44l1.5 1.5C21.42 15.2 23 12 23 12s-4.648-7-11-7Z"
+            />
+        </svg>
+    );
+}
+
+const StreamProofButton: ChatBarButtonFactory = ({ isMainChat }) => {
+    useStateFromStores([StreamStore], () => isStreaming());
+    const [enabled, setEnabled] = useState(streamProofActive);
+
+    if (!isMainChat) return null;
+
+    function toggle() {
+        if (streamProofActive) {
+            disableStreamProof();
+            setEnabled(false);
+        } else {
+            enableStreamProof();
+            setEnabled(true);
+        }
+    }
+
+    const tooltip = enabled
+        ? "StreamProof : ON — click to disable"
+        : "StreamProof : OFF — click to enable";
+
+    return (
+        <ChatBarButton tooltip={tooltip} onClick={toggle}>
+            <span style={{ color: enabled ? "var(--status-danger)" : "currentColor" }}>
+                {enabled ? <EyeSlashIcon /> : <EyeIcon />}
+            </span>
+        </ChatBarButton>
+    );
+};
+
+export default definePlugin({
+    name: "StreamProof",
+    description: "Hides messages, links, images, DMs, but not the screen share/voice grid. Toggle via chat bar button.",
+    authors: [EquicordDevs.noxify],
+    dependencies: ["ChatInputButtonAPI"],
+    enabledByDefault: true,
+    settings,
+
+    chatBarButton: {
+        icon: EyeSlashIcon,
+        render: StreamProofButton
+    },
+
+   flux: {
+    STREAM_START: handleStreamChange,
+    STREAM_STOP: handleStreamChange,
+    STREAM_CREATE: handleStreamChange,
+    STREAM_DELETE: handleStreamChange
+},
+
+    start() {
+        if (settings.store.autoStreamProof && isStreaming()) {
+            enableStreamProof();
+        }
+    },
+
+    stop() {
+        disableStreamProof();
+    }
+});

--- a/src/equicordplugins/streamProof/StreamProof.tsx
+++ b/src/equicordplugins/streamProof/StreamProof.tsx
@@ -9,13 +9,46 @@ import "./styles.css";
 import { ChatBarButton, ChatBarButtonFactory } from "@api/ChatButtons";
 import { definePluginSettings } from "@api/Settings";
 import { EquicordDevs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
 import definePlugin, { OptionType } from "@utils/types";
 import { findByPropsLazy } from "@webpack";
-import { React, UserStore, useState, useStateFromStores } from "@webpack/common";
+import { React, UserStore, useStateFromStores } from "@webpack/common";
 
 const StreamStore = findByPropsLazy("getActiveStreamForUser", "getAllActiveStreams");
+const cl = classNameFactory("vc-streamproof-");
 
 const settings = definePluginSettings({
+    enabled: {
+        type: OptionType.BOOLEAN,
+        description: "Whether StreamProof is currently enabled",
+        default: false,
+        hidden: true
+    },
+
+    blurMessages: {
+        type: OptionType.BOOLEAN,
+        description: "Blur message text",
+        default: true
+    },
+
+    blurMedia: {
+        type: OptionType.BOOLEAN,
+        description: "Blur images, videos, embeds and attachments",
+        default: true
+    },
+
+    blurDMs: {
+        type: OptionType.BOOLEAN,
+        description: "Blur direct messages in the DM list",
+        default: true
+    },
+
+    blurProfileBio: {
+        type: OptionType.BOOLEAN,
+        description: "Blur profile bios",
+        default: true
+    },
+
     autoStreamProof: {
         type: OptionType.BOOLEAN,
         description: "Automatically enable StreamProof when you start streaming",
@@ -28,18 +61,13 @@ const settings = definePluginSettings({
     }
 });
 
-let clickHandler: ((e: MouseEvent) => void) | null = null;
-let streamProofActive = false;
-
 function isStreaming(): boolean {
     const user = UserStore.getCurrentUser();
     if (!user) return false;
 
-    if (StreamStore.getActiveStreamForUser(user.id)) return true;
-
-    const streams = StreamStore.getAllActiveStreams();
-    return streams?.some((s: any) => s.ownerId === user.id) ?? false;
+    return Boolean(StreamStore.getActiveStreamForUser(user.id));
 }
+
 function handleStreamChange() {
     if (!settings.store.autoStreamProof) return;
 
@@ -51,62 +79,107 @@ function handleStreamChange() {
 }
 
 function enableStreamProof() {
-    if (streamProofActive) return;
-    streamProofActive = true;
-
-    document.body.classList.add("stream-proof-enabled");
-
-    if (!clickHandler) {
-        clickHandler = e => {
-            const target = e.target as HTMLElement | null;
-            if (!target) return;
-
-            const selectors = [
-                '[class*="messageContent_"]',
-                '[class*="markup_"]',
-                '[class*="imageWrapper_"]',
-                '[class*="embedWrapper_"]',
-                '[id^="message-accessories-"] article',
-                '[class*="attachment_"]',
-                '[class*="video_"]',
-                '[class*="voiceMessage_"]',
-                '[class*="wrapperPaused_"]',
-                '[class*="wrapperPlaying_"]',
-                '[class*="audioAttachment_"]',
-                '[class*="fileUpload_"]',
-                '[class*="wrapperAudio_"]',
-                '[class*="mediaBarInteraction_"]',
-                '[class*="newMosaicStyle_"]',
-                '[class*="stickerAsset_"]',
-                '[class*="channel_"][class*="interactive_"]'
-            ].join(", ");
-
-            const targetElement = target.closest(selectors);
-            if (targetElement && !targetElement.classList.contains("stream-proof-revealed")) {
-                targetElement.classList.add("stream-proof-revealed");
-                e.preventDefault();
-                e.stopPropagation();
-            }
-        };
-
-        document.addEventListener("click", clickHandler, true);
-    }
+    settings.store.enabled = true;
 }
 
 function disableStreamProof() {
-    if (!streamProofActive) return;
-    streamProofActive = false;
+    settings.store.enabled = false;
+}
 
-    document.body.classList.remove("stream-proof-enabled");
+function StreamProofContentRevealed({ children }: { children: React.ReactNode }) {
+    const [revealed, setRevealed] = React.useState(false);
 
-    if (clickHandler) {
-        document.removeEventListener("click", clickHandler, true);
-        clickHandler = null;
-    }
+    return (
+        <span
+            className={cl(revealed ? "revealed" : "blurred")}
+            onClick={() => setRevealed(true)}
+        >
+            {children}
+        </span>
+    );
+}
 
-    document.querySelectorAll(".stream-proof-revealed").forEach(el => {
-        el.classList.remove("stream-proof-revealed");
-    });
+function StreamProofContent({ children }: { children: React.ReactNode }) {
+    const { enabled, blurMessages } = settings.use(["enabled", "blurMessages"]);
+
+    if (!enabled || !blurMessages) return children;
+
+    return <StreamProofContentRevealed>{children}</StreamProofContentRevealed>;
+}
+
+function StreamProofMediaRevealed({ children }: { children: React.ReactNode }) {
+    const [revealed, setRevealed] = React.useState(false);
+
+    return (
+        <div
+            className={cl(revealed ? "revealed" : "media-blurred")}
+            onClickCapture={e => {
+                if (!revealed) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setRevealed(true);
+                }
+            }}
+        >
+            {children}
+        </div>
+    );
+}
+
+function StreamProofMedia({ children }: { children: React.ReactNode }) {
+    const { enabled, blurMedia } = settings.use(["enabled", "blurMedia"]);
+
+    if (!enabled || !blurMedia) return children;
+
+    return <StreamProofMediaRevealed>{children}</StreamProofMediaRevealed>;
+}
+
+function StreamProofDMRevealed({ children }: { children: React.ReactNode }) {
+    const [revealed, setRevealed] = React.useState(false);
+
+    return (
+        <div
+            className={cl(revealed ? "revealed" : "blurred")}
+            onClickCapture={e => {
+                if (!revealed) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setRevealed(true);
+                }
+            }}
+        >
+            {children}
+        </div>
+    );
+}
+
+function StreamProofDM({ children }: { children: React.ReactNode }) {
+    const { enabled, blurDMs } = settings.use(["enabled", "blurDMs"]);
+
+    if (!enabled || !blurDMs) return children;
+
+    return <StreamProofDMRevealed>{children}</StreamProofDMRevealed>;
+}
+
+function StreamProofBioRevealed({ children }: { children: React.ReactNode }) {
+    const [revealed, setRevealed] = React.useState(false);
+
+    return (
+        <span
+            className={cl(revealed ? "revealed" : "blurred")}
+            onClick={() => setRevealed(true)}
+        >
+            {children}
+        </span>
+    );
+}
+
+function StreamProofBio({ children }: { children: React.ReactNode }) {
+    const { enabled, blurProfileBio } = settings.use(["enabled", "blurProfileBio"]);
+
+    if (!enabled || !blurProfileBio) return children;
+
+    return <StreamProofBioRevealed>{children}</StreamProofBioRevealed>;
 }
 
 function EyeIcon() {
@@ -133,17 +206,15 @@ function EyeSlashIcon() {
 
 const StreamProofButton: ChatBarButtonFactory = ({ isMainChat }) => {
     useStateFromStores([StreamStore], () => isStreaming());
-    const [enabled, setEnabled] = useState(streamProofActive);
+    const { enabled } = settings.use(["enabled"]);
 
     if (!isMainChat) return null;
 
     function toggle() {
-        if (streamProofActive) {
+        if (settings.store.enabled) {
             disableStreamProof();
-            setEnabled(false);
         } else {
             enableStreamProof();
-            setEnabled(true);
         }
     }
 
@@ -168,17 +239,64 @@ export default definePlugin({
     enabledByDefault: true,
     settings,
 
+    patches: [
+        {
+            find: '.CUSTOM_GIFT?""',
+            replacement: {
+                match: /childrenMessageContent:(\i),/g,
+                replace: "childrenMessageContent:$self.wrapContent($1),"
+            }
+        },
+        {
+            find: "this.renderAttachments(",
+            replacement: {
+                match: /(?<=\i=)this\.render(?:Attachments|Embeds|StickersAccessories|ComponentAccessories)\((\i)\)/g,
+                replace: "$self.wrapMedia($&)"
+            }
+        },
+        {
+            find: "parseBioReact",
+            replacement: {
+                match: /\(0,\i\.parseBioReact\)\((\i)\)/,
+                replace: "$self.wrapBio($&)"
+            }
+        },
+        {
+            find: "PrivateChannel.renderAvatar",
+            replacement: {
+                match: /(?<=children:)(\(0,\i\.jsx\)\(\i\.\i,\{ref:\i,avatar:.*?withDisplayNameStyles:\i\}\))/,
+                replace: "$self.wrapDM($1)"
+            }
+        }
+    ],
+
     chatBarButton: {
         icon: EyeSlashIcon,
         render: StreamProofButton
     },
 
-   flux: {
-    STREAM_START: handleStreamChange,
-    STREAM_STOP: handleStreamChange,
-    STREAM_CREATE: handleStreamChange,
-    STREAM_DELETE: handleStreamChange
-},
+    flux: {
+        STREAM_START: handleStreamChange,
+        STREAM_STOP: handleStreamChange,
+        STREAM_CREATE: handleStreamChange,
+        STREAM_DELETE: handleStreamChange
+    },
+
+    wrapContent(content: React.ReactNode) {
+        return <StreamProofContent>{content}</StreamProofContent>;
+    },
+
+    wrapMedia(content: React.ReactNode) {
+        return <StreamProofMedia>{content}</StreamProofMedia>;
+    },
+
+    wrapBio(content: React.ReactNode) {
+        return <StreamProofBio>{content}</StreamProofBio>;
+    },
+
+    wrapDM(content: React.ReactNode) {
+        return <StreamProofDM>{content}</StreamProofDM>;
+    },
 
     start() {
         if (settings.store.autoStreamProof && isStreaming()) {

--- a/src/equicordplugins/streamProof/index.ts
+++ b/src/equicordplugins/streamProof/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+export { default } from "./StreamProof";

--- a/src/equicordplugins/streamProof/styles.css
+++ b/src/equicordplugins/streamProof/styles.css
@@ -1,0 +1,54 @@
+.stream-proof-enabled [class*="messageContent_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="markup_"]:not(.stream-proof-revealed) {
+    filter: blur(8px);
+    transition: filter 0.2s ease-in-out;
+    cursor: pointer !important;
+    user-select: none;
+    border-radius: 4px;
+}
+
+.stream-proof-enabled [id^="message-accessories-"] article:not(.stream-proof-revealed) {
+    filter: blur(20px);
+    transition: filter 0.2s ease-in-out;
+    cursor: pointer !important;
+}
+
+.stream-proof-enabled [class*="imageWrapper_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="embedWrapper_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="attachment_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="chatContent_"] [class*="video_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="message_"] [class*="video_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="newMosaicStyle_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="stickerAsset_"]:not(.stream-proof-revealed) {
+    filter: blur(20px);
+    transition: filter 0.2s ease-in-out;
+    cursor: pointer !important;
+}
+
+.stream-proof-enabled [class*="wrapperPaused_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="wrapperPlaying_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="voiceMessage_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="audioAttachment_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="wrapperAudio_"]:not(.stream-proof-revealed),
+.stream-proof-enabled [class*="mediaBarInteraction_"]:not(.stream-proof-revealed) {
+    filter: blur(20px);
+    transition: filter 0.2s ease-in-out;
+    cursor: pointer !important;
+}
+
+.stream-proof-enabled [class*="fileUpload_"]:not(.stream-proof-revealed) {
+    filter: blur(20px);
+    transition: filter 0.2s ease-in-out;
+    cursor: pointer !important;
+}
+
+.stream-proof-enabled [class*="privateChannels_"] [class*="channel_"][class*="interactive_"]:not(.stream-proof-revealed) {
+    filter: blur(8px);
+    transition: filter 0.2s ease-in-out;
+    cursor: pointer !important;
+}
+
+.stream-proof-enabled [class*="messageContent_"]:not(.stream-proof-revealed) a,
+.stream-proof-enabled [class*="markup_"]:not(.stream-proof-revealed) a {
+    pointer-events: none;
+}

--- a/src/equicordplugins/streamProof/styles.css
+++ b/src/equicordplugins/streamProof/styles.css
@@ -1,54 +1,17 @@
-.stream-proof-enabled [class*="messageContent_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="markup_"]:not(.stream-proof-revealed) {
+.vc-streamproof-blurred {
     filter: blur(8px);
     transition: filter 0.2s ease-in-out;
-    cursor: pointer !important;
+    cursor: pointer;
     user-select: none;
-    border-radius: 4px;
 }
 
-.stream-proof-enabled [id^="message-accessories-"] article:not(.stream-proof-revealed) {
+.vc-streamproof-media-blurred {
     filter: blur(20px);
     transition: filter 0.2s ease-in-out;
-    cursor: pointer !important;
+    cursor: pointer;
+    user-select: none;
 }
 
-.stream-proof-enabled [class*="imageWrapper_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="embedWrapper_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="attachment_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="chatContent_"] [class*="video_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="message_"] [class*="video_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="newMosaicStyle_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="stickerAsset_"]:not(.stream-proof-revealed) {
-    filter: blur(20px);
-    transition: filter 0.2s ease-in-out;
-    cursor: pointer !important;
-}
-
-.stream-proof-enabled [class*="wrapperPaused_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="wrapperPlaying_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="voiceMessage_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="audioAttachment_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="wrapperAudio_"]:not(.stream-proof-revealed),
-.stream-proof-enabled [class*="mediaBarInteraction_"]:not(.stream-proof-revealed) {
-    filter: blur(20px);
-    transition: filter 0.2s ease-in-out;
-    cursor: pointer !important;
-}
-
-.stream-proof-enabled [class*="fileUpload_"]:not(.stream-proof-revealed) {
-    filter: blur(20px);
-    transition: filter 0.2s ease-in-out;
-    cursor: pointer !important;
-}
-
-.stream-proof-enabled [class*="privateChannels_"] [class*="channel_"][class*="interactive_"]:not(.stream-proof-revealed) {
-    filter: blur(8px);
-    transition: filter 0.2s ease-in-out;
-    cursor: pointer !important;
-}
-
-.stream-proof-enabled [class*="messageContent_"]:not(.stream-proof-revealed) a,
-.stream-proof-enabled [class*="markup_"]:not(.stream-proof-revealed) a {
-    pointer-events: none;
+.vc-streamproof-revealed {
+    filter: none;
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -697,6 +697,10 @@ export const EquicordDevs = Object.freeze({
         name: "nobody",
         id: 0n
     },
+    noxify: {
+        name: "noxify",
+        id: 1167135976209002508n
+    },
     thororen: {
         name: "thororen",
         id: 848339671629299742n


### PR DESCRIPTION
StreamProof is a plugin designed to protect private content while screen sharing by adding a toggle button directly to the chat bar.

Features:

- Privacy Blurring: Blurs message text, links, media, images, videos, stickers, attachments, voice messages, and DM entries in the sidebar.
- Click to Reveal: Any blurred element can be temporarily revealed simply by clicking on it.
- Auto-Enable: Includes an optional setting to automatically turn on StreamProof as soon as you start streaming.
-Can edit what it Blurs


<img width="719" height="439" alt="Screenshot 2026-08-18 084555" src="https://github.com/user-attachments/assets/cf5b8d83-637c-4b79-a7c3-d6bcd35b7b1b" />
<img width="667" height="620" alt="Screenshot 2026-08-18 084622" src="https://github.com/user-attachments/assets/70a00732-f544-4c81-88eb-d1c54513bf77" />
<img width="1062" height="729" alt="Screenshot 2026-08-18 084611" src="https://github.com/user-attachments/assets/bb4916cb-4bc4-44c8-a745-44fabb0df72d" />
<img width="695" height="471" alt="Screenshot 2026-08-18 084601" src="https://github.com/user-attachments/assets/60ccf719-c522-444d-8a78-8a801fd8168d" />




- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
