### PR TITLE
Fixes: Questify, Declutter, MiddleClickTweaks, ServerInfo

### DIFF
--- a/src/equicordplugins/declutter/index.tsx
+++ b/src/equicordplugins/declutter/index.tsx
@@ -325,12 +325,12 @@ export default definePlugin({
                     predicate: () => settings.store.removeShopAboveDms,
                 },
                 {
-                    match: /\.QUEST_HOME\},"quests"\)/,
+                    match: /\.QUEST_HOME\)\},"quests"\)/,
                     replace: "$&&&undefined",
                     predicate: () => settings.store.removeQuestsAboveDms,
                 },
                 {
-                    match: /\.APPLICATION_LIBRARY\},"library"\)/,
+                    match: /\.APPLICATION_LIBRARY\)\},"library"\)/,
                     replace: "$&&&undefined",
                     predicate: () => settings.store.removeLibraryAboveDms,
                 },

--- a/src/equicordplugins/limitlessScreenshare/style.css
+++ b/src/equicordplugins/limitlessScreenshare/style.css
@@ -7,7 +7,7 @@
     padding-left: 0.5em;
 }
 
-.vc-limitlessScreenshare-settings-flex-input > div:has(+ button) div:has(> input) {
+.vc-limitlessScreenshare-settings-flex-input > div:first-child > div > div > div {
     --custom-text-input-height: 2em;
 
     width: 5em;

--- a/src/equicordplugins/middleClickTweaks/index.ts
+++ b/src/equicordplugins/middleClickTweaks/index.ts
@@ -103,7 +103,7 @@ export default definePlugin({
             // Detects paste events triggered by the "browser" outside of input fields.
             find: 'document.addEventListener("paste",',
             replacement: {
-                match: /(?<=\.getMigrationStatus\(\)\);.{0,50}\i\((\i)\)\{)/,
+                match: /(?<=APPLICATION_DIRECTORY}\)}\(\);return \i\.useEffect\(\(\)=>{function \i\((\i)\)\{)/,
                 replace: "if($1.target.tagName===\"BUTTON\"||$self.isPastingDisabled(false)){$1.preventDefault?.();$1.stopPropagation?.();return;};"
             }
         },

--- a/src/equicordplugins/questify/index.tsx
+++ b/src/equicordplugins/questify/index.tsx
@@ -199,7 +199,7 @@ export default definePlugin({
         },
         {
             // Hides Quests tab in the DMs tab list.
-            find: ".QUEST_HOME):",
+            find: '.QUEST_HOME)},"quests")',
             predicate: () => getQuestifySettings().disableQuestsEverything,
             replacement: [
                 {

--- a/src/plugins/serverInfo/index.tsx
+++ b/src/plugins/serverInfo/index.tsx
@@ -57,6 +57,7 @@ export default definePlugin({
     dependencies: ["DynamicImageModalAPI"],
     searchTerms: ["guild", "info", "ServerProfile"],
     isModified: true,
+    settings,
     contextMenus: {
         "guild-context": makePatch(false),
         "guild-header-popout": makePatch(true)


### PR DESCRIPTION
Fixes:
- Updated broken find for Questify.
- Updated broken matches for Declutter.
- Updated broken match for MiddleClickTweaks.
- Fixed regression in recent ServerInfo merge which dropped the `settings` object from the plugin definition which leads to client crashes in the ServerInfo modal.