### PR TITLE
add SilentDelete plugin

### DIFF
--- a/src/equicordplugins/SilentDelete/index.tsx
+++ b/src/equicordplugins/SilentDelete/index.tsx
@@ -1,0 +1,104 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { findGroupChildrenByChildId } from "@api/ContextMenu";
+import definePlugin from "@utils/types";
+import { Menu, RestAPI, UserStore } from "@webpack/common";
+import { settings } from './settings';
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+const messageCtxPatch = (children, { message }) => {
+    if (message.author.id !== UserStore.getCurrentUser()?.id) return;
+
+    const group = findGroupChildrenByChildId("delete", children);
+    if (!group) return;
+
+    const deleteIndex = group.findIndex(c => c?.props?.id === "delete");
+    if (deleteIndex === -1) return;
+
+    group.splice(deleteIndex + 1, 0, (
+        <Menu.MenuItem
+            id="vc-silent-delete"
+            label="‌ ‌🗑️‌ ‌ ‌ ‌Silent Delete"
+            action={async () => {
+                try {
+                    const response = await RestAPI.post({
+                        url: `/channels/${message.channel_id}/messages`,
+                        body: {
+                            content: settings.store.replacementText,
+                            flags: settings.store.suppressNotifications ? 4096 : 0,
+                            mobile_network_type: "unknown",
+                            nonce: message.id,
+                            tts: false,
+                        },
+                    });
+
+                    await sleep(settings.store.deleteDelay);
+                    await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${response.body.id}` });
+                    await sleep(100);
+                    await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${message.id}` });
+                } catch (err) {
+                    console.error("[SilentDelete] Error:", err);
+                }
+            }}
+        />
+    ));
+};
+
+const messageActionsPatch = (children, { message }) => {
+    if (message.author.id !== UserStore.getCurrentUser()?.id) return;
+
+    const group = findGroupChildrenByChildId("delete", children);
+    if (!group) return;
+
+    const deleteIndex = group.findIndex(c => c?.props?.id === "delete");
+    if (deleteIndex === -1) return;
+
+    group.splice(deleteIndex + 1, 0, (
+        <Menu.MenuItem
+            id="vc-silent-delete"
+            label="‌ ‌🗑️‌ ‌ ‌ ‌Silent Delete"
+            action={async () => {
+                try {
+                    const response = await RestAPI.post({
+                        url: `/channels/${message.channel_id}/messages`,
+                        body: {
+                            content: settings.store.replacementText,
+                            flags: settings.store.suppressNotifications ? 4096 : 0,
+                            mobile_network_type: "unknown",
+                            nonce: message.id,
+                            tts: false,
+                        },
+                    });
+
+                    await sleep(settings.store.deleteDelay);
+                    await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${response.body.id}` });
+                    await sleep(100);
+                    await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${message.id}` });
+                } catch (err) {
+                    console.error("[SilentDelete] Error:", err);
+                }
+            }}
+        />
+    ));
+};
+
+const plugin = definePlugin({
+    name: "SilentDelete",
+    description: "Silently deletes a message to bypass vencord message loggers.",
+    authors: [
+        { name: "Duck", id: "798441657895878696" },
+        { name: "coder", id: "1099039269391171765" }
+    ],
+    settings,
+    contextMenus: {
+        "message": messageCtxPatch,
+        "message-actions": messageActionsPatch
+    }
+});
+
+export default plugin;

--- a/src/equicordplugins/SilentDelete/index.tsx
+++ b/src/equicordplugins/SilentDelete/index.tsx
@@ -5,11 +5,41 @@
  */
 
 import { findGroupChildrenByChildId } from "@api/ContextMenu";
+import { Logger } from "@utils/Logger";
+import { sleep } from "@utils/misc";
 import definePlugin from "@utils/types";
 import { Menu, RestAPI, UserStore } from "@webpack/common";
 import { settings } from './settings';
 
-const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+const logger = new Logger("SilentDelete");
+
+const createMenuItem = (message) => (
+    <Menu.MenuItem
+        id="vc-silent-delete"
+        label="‌ ‌🗑️‌ ‌ ‌ ‌Silent Delete" // i will NOT edit this "remove spaces and unicode" why? cuz if i remove them the UI will be bad so take it like that >:(
+        action={async () => {
+            try {
+                const response = await RestAPI.post({
+                    url: `/channels/${message.channel_id}/messages`,
+                    body: {
+                        content: settings.store.replacementText,
+                        flags: settings.store.suppressNotifications ? 4096 : 0,
+                        mobile_network_type: "unknown",
+                        nonce: message.id,
+                        tts: false,
+                    },
+                });
+
+                await sleep(settings.store.deleteDelay);
+                await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${response.body.id}` });
+                await sleep(100);
+                await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${message.id}` });
+            } catch (err) {
+                logger.error("Error:", err);
+            }
+        }}
+    />
+);
 
 const messageCtxPatch = (children, { message }) => {
     if (message.author.id !== UserStore.getCurrentUser()?.id) return;
@@ -20,33 +50,7 @@ const messageCtxPatch = (children, { message }) => {
     const deleteIndex = group.findIndex(c => c?.props?.id === "delete");
     if (deleteIndex === -1) return;
 
-    group.splice(deleteIndex + 1, 0, (
-        <Menu.MenuItem
-            id="vc-silent-delete"
-            label="‌ ‌🗑️‌ ‌ ‌ ‌Silent Delete"
-            action={async () => {
-                try {
-                    const response = await RestAPI.post({
-                        url: `/channels/${message.channel_id}/messages`,
-                        body: {
-                            content: settings.store.replacementText,
-                            flags: settings.store.suppressNotifications ? 4096 : 0,
-                            mobile_network_type: "unknown",
-                            nonce: message.id,
-                            tts: false,
-                        },
-                    });
-
-                    await sleep(settings.store.deleteDelay);
-                    await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${response.body.id}` });
-                    await sleep(100);
-                    await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${message.id}` });
-                } catch (err) {
-                    console.error("[SilentDelete] Error:", err);
-                }
-            }}
-        />
-    ));
+    group.splice(deleteIndex + 1, 0, createMenuItem(message));
 };
 
 const messageActionsPatch = (children, { message }) => {
@@ -58,33 +62,7 @@ const messageActionsPatch = (children, { message }) => {
     const deleteIndex = group.findIndex(c => c?.props?.id === "delete");
     if (deleteIndex === -1) return;
 
-    group.splice(deleteIndex + 1, 0, (
-        <Menu.MenuItem
-            id="vc-silent-delete"
-            label="‌ ‌🗑️‌ ‌ ‌ ‌Silent Delete"
-            action={async () => {
-                try {
-                    const response = await RestAPI.post({
-                        url: `/channels/${message.channel_id}/messages`,
-                        body: {
-                            content: settings.store.replacementText,
-                            flags: settings.store.suppressNotifications ? 4096 : 0,
-                            mobile_network_type: "unknown",
-                            nonce: message.id,
-                            tts: false,
-                        },
-                    });
-
-                    await sleep(settings.store.deleteDelay);
-                    await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${response.body.id}` });
-                    await sleep(100);
-                    await RestAPI.del({ url: `/channels/${message.channel_id}/messages/${message.id}` });
-                } catch (err) {
-                    console.error("[SilentDelete] Error:", err);
-                }
-            }}
-        />
-    ));
+    group.splice(deleteIndex + 1, 0, createMenuItem(message));
 };
 
 const plugin = definePlugin({

--- a/src/equicordplugins/SilentDelete/settings.tsx
+++ b/src/equicordplugins/SilentDelete/settings.tsx
@@ -11,16 +11,18 @@ export const settings = definePluginSettings({
     replacementText: {
         type: OptionType.STRING,
         default: "** **",
-        description: "Replacement Text"
+        description: "Replacement Text."
     },
     suppressNotifications: {
         type: OptionType.BOOLEAN,
-        default: true,
-        description: "Suppress Notifications"
+        default: false,
+        description: "Suppress Notifications."
     },
     deleteDelay: {
         type: OptionType.NUMBER,
-        default: 200,
-        description: "Delete Delay (ms)"
+        default: 60,
+        min: 30,
+        max: 1000,
+        description: "Delete Delay (ms)."
     }
 });

--- a/src/equicordplugins/SilentDelete/settings.tsx
+++ b/src/equicordplugins/SilentDelete/settings.tsx
@@ -1,0 +1,26 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2024 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { definePluginSettings } from "@api/Settings";
+import { OptionType } from "@utils/types";
+
+export const settings = definePluginSettings({
+    replacementText: {
+        type: OptionType.STRING,
+        default: "** **",
+        description: "Replacement Text"
+    },
+    suppressNotifications: {
+        type: OptionType.BOOLEAN,
+        default: true,
+        description: "Suppress Notifications"
+    },
+    deleteDelay: {
+        type: OptionType.NUMBER,
+        default: 200,
+        description: "Delete Delay (ms)"
+    }
+});


### PR DESCRIPTION
Silent Delete is a plugin to bypass vencord message logger
(btw it work with MessageLoggerEnhanced 50% cuz its keep messages after restart) (but vencord dont)
this plugin uses RestAPI but its NOT banable ill explain why :3

first:
it send req to send another message with the SAME nonce of the old message...
after the message sent it delete the old message (to make it hidden after the another person restarted his client lol)
so yeah

## Features:
delete messages from vencord users :)
idk its just doing that (fr)


## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
