### PR TITLE
MessageLoggerEnhanced: Auto delete option for hide message from message loggers

### DIFF
--- a/src/equicordplugins/messageLoggerEnhanced/index.tsx
+++ b/src/equicordplugins/messageLoggerEnhanced/index.tsx
@@ -188,6 +188,7 @@ function messageCreateHandler(payload: MessageCreatePayload) {
         const nonce = String(payload.message.nonce);
         pendingAutoDeleteNonces.delete(nonce);
         MessageActions.deleteMessage(payload.channelId ?? payload.message.channel_id, payload.message.id);
+        return;
     }
 
     // we do this here because cache is limited and to save memory

--- a/src/equicordplugins/messageLoggerEnhanced/index.tsx
+++ b/src/equicordplugins/messageLoggerEnhanced/index.tsx
@@ -14,7 +14,7 @@ import { classNameFactory } from "@utils/css";
 import { Logger } from "@utils/Logger";
 import definePlugin from "@utils/types";
 import { findByPropsLazy } from "@webpack";
-import { FluxDispatcher, MessageStore, SelectedChannelStore, UserStore } from "@webpack/common";
+import { FluxDispatcher, MessageActions, MessageStore, SelectedChannelStore, UserStore } from "@webpack/common";
 
 import { OpenLogsButton } from "./components/LogsButton";
 import { openLogModal } from "./components/LogsModal";
@@ -23,7 +23,7 @@ import * as LoggedMessageManager from "./LoggedMessageManager";
 import { addMessage } from "./LoggedMessageManager";
 import { settings } from "./settings";
 import { FetchMessagesResponse, LoadMessagePayload, LoggedMessage, LoggedMessageJSON, MessageCreatePayload, MessageDeleteBulkPayload, MessageDeletePayload, MessageUpdatePayload } from "./types";
-import { cleanUpCachedMessage, cleanupUserObject, getNative, isGhostPinged, mapTimestamp, messageJsonToMessageClass, reAddDeletedMessages } from "./utils";
+import { cleanUpCachedMessage, cleanupUserObject, getNative, isGhostPinged, mapTimestamp, messageJsonToMessageClass, pendingAutoDeleteNonces, reAddDeletedMessages } from "./utils";
 import { removeContextMenuBindings, setupContextMenuPatches } from "./utils/contextMenu";
 import { shouldIgnore } from "./utils/index";
 import { LimitedMap } from "./utils/LimitedMap";
@@ -180,6 +180,16 @@ async function messageUpdateHandler(payload: MessageUpdatePayload) {
 }
 
 function messageCreateHandler(payload: MessageCreatePayload) {
+    if (
+        !payload.optimistic &&
+        payload.message?.nonce &&
+        pendingAutoDeleteNonces.has(String(payload.message.nonce))
+    ) {
+        const nonce = String(payload.message.nonce);
+        pendingAutoDeleteNonces.delete(nonce);
+        MessageActions.deleteMessage(payload.channelId ?? payload.message.channel_id, payload.message.id);
+    }
+
     // we do this here because cache is limited and to save memory
     if (!settings.store.cacheMessagesFromServers && payload.guildId != null) {
         const ids = [payload.channelId, payload.message?.author?.id, payload.guildId];

--- a/src/equicordplugins/messageLoggerEnhanced/settings.tsx
+++ b/src/equicordplugins/messageLoggerEnhanced/settings.tsx
@@ -149,6 +149,18 @@ export const settings = definePluginSettings({
         description: "When enabled, a context menu button will be added to messages to allow you to delete messages without them being logged by other loggers. Might not be safe, use at your own risk."
     },
 
+    hideMessageFromMessageLoggersDeletedMessage: {
+        default: "redacted eh",
+        type: OptionType.STRING,
+        description: "The message content to replace the message with when using the hide message from message loggers feature.",
+    },
+
+    autoDeleteHideMessageFromMessageLoggersDeletedMessage: {
+        default: false,
+        type: OptionType.BOOLEAN,
+        description: "Whether to auto delete the \"Hide message from message loggers deleted message\" after sending.",
+    },
+
     ShowLogsButton: {
         default: true,
         type: OptionType.BOOLEAN,
@@ -166,12 +178,6 @@ export const settings = definePluginSettings({
         default: 100,
         type: OptionType.NUMBER,
         description: "Number of messages to display at once in logs & number of messages to load when loading more messages in logs.",
-    },
-
-    hideMessageFromMessageLoggersDeletedMessage: {
-        default: "redacted eh",
-        type: OptionType.STRING,
-        description: "The message content to replace the message with when using the hide message from message loggers feature.",
     },
 
     messageLimit: {

--- a/src/equicordplugins/messageLoggerEnhanced/utils/contextMenu.tsx
+++ b/src/equicordplugins/messageLoggerEnhanced/utils/contextMenu.tsx
@@ -10,7 +10,7 @@ import { FluxDispatcher, Menu, MessageActions, React, SortedGuildStore, Toasts, 
 import { openLogModal } from "../components/LogsModal";
 import { deleteMessageIDB } from "../db";
 import { settings } from "../index";
-import { addToXAndRemoveFromOpposite, ListType, removeFromX } from ".";
+import { addToXAndRemoveFromOpposite, ListType, queueAutoDeleteNonce, removeFromX } from ".";
 
 const idFunctions = {
     Folder: props =>
@@ -141,6 +141,9 @@ export const contextMenuPath: NavContextMenuPatchCallback = (children, props) =>
 
                                 action={async () => {
                                     await MessageActions.deleteMessage(props.message.channel_id, props.message.id);
+                                    if (settings.store.autoDeleteHideMessageFromMessageLoggersDeletedMessage) {
+                                        queueAutoDeleteNonce(props.message.id);
+                                    }
                                     MessageActions._sendMessage(props.message.channel_id, {
                                         "content": settings.store.hideMessageFromMessageLoggersDeletedMessage,
                                         "tts": false,

--- a/src/equicordplugins/messageLoggerEnhanced/utils/misc.ts
+++ b/src/equicordplugins/messageLoggerEnhanced/utils/misc.ts
@@ -174,3 +174,13 @@ export function getNative(): PluginNative<typeof import("../native")> {
         .find(m => m.messageLoggerEnhancedUniqueIdThingyIdkMan) as PluginNative<typeof import("../native")>;
 
 }
+
+export const pendingAutoDeleteNonces = new Set<string>();
+
+export function queueAutoDeleteNonce(nonce: string) {
+    pendingAutoDeleteNonces.add(String(nonce));
+    setTimeout(() => {
+        pendingAutoDeleteNonces.delete(String(nonce));
+    }, 30000);
+}
+


### PR DESCRIPTION
## Describe your Changes
Adds a toggle option to delete the "Hide Message From Message Loggers Deleted Message" after the message is edited/replaced.

## Screenshots (if applicable)
<img width="585" height="68" alt="WA4" src="https://github.com/user-attachments/assets/f58013c1-7fd8-4c1e-b50e-e75ffcc9b344" />

## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
