### PR TITLE
VoiceBulkMove: Bulk move voice channel members

### DIFF
--- a/src/equicordplugins/voiceBulkMove/BulkMoveModal.tsx
+++ b/src/equicordplugins/voiceBulkMove/BulkMoveModal.tsx
@@ -1,0 +1,143 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { Flex } from "@components/Flex";
+import { HeadingSecondary } from "@components/Heading";
+import { classNameFactory } from "@utils/css";
+import { Logger } from "@utils/Logger";
+import { sleep } from "@utils/misc";
+import type { Channel, RenderModalProps, User } from "@vencord/discord-types";
+import { Avatar, ChannelStore, Checkbox, GuildChannelStore, GuildMemberStore, IconUtils, Modal, RestAPI, SearchableSelect, showToast, Toasts, UserStore, useState, useStateFromStores,VoiceStateStore } from "@webpack/common";
+
+const cl = classNameFactory("vc-bulk-move-");
+const logger = new Logger("VoiceBulkMove");
+
+function getUserName(guildId: string, user: User) {
+    return GuildMemberStore.getMember(guildId, user.id)?.nick ?? user.globalName ?? user.username;
+}
+
+export function BulkMoveModal({ modalProps, channel }: { modalProps: RenderModalProps; channel: Channel; }) {
+    const [checked, setChecked] = useState<Set<string>>(new Set());
+    const [targetId, setTargetId] = useState<string | null>(null);
+    const [moving, setMoving] = useState(false);
+
+    const voiceStates = useStateFromStores(
+        [VoiceStateStore],
+        () => VoiceStateStore.getVoiceStatesForChannel(channel.id),
+        [channel.id]
+    );
+    const selfId = UserStore.getCurrentUser().id;
+    const users = Object.values(voiceStates)
+        .filter(voiceState => voiceState.userId !== selfId)
+        .map(voiceState => UserStore.getUser(voiceState.userId))
+        .filter((user): user is User => user != null);
+
+    const options = GuildChannelStore.getChannels(channel.guild_id).VOCAL
+        .map(({ channel: voiceChannel }) => voiceChannel)
+        .filter(voiceChannel => voiceChannel.id !== channel.id)
+        .map(voiceChannel => ({ label: voiceChannel.name, value: voiceChannel.id }));
+
+    const checkedCount = [...checked].filter(userId => users.some(user => user.id === userId)).length;
+
+    function toggleUser(userId: string) {
+        setChecked(current => {
+            const next = new Set(current);
+            if (next.has(userId)) next.delete(userId);
+            else next.add(userId);
+            return next;
+        });
+    }
+
+    function toggleAll() {
+        const allChecked = users.length > 0 && users.every(user => checked.has(user.id));
+        setChecked(new Set(allChecked ? [] : users.map(user => user.id)));
+    }
+
+    async function move() {
+        if (targetId == null || checkedCount === 0 || moving) return;
+        setMoving(true);
+        const targetChannel = ChannelStore.getChannel(targetId);
+        const userIds = [...checked].filter(userId => VoiceStateStore.getVoiceStateForUser(userId)?.channelId === channel.id);
+
+        let moved = 0;
+        for (const userId of userIds) {
+            try {
+                await RestAPI.patch({
+                    url: `/guilds/${channel.guild_id}/members/${userId}`,
+                    body: { channel_id: targetId },
+                });
+                moved++;
+            } catch (error) {
+                logger.warn(`Failed to move member ${userId}`, error);
+            }
+            await sleep(200);
+        }
+        showToast(`Moved ${moved} member${moved === 1 ? "" : "s"} to #${targetChannel?.name ?? targetId}`, Toasts.Type.SUCCESS);
+        modalProps.onClose();
+    }
+
+    return (
+        <Modal
+            {...modalProps}
+            title="Bulk move members"
+            actions={[
+                {
+                    text: "Cancel",
+                    variant: "secondary",
+                    onClick: modalProps.onClose,
+                    disabled: moving,
+                },
+                {
+                    text: moving ? "Moving..." : `Move selected (${checkedCount})`,
+                    variant: "primary",
+                    onClick: () => void move(),
+                    disabled: moving || checkedCount === 0 || targetId == null,
+                },
+            ]}
+        >
+            <Flex flexDirection="column" gap={12}>
+                {users.length === 0 ? (
+                    <span>No members to move.</span>
+                ) : (
+                    <>
+                        <Checkbox type="row" value={checkedCount > 0 && checkedCount === users.length} onChange={toggleAll}>
+                            Select all
+                        </Checkbox>
+                        <div className={cl("users")}>
+                            {users.map(user => (
+                                <Checkbox
+                                    key={user.id}
+                                    type="row"
+                                    value={checked.has(user.id)}
+                                    onChange={() => toggleUser(user.id)}
+                                >
+                                    <Flex alignItems="center" gap={8}>
+                                        <Avatar src={IconUtils.getUserAvatarURL(user)} size="SIZE_32" />
+                                        <span>{getUserName(channel.guild_id, user)}</span>
+                                    </Flex>
+                                </Checkbox>
+                            ))}
+                        </div>
+                    </>
+                )}
+
+                <section>
+                    <HeadingSecondary>Move to</HeadingSecondary>
+                    <SearchableSelect
+                        options={options}
+                        value={targetId ?? undefined}
+                        placeholder="Select a voice channel"
+                        maxVisibleItems={6}
+                        closeOnSelect
+                        onChange={setTargetId}
+                    />
+                </section>
+            </Flex>
+        </Modal>
+    );
+}

--- a/src/equicordplugins/voiceBulkMove/index.tsx
+++ b/src/equicordplugins/voiceBulkMove/index.tsx
@@ -1,0 +1,47 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import type { NavContextMenuPatchCallback } from "@api/ContextMenu";
+import { EquicordDevs } from "@utils/constants";
+import definePlugin from "@utils/types";
+import type { Channel } from "@vencord/discord-types";
+import { Menu, openModal, PermissionsBits,PermissionStore } from "@webpack/common";
+
+import { BulkMoveModal } from "./BulkMoveModal";
+
+function isVoiceChannel(channel: Channel | undefined): boolean {
+    return channel != null && (channel.type === 2 || channel.type === 13);
+}
+
+function openBulkMoveModal(channel: Channel) {
+    openModal(modalProps => (
+        <BulkMoveModal modalProps={modalProps} channel={channel} />
+    ));
+}
+
+const channelContextMenu: NavContextMenuPatchCallback = (children, { channel }: { channel: Channel }) => {
+    if (!isVoiceChannel(channel)) return;
+    if (!PermissionStore.can(PermissionsBits.MOVE_MEMBERS, channel)) return;
+
+    children.splice(-1, 0,
+        <Menu.MenuItem
+            key="vc-bulk-move-open"
+            id="vc-bulk-move-open"
+            label="Bulk move members"
+            action={() => openBulkMoveModal(channel)}
+        />
+    );
+};
+
+export default definePlugin({
+    name: "VoiceBulkMove",
+    description: "Move multiple voice channel members at once through a modal.",
+    tags: ["Servers", "Utility", "Voice"],
+    authors: [EquicordDevs.whoami],
+    contextMenus: {
+        "channel-context": channelContextMenu,
+    },
+});

--- a/src/equicordplugins/voiceBulkMove/style.css
+++ b/src/equicordplugins/voiceBulkMove/style.css
@@ -1,0 +1,4 @@
+.vc-bulk-move-users {
+    max-height: 40vh;
+    overflow-y: auto;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1426,6 +1426,10 @@ export const EquicordDevs = Object.freeze({
         name: "k304",
         id: 255004979637649408n
     },
+    whoami: {
+        name: "whoami.udonotknow",
+        id: 274285684100169731n
+    },
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
## Summary

Adds the **VoiceBulkMove** plugin. Right-click a voice/stage channel and choose "Bulk move members" to open a modal listing every connected member (avatar + name + checkbox) with a select-all toggle and a target voice channel dropdown. Picking a target and clicking "Move selected" moves all checked members.

Moves use the standard member move endpoint (`PATCH /guilds/{guild}/members/{user}`), spaced ~200ms apart to respect rate limits. The menu item only appears when you have the Move Members permission.

Also registers the new contributor in `EquicordDevs`.

## Notes

- This plugin was developed with AI assistance.
- Tested on **Arch Linux** with the **Equibop** client.