### PR TITLE
 SMYN: Make custom names searchable in mention autocomplete

### DIFF
--- a/src/plugins/showMeYourName/index.tsx
+++ b/src/plugins/showMeYourName/index.tsx
@@ -16,6 +16,7 @@ import { Heading } from "@components/Heading";
 import ircColors from "@plugins/ircColors";
 import mentionAvatars from "@plugins/mentionAvatars";
 import { Devs, EquicordDevs } from "@utils/constants";
+import { getCurrentChannel } from "@utils/discord";
 import { classNameFactory } from "@utils/index";
 import definePlugin, { OptionType } from "@utils/types";
 import { GuildMember, Message, RenderModalProps, User } from "@vencord/discord-types";
@@ -1253,6 +1254,12 @@ const settings = definePluginSettings({
     },
 });
 
+function matchableCustomName(userId: string) {
+    const custom = customNicknames[userId];
+    if (!custom || (settings.store.customNameOnlyInDirectMessages && getCurrentChannel()?.guild_id)) return "";
+    return custom.toLocaleLowerCase();
+}
+
 export default definePlugin({
     name: "ShowMeYourName",
     description: "Display any permutation of custom nicknames, friend nicknames, server nicknames, display names, and usernames in chat.",
@@ -1500,6 +1507,23 @@ export default definePlugin({
                 match: /(serverDeaf:\i,)nick:(\i)/,
                 replace: "$1showMeYourNameVoice:$2=$self.getTypingMemberListProfilesReactionsVoiceNameText({user:arguments[0].user,guildId:arguments[0].channel.guild_id,type:\"voiceChannel\"})??(arguments[0].nick)"
             }
+        },
+        {
+            // Let the mention autocomplete match custom names too.
+            find: "queryGuildMentionResults(",
+            group: true,
+            replacement: [
+                {
+                    // Rank a leading match the same as one on a username, nickname or display name.
+                    match: /\i&&\i===(\i)\.id\|\|\i\.substring\(0,(\i)\.length\)===\2\|\|/,
+                    replace: "$&$self.matchableCustomName($1.id).startsWith($2)||"
+                },
+                {
+                    // Rank a looser match with the same matcher and tier as those names.
+                    match: /\i<50&&\((\i)\(\)\((\i),\i\).{0,120}?(?=\)&&\(\i\.push\(\{type:\i\.\i\.\i,record:(\i),)/,
+                    replace: "$&||$1()($2,$self.matchableCustomName($3.id))"
+                }
+            ]
         }
     ],
 
@@ -1551,5 +1575,6 @@ export default definePlugin({
     getNativeGradientGlowOverflowClassName,
     shouldAnimateNameEffects,
     getTypingMemberListProfilesReactionsVoiceNameText,
-    getTypingMemberListProfilesReactionsVoiceNameElement
+    getTypingMemberListProfilesReactionsVoiceNameElement,
+    matchableCustomName
 });


### PR DESCRIPTION
## Describe your Changes

Makes users you've given a custom name findable by that name in the @ mention
autocomplete. Right now they only come up under their real name.

The names shown in the suggestions are unchanged ― the swap happens only inside the list handed to the matching.

## Screenshots (if applicable)
- <img width="260" height="148" alt="image" src="https://github.com/user-attachments/assets/9e71a9aa-3cae-4f81-995a-f28a4d5ddb8f" />

- <img width="259" height="64" alt="image" src="https://github.com/user-attachments/assets/d6be5a1b-04b9-4b23-8c6e-02eaa75726d6" />


## Checklist before submitting

- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent