### PR TITLE
feat(ExportMessages): add multi-message picker and correct save location

### DIFF
--- a/src/equicordplugins/exportMessages/MultiMessageExportModal.tsx
+++ b/src/equicordplugins/exportMessages/MultiMessageExportModal.tsx
@@ -30,8 +30,8 @@ export function MultiMessageExportModal({ modalProps, initialMessage, onExport }
         [MessageStore],
         () => {
             const cached = [...MessageStore.getMessages(initialMessage.channel_id)?._array ?? []].filter(m => !m.deleted);
-            if (cached.some(m => m.id === initialMessage.id)) return cached;
-            return [...cached, initialMessage].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+            if (!cached.some(m => m.id === initialMessage.id)) cached.push(initialMessage);
+            return cached.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
         },
         [initialMessage]
     );

--- a/src/equicordplugins/exportMessages/MultiMessageExportModal.tsx
+++ b/src/equicordplugins/exportMessages/MultiMessageExportModal.tsx
@@ -7,10 +7,25 @@
 import { BaseText } from "@components/BaseText";
 import { classNameFactory } from "@utils/css";
 import { classes, getUserAvatarUrl } from "@utils/misc";
-import { Message, type RenderModalProps } from "@vencord/discord-types";
-import { Avatar, Checkbox, Clickable, MessageStore, Modal, moment, useLayoutEffect, useRef, useState, useStateFromStores } from "@webpack/common";
+import { Message, type RenderModalProps, type ScrollerBaseRef } from "@vencord/discord-types";
+import { findByCodeLazy } from "@webpack";
+import { Avatar, Checkbox, Clickable, Constants, ListScrollerThin, MessageStore, Modal, moment, RestAPI, showToast, SnowflakeUtils, Toasts, useEffect, useLayoutEffect, useRef, useState } from "@webpack/common";
 
 const cl = classNameFactory("vc-exportmessages-");
+const PAGE_SIZE = 50;
+const AROUND_LIMIT = PAGE_SIZE * 2;
+const ROW_HEIGHT = 50;
+
+const createMessageRecord = findByCodeLazy(".createFromServer(", ".isBlockedForMessage", "messageReference:");
+
+type PageDirection = "before" | "after";
+
+interface MessageHistory {
+    messages: Message[];
+    hasMoreBefore: boolean;
+    hasMoreAfter: boolean;
+    needsAround: boolean;
+}
 
 interface MultiMessageExportModalProps {
     modalProps: RenderModalProps;
@@ -25,30 +40,179 @@ function getMessagePreview(message: Message) {
     return "";
 }
 
-export function MultiMessageExportModal({ modalProps, initialMessage, onExport }: MultiMessageExportModalProps) {
-    const messages = useStateFromStores(
-        [MessageStore],
-        () => {
-            const cached = [...MessageStore.getMessages(initialMessage.channel_id)?._array ?? []].filter(m => !m.deleted);
-            if (!cached.some(m => m.id === initialMessage.id)) cached.push(initialMessage);
-            return cached.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
-        },
-        [initialMessage]
-    );
+function mergeMessages(messages: Message[], initialMessage: Message) {
+    const messagesById = new Map<string, Message>();
+    for (const message of messages) {
+        if (!message.deleted) messagesById.set(message.id, message);
+    }
+    messagesById.set(initialMessage.id, messagesById.get(initialMessage.id) ?? initialMessage);
 
+    return [...messagesById.values()].sort((a, b) => SnowflakeUtils.compare(a.id, b.id));
+}
+
+function getInitialHistory(initialMessage: Message): MessageHistory {
+    const cache = MessageStore.getMessages(initialMessage.channel_id);
+    const cached = [
+        ...(cache?._before?._messages ?? []),
+        ...(cache?._array ?? []),
+        ...(cache?._after?._messages ?? [])
+    ];
+    const initialIsCached = cached.some(message => message.id === initialMessage.id);
+    const messages = mergeMessages(initialIsCached ? cached : [], initialMessage);
+    const initialIndex = messages.findIndex(message => message.id === initialMessage.id);
+    const hasMoreBefore = !initialIsCached || Boolean(cache?.hasMoreBefore);
+    const hasMoreAfter = !initialIsCached || Boolean(cache?.hasMoreAfter);
+
+    return {
+        messages,
+        hasMoreBefore,
+        hasMoreAfter,
+        needsAround: !initialIsCached
+            || hasMoreBefore && initialIndex < PAGE_SIZE / 2
+            || hasMoreAfter && messages.length - initialIndex - 1 < PAGE_SIZE / 2
+    };
+}
+
+async function fetchMessagePage(channelId: string, query: Record<string, string | number>) {
+    const response = await RestAPI.get({
+        url: Constants.Endpoints.MESSAGES(channelId),
+        query
+    });
+
+    if (!Array.isArray(response?.body)) throw new Error("Invalid message response");
+    return response.body.map(message => createMessageRecord(message) as Message);
+}
+
+export function MultiMessageExportModal({ modalProps, initialMessage, onExport }: MultiMessageExportModalProps) {
+    const [history, setHistory] = useState(() => getInitialHistory(initialMessage));
     const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set([initialMessage.id]));
     const anchorId = useRef(initialMessage.id);
     const [isExporting, setIsExporting] = useState(false);
-    const initialRowRef = useRef<HTMLDivElement | null>(null);
-    const selectedMessages = messages.filter(m => selectedIds.has(m.id));
+    const [initialLoadFailed, setInitialLoadFailed] = useState(false);
+    const [aroundAttempt, setAroundAttempt] = useState(0);
+    const historyRef = useRef(history);
+    const isLoadingRef = useRef(history.needsAround);
+    const requestGeneration = useRef(0);
+    const listRef = useRef<ScrollerBaseRef>(null);
+    const listContainerRef = useRef<HTMLDivElement>(null);
+    const pendingScroll = useRef<"center" | { distanceFromTop: number; added: number; } | null>("center");
+    const selectedMessages = history.messages.filter(message => selectedIds.has(message.id));
+
+    historyRef.current = history;
 
     useLayoutEffect(() => {
-        initialRowRef.current?.scrollIntoView({ block: "center" });
-    }, []);
+        const scroller = listRef.current;
+        const pending = pendingScroll.current;
+        if (!scroller || !pending) return;
+
+        if (pending === "center") {
+            const initialIndex = history.messages.findIndex(message => message.id === initialMessage.id);
+            const viewportHeight = listContainerRef.current?.clientHeight ?? ROW_HEIGHT;
+            scroller.scrollTo({
+                to: Math.max(0, initialIndex * ROW_HEIGHT - (viewportHeight - ROW_HEIGHT) / 2)
+            });
+        } else {
+            scroller.scrollTo({ to: pending.distanceFromTop + pending.added * ROW_HEIGHT });
+        }
+        pendingScroll.current = null;
+    }, [history.messages]);
+
+    useEffect(() => {
+        if (!history.needsAround) return () => void requestGeneration.current++;
+
+        const generation = ++requestGeneration.current;
+        isLoadingRef.current = true;
+        setInitialLoadFailed(false);
+        void fetchMessagePage(initialMessage.channel_id, {
+            around: initialMessage.id,
+            limit: AROUND_LIMIT
+        }).then(fetched => {
+            if (requestGeneration.current !== generation) return;
+            const { current } = historyRef;
+            const olderCount = fetched.filter(message => SnowflakeUtils.compare(message.id, initialMessage.id) < 0).length;
+            const laterCount = fetched.filter(message => SnowflakeUtils.compare(message.id, initialMessage.id) > 0).length;
+
+            pendingScroll.current = "center";
+            setHistory({
+                messages: mergeMessages([...current.messages, ...fetched], initialMessage),
+                hasMoreBefore: current.hasMoreBefore && olderCount >= PAGE_SIZE - 1,
+                hasMoreAfter: current.hasMoreAfter && laterCount >= PAGE_SIZE - 1,
+                needsAround: false
+            });
+        }).catch(() => {
+            if (requestGeneration.current === generation) {
+                setInitialLoadFailed(true);
+                showToast("Failed to load more messages.", Toasts.Type.FAILURE);
+            }
+        }).finally(() => {
+            if (requestGeneration.current !== generation) return;
+            isLoadingRef.current = false;
+        });
+
+        return () => {
+            requestGeneration.current++;
+        };
+    }, [initialMessage.channel_id, initialMessage.id, aroundAttempt]);
+
+    async function loadMore(direction: PageDirection) {
+        const { current } = historyRef;
+        const hasMore = direction === "before" ? current.hasMoreBefore : current.hasMoreAfter;
+        if (isLoadingRef.current || !hasMore) return;
+
+        const cursor = direction === "before" ? current.messages[0] : current.messages.at(-1);
+        if (!cursor) return;
+
+        const generation = ++requestGeneration.current;
+        isLoadingRef.current = true;
+
+        try {
+            const fetched = await fetchMessagePage(initialMessage.channel_id, {
+                [direction]: cursor.id,
+                limit: PAGE_SIZE
+            });
+            if (requestGeneration.current !== generation) return;
+
+            const messages = mergeMessages([...current.messages, ...fetched], initialMessage);
+            const added = messages.length - current.messages.length;
+            if (direction === "before" && added > 0)
+                pendingScroll.current = {
+                    distanceFromTop: listRef.current?.getDistanceFromTop() ?? 0,
+                    added
+                };
+
+            setHistory({
+                messages,
+                hasMoreBefore: direction === "before" ? fetched.length === PAGE_SIZE && added > 0 : current.hasMoreBefore,
+                hasMoreAfter: direction === "after" ? fetched.length === PAGE_SIZE && added > 0 : current.hasMoreAfter,
+                needsAround: false
+            });
+        } catch {
+            if (requestGeneration.current === generation)
+                showToast(`Failed to load ${direction === "before" ? "earlier" : "later"} messages.`, Toasts.Type.FAILURE);
+        } finally {
+            if (requestGeneration.current !== generation) return;
+            isLoadingRef.current = false;
+        }
+    }
+
+    function handleScroll() {
+        const scroller = listRef.current;
+        if (!scroller || isLoadingRef.current) return;
+
+        const { current } = historyRef;
+        if (current.hasMoreBefore && scroller.getDistanceFromTop() < ROW_HEIGHT * 2)
+            void loadMore("before");
+        else if (current.hasMoreAfter && scroller.getDistanceFromBottom() < ROW_HEIGHT * 2)
+            void loadMore("after");
+    }
+
+    function retryInitialLoad() {
+        if (!isLoadingRef.current) setAroundAttempt(attempt => attempt + 1);
+    }
 
     function toggleMessage(message: Message, shiftKey: boolean) {
         if (shiftKey) {
-            const ids = messages.map(m => m.id);
+            const ids = history.messages.map(m => m.id);
             const start = ids.indexOf(anchorId.current);
             const end = ids.indexOf(message.id);
             if (start !== -1 && end !== -1) {
@@ -100,6 +264,12 @@ export function MultiMessageExportModal({ modalProps, initialMessage, onExport }
                     onClick: modalProps.onClose,
                     disabled: isExporting
                 },
+                ...(initialLoadFailed ? [{
+                    text: "Retry",
+                    variant: "secondary" as const,
+                    onClick: retryInitialLoad,
+                    disabled: isExporting
+                }] : []),
                 {
                     text: `Export (${selectedMessages.length})`,
                     variant: "primary",
@@ -108,48 +278,57 @@ export function MultiMessageExportModal({ modalProps, initialMessage, onExport }
                 }
             ]}
         >
-            <div className={cl("list")}>
-                {messages.map(message => {
-                    const isSelected = selectedIds.has(message.id);
-                    const { author } = message;
-                    const name = author.globalName ?? author.username;
+            <div ref={listContainerRef} className={cl("list")}>
+                <ListScrollerThin
+                    ref={listRef}
+                    className={cl("list-scroller")}
+                    sections={[history.messages.length]}
+                    sectionHeight={0}
+                    rowHeight={ROW_HEIGHT}
+                    renderSection={() => null}
+                    onScroll={handleScroll}
+                    innerRole="group"
+                    innerAriaLabel="Messages available to export"
+                    renderRow={({ row }) => {
+                        const message = history.messages[row];
+                        const isSelected = selectedIds.has(message.id);
+                        const { author } = message;
+                        const name = author.globalName ?? author.username;
 
-                    return (
-                        <Clickable
-                            key={message.id}
-                            className={classes(cl("row"), isSelected && cl("row-selected"))}
-                            role="checkbox"
-                            aria-checked={isSelected}
-                            onClick={e => toggleMessage(message, e.shiftKey)}
-                        >
-                            <div className={cl("checkbox")}>
-                                <Checkbox
-                                    value={isSelected}
-                                    onChange={() => { }}
-                                    displayOnly
-                                    size={20}
-                                />
-                            </div>
-                            <div
-                                ref={message.id === initialMessage.id ? initialRowRef : undefined}
-                                className={cl("row-content")}
+                        return (
+                            <Clickable
+                                key={message.id}
+                                className={classes(cl("row"), isSelected && cl("row-selected"))}
+                                role="checkbox"
+                                aria-checked={isSelected}
+                                onClick={e => toggleMessage(message, e.shiftKey)}
                             >
-                                <Avatar src={getUserAvatarUrl(author)} size="SIZE_32" aria-label={name} />
-                                <div className={cl("details")}>
-                                    <div className={cl("meta")}>
-                                        <BaseText size="sm" weight="medium">{name}</BaseText>
-                                        <BaseText size="xs" color="text-subtle">
-                                            {moment(message.timestamp).format("L LT")}
+                                <div className={cl("checkbox")}>
+                                    <Checkbox
+                                        value={isSelected}
+                                        onChange={() => { }}
+                                        displayOnly
+                                        size={20}
+                                    />
+                                </div>
+                                <div className={cl("row-content")}>
+                                    <Avatar src={getUserAvatarUrl(author)} size="SIZE_32" aria-label={name} />
+                                    <div className={cl("details")}>
+                                        <div className={cl("meta")}>
+                                            <BaseText size="sm" weight="medium">{name}</BaseText>
+                                            <BaseText size="xs" color="text-subtle">
+                                                {moment(message.timestamp).format("L LT")}
+                                            </BaseText>
+                                        </div>
+                                        <BaseText size="sm" color="text-muted" className={cl("preview")}>
+                                            {getMessagePreview(message)}
                                         </BaseText>
                                     </div>
-                                    <BaseText size="sm" color="text-muted" className={cl("preview")}>
-                                        {getMessagePreview(message)}
-                                    </BaseText>
                                 </div>
-                            </div>
-                        </Clickable>
-                    );
-                })}
+                            </Clickable>
+                        );
+                    }}
+                />
             </div>
         </Modal>
     );

--- a/src/equicordplugins/exportMessages/MultiMessageExportModal.tsx
+++ b/src/equicordplugins/exportMessages/MultiMessageExportModal.tsx
@@ -1,0 +1,156 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { BaseText } from "@components/BaseText";
+import { classNameFactory } from "@utils/css";
+import { classes, getUserAvatarUrl } from "@utils/misc";
+import { Message, type RenderModalProps } from "@vencord/discord-types";
+import { Avatar, Checkbox, Clickable, MessageStore, Modal, moment, useLayoutEffect, useRef, useState, useStateFromStores } from "@webpack/common";
+
+const cl = classNameFactory("vc-exportmessages-");
+
+interface MultiMessageExportModalProps {
+    modalProps: RenderModalProps;
+    initialMessage: Message;
+    onExport(messages: Message[]): Promise<boolean>;
+}
+
+function getMessagePreview(message: Message) {
+    if (message.content) return message.content;
+    if (message.attachments?.length > 0) return message.attachments.map(a => a.filename).join(", ");
+    if (message.embeds?.length > 0) return message.embeds.map(e => e.rawTitle ?? "Embed").join(", ");
+    return "";
+}
+
+export function MultiMessageExportModal({ modalProps, initialMessage, onExport }: MultiMessageExportModalProps) {
+    const messages = useStateFromStores(
+        [MessageStore],
+        () => {
+            const cached = [...MessageStore.getMessages(initialMessage.channel_id)?._array ?? []].filter(m => !m.deleted);
+            if (cached.some(m => m.id === initialMessage.id)) return cached;
+            return [...cached, initialMessage].sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+        },
+        [initialMessage]
+    );
+
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set([initialMessage.id]));
+    const anchorId = useRef(initialMessage.id);
+    const [isExporting, setIsExporting] = useState(false);
+    const initialRowRef = useRef<HTMLDivElement | null>(null);
+    const selectedMessages = messages.filter(m => selectedIds.has(m.id));
+
+    useLayoutEffect(() => {
+        initialRowRef.current?.scrollIntoView({ block: "center" });
+    }, []);
+
+    function toggleMessage(message: Message, shiftKey: boolean) {
+        if (shiftKey) {
+            const ids = messages.map(m => m.id);
+            const start = ids.indexOf(anchorId.current);
+            const end = ids.indexOf(message.id);
+            if (start !== -1 && end !== -1) {
+                const [from, to] = start <= end ? [start, end] : [end, start];
+                setSelectedIds(prev => {
+                    const next = new Set(prev);
+                    const shouldSelect = !next.has(message.id);
+                    for (const id of ids.slice(from, to + 1)) {
+                        if (shouldSelect) next.add(id);
+                        else next.delete(id);
+                    }
+                    return next;
+                });
+                anchorId.current = message.id;
+                return;
+            }
+        }
+
+        anchorId.current = message.id;
+        setSelectedIds(prev => {
+            const next = new Set(prev);
+            if (next.has(message.id)) next.delete(message.id);
+            else next.add(message.id);
+            return next;
+        });
+    }
+
+    async function handleExport() {
+        if (isExporting || selectedMessages.length === 0) return;
+
+        setIsExporting(true);
+        if (await onExport(selectedMessages)) {
+            modalProps.onClose();
+            return;
+        }
+        setIsExporting(false);
+    }
+
+    return (
+        <Modal
+            {...modalProps}
+            size="lg"
+            title="Export Messages"
+            subtitle="Shift-click to select multiple messages."
+            actions={[
+                {
+                    text: "Cancel",
+                    variant: "secondary",
+                    onClick: modalProps.onClose,
+                    disabled: isExporting
+                },
+                {
+                    text: `Export (${selectedMessages.length})`,
+                    variant: "primary",
+                    onClick: () => void handleExport(),
+                    disabled: isExporting || selectedMessages.length === 0
+                }
+            ]}
+        >
+            <div className={cl("list")}>
+                {messages.map(message => {
+                    const isSelected = selectedIds.has(message.id);
+                    const { author } = message;
+                    const name = author.globalName ?? author.username;
+
+                    return (
+                        <Clickable
+                            key={message.id}
+                            className={classes(cl("row"), isSelected && cl("row-selected"))}
+                            role="checkbox"
+                            aria-checked={isSelected}
+                            onClick={e => toggleMessage(message, e.shiftKey)}
+                        >
+                            <div className={cl("checkbox")}>
+                                <Checkbox
+                                    value={isSelected}
+                                    onChange={() => { }}
+                                    displayOnly
+                                    size={20}
+                                />
+                            </div>
+                            <div
+                                ref={message.id === initialMessage.id ? initialRowRef : undefined}
+                                className={cl("row-content")}
+                            >
+                                <Avatar src={getUserAvatarUrl(author)} size="SIZE_32" aria-label={name} />
+                                <div className={cl("details")}>
+                                    <div className={cl("meta")}>
+                                        <BaseText size="sm" weight="medium">{name}</BaseText>
+                                        <BaseText size="xs" color="text-subtle">
+                                            {moment(message.timestamp).format("L LT")}
+                                        </BaseText>
+                                    </div>
+                                    <BaseText size="sm" color="text-muted" className={cl("preview")}>
+                                        {getMessagePreview(message)}
+                                    </BaseText>
+                                </div>
+                            </div>
+                        </Clickable>
+                    );
+                })}
+            </div>
+        </Modal>
+    );
+}

--- a/src/equicordplugins/exportMessages/index.tsx
+++ b/src/equicordplugins/exportMessages/index.tsx
@@ -6,23 +6,24 @@
 
 import "./styles.css";
 
-import { showNotification } from "@api/Notifications";
 import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { copyToClipboard } from "@utils/clipboard";
 import { EquicordDevs } from "@utils/constants";
+import { openModal } from "@utils/modal";
 import { showItemInFolder } from "@utils/native";
 import definePlugin, { OptionType } from "@utils/types";
 import { saveFile } from "@utils/web";
 import { Message } from "@vencord/discord-types";
-import { Menu, Toasts } from "@webpack/common";
+import { Menu, showToast, Toasts } from "@webpack/common";
 
+import { MultiMessageExportModal } from "./MultiMessageExportModal";
 import { ContactsList } from "./types";
 
 const settings = definePluginSettings({
     openFileAfterExport: {
         type: OptionType.BOOLEAN,
-        description: "Open the exported file in the default file handler after export",
+        description: "Show the exported file in its folder after export",
         default: true
     },
     exportContacts: {
@@ -61,36 +62,36 @@ function formatMessage(message: Message) {
     return content;
 }
 
-async function exportMessage(message: Message) {
-    const timestamp = new Date(message.timestamp.toString()).toISOString().split("T")[0];
-    const filename = `message-${message.id}-${timestamp}.txt`;
+async function exportMessages(messages: Message[]) {
+    const first = messages[0];
+    const last = messages[messages.length - 1];
+    const isMultiple = messages.length > 1;
+    const timestamp = (isMultiple ? new Date() : new Date(first.timestamp.toString())).toISOString().split("T")[0];
+    const filename = isMultiple
+        ? `messages-${first.id}-${last.id}-${timestamp}.txt`
+        : `message-${first.id}-${timestamp}.txt`;
 
-    const content = formatMessage(message);
+    const content = messages.map(formatMessage).join("\n\n");
 
     try {
         if (IS_DISCORD_DESKTOP) {
             const data = new TextEncoder().encode(content);
-            const result = await DiscordNative.fileManager.saveWithDialog(data, filename);
+            const result: { canceledByUser: boolean; filePath: string; } | null = await DiscordNative.fileManager.saveWithDialog2(data, filename);
+            if (!result || result.canceledByUser) return false;
 
-            if (result && settings.store.openFileAfterExport) {
-                showItemInFolder(result);
+            if (settings.store.openFileAfterExport) {
+                showItemInFolder(result.filePath);
             }
         } else {
             const file = new File([content], filename, { type: "text/plain" });
             saveFile(file);
         }
 
-        showNotification({
-            title: "Export Messages",
-            body: `Message exported successfully as ${filename}`,
-            icon: "📄"
-        });
-    } catch (error) {
-        showNotification({
-            title: "Export Messages",
-            body: "Failed to export message",
-            icon: "❌"
-        });
+        showToast(isMultiple ? `${messages.length} messages exported.` : "Message exported.", Toasts.Type.SUCCESS);
+        return true;
+    } catch {
+        showToast(isMultiple ? "Failed to export messages." : "Failed to export message.", Toasts.Type.FAILURE);
+        return false;
     }
 }
 
@@ -101,15 +102,31 @@ const messageContextMenuPatch = (children: Array<React.ReactElement<any> | null>
 
     children.push(
         <Menu.MenuItem
-            id="export-message"
-            label="Export Message"
+            id="export-messages"
+            label="Export Messages"
             icon={() => (
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
                 </svg>
             )}
-            action={() => exportMessage(message)}
-        />
+        >
+            <Menu.MenuItem
+                id="export-message"
+                label="This Message"
+                action={() => exportMessages([message])}
+            />
+            <Menu.MenuItem
+                id="export-multiple-messages"
+                label="Select Messages..."
+                action={() => openModal(modalProps => (
+                    <MultiMessageExportModal
+                        modalProps={modalProps}
+                        initialMessage={message}
+                        onExport={exportMessages}
+                    />
+                ))}
+            />
+        </Menu.MenuItem>
     );
 };
 
@@ -128,9 +145,9 @@ function getUsernames(contacts: ContactsList[], type: number): string[] {
 
 export default definePlugin({
     name: "ExportMessages",
-    description: "Allows you to export any message to a file",
+    description: "Allows you to export one or multiple messages to a file",
     tags: ["Chat", "Utility"],
-    authors: [EquicordDevs.veygax, EquicordDevs.dat_insanity],
+    authors: [EquicordDevs.veygax, EquicordDevs.dat_insanity, EquicordDevs.Z1xus],
     settings,
     contextMenus: {
         "message": messageContextMenuPatch

--- a/src/equicordplugins/exportMessages/index.tsx
+++ b/src/equicordplugins/exportMessages/index.tsx
@@ -10,12 +10,11 @@ import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { copyToClipboard } from "@utils/clipboard";
 import { EquicordDevs } from "@utils/constants";
-import { openModal } from "@utils/modal";
 import { showItemInFolder } from "@utils/native";
 import definePlugin, { OptionType } from "@utils/types";
 import { saveFile } from "@utils/web";
 import { Message } from "@vencord/discord-types";
-import { Menu, showToast, Toasts } from "@webpack/common";
+import { Menu, openModal, showToast, Toasts } from "@webpack/common";
 
 import { MultiMessageExportModal } from "./MultiMessageExportModal";
 import { ContactsList } from "./types";

--- a/src/equicordplugins/exportMessages/styles.css
+++ b/src/equicordplugins/exportMessages/styles.css
@@ -25,3 +25,62 @@
 .export-contacts-button:hover {
     background-color: #454fbf;
 }
+
+.vc-exportmessages-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.vc-exportmessages-row {
+    display: flex;
+    align-items: center;
+    border-radius: 8px;
+    user-select: none;
+}
+
+.vc-exportmessages-checkbox {
+    display: flex;
+    flex: 0 0 20px;
+    align-items: center;
+    justify-content: center;
+    margin-left: 8px;
+    pointer-events: none;
+}
+
+.vc-exportmessages-row:hover {
+    background-color: var(--background-modifier-hover);
+}
+
+.vc-exportmessages-row-selected {
+    background-color: var(--background-modifier-selected);
+}
+
+.vc-exportmessages-row-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex: 1;
+    min-width: 0;
+    padding: 8px 8px 8px 12px;
+}
+
+.vc-exportmessages-details {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+    min-width: 0;
+}
+
+.vc-exportmessages-meta {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+
+.vc-exportmessages-preview {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/src/equicordplugins/exportMessages/styles.css
+++ b/src/equicordplugins/exportMessages/styles.css
@@ -27,14 +27,18 @@
 }
 
 .vc-exportmessages-list {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
+    height: clamp(240px, 60vh, 600px);
+}
+
+.vc-exportmessages-list-scroller {
+    height: 100%;
 }
 
 .vc-exportmessages-row {
     display: flex;
     align-items: center;
+    height: 48px;
+    margin-bottom: 2px;
     border-radius: 8px;
     user-select: none;
 }


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
Also do not use AI in communication, it makes me ill
-->

## Describe your Changes
this pr adds a modal to pick multiple messages, consolidating the two options under a dropdown in the context menu (see screenshot)

also replaced saveWithDialog w/ saveWithDialog2 because saveWithDialog was only returning the folder making show in folder open the wrong location. and replaced broken notifications with toasts (previously it was passing the emoji as the image url ???)

## Screenshots (if applicable)
dropdown:
<img width="424" height="119" alt="wezterm-gui_GJl45nWcmH" src="https://github.com/user-attachments/assets/7d636789-be42-4d9a-857b-cacbccffec00" />
modal:
<img width="680" height="856" alt="Discord_HhT21I1ba8" src="https://github.com/user-attachments/assets/cad32a52-2bff-46fd-b9dd-488926685199" />
old broken notification:
<img width="366" height="192" alt="Discord_6TJwR0VBwD" src="https://github.com/user-attachments/assets/4fbab650-e934-46e9-9fc0-fde862f9bd35" />
new sexy toasts:
<img width="227" height="70" alt="Discord_pXFuWG0LI2" src="https://github.com/user-attachments/assets/e48ffa8a-778e-4f6d-8714-b91613fbfa63" />

## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
