### PR TITLE
Add Betterimageeditor Plugin

### DIFF
--- a/src/equicordplugins/betterImageEditor/components/Shelf.tsx
+++ b/src/equicordplugins/betterImageEditor/components/Shelf.tsx
@@ -1,0 +1,153 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import { DeleteIcon } from "@components/Icons";
+import { classNameFactory } from "@utils/css";
+import { React, useCallback, useEffect, useRef, useState } from "@webpack/common";
+
+import { Entry, getFile, Group, Kind } from "../library";
+
+export const cl = classNameFactory("vc-bie-");
+
+const SQUARE = new Set(["AVATAR", "AVATAR_DECORATION", "GUILD_ICON", "PERSONAL_WIDGET_FIELD"]);
+
+const KIND_NAMES: Record<string, string> = {
+    AVATAR: "avatars",
+    BANNER: "banners",
+    GUILD_ICON: "server icons",
+    GUILD_BANNER: "server banners",
+    SCHEDULED_EVENT_IMAGE: "event covers",
+    HOME_HEADER: "home headers",
+    AVATAR_DECORATION: "decorations",
+    PERSONAL_WIDGET_COVER: "widget covers",
+    PERSONAL_WIDGET_FIELD: "widget images",
+    VIDEO_BACKGROUND: "video backgrounds"
+};
+
+const kindName = (kind: Kind) => KIND_NAMES[kind] ?? kind.toLowerCase().replace(/_/g, " ");
+
+const isAnimated = (entry: Entry) => entry.type === "image/gif" || entry.name.toLowerCase().endsWith(".gif");
+export const croppedLabel = (kind: Kind) => `Cropped ${kindName(kind)}`;
+
+const PinIcon = (props: React.SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden {...props}>
+        <path d="M15 4V9l3 3v2h-5v7l-1 1-1-1v-7H6v-2l3-3V4H8V2h8v2z" />
+    </svg>
+);
+
+export function Shelf({ kind, group, entries, thumbs, activeId, wornId, onGroup, onPick, onPin, onForget, onPutBack }: {
+    kind: Kind;
+    group: Group;
+    entries: Entry[];
+    thumbs: Record<string, string>;
+    activeId: string | null;
+    wornId: string | null;
+    onGroup(group: Group): void;
+    onPick(entry: Entry): void;
+    onPin(entry: Entry): void;
+    onForget(entry: Entry, immediate: boolean): void;
+    onPutBack?(): void;
+}) {
+    const shape = SQUARE.has(kind) ? "square" : "wide";
+
+    const [hovered, setHovered] = useState<string | null>(null);
+    const [playing, setPlaying] = useState<Record<string, string>>({});
+    const played = useRef<string[]>([]);
+
+    useEffect(() => () => played.current.forEach(URL.revokeObjectURL), []);
+
+    const play = useCallback(async (entry: Entry) => {
+        setHovered(entry.id);
+        if (!isAnimated(entry) || playing[entry.id]) return;
+
+        const blob = await getFile(entry.id);
+        if (!blob) return;
+
+        const url = URL.createObjectURL(blob);
+        played.current.push(url);
+        setPlaying(current => ({ ...current, [entry.id]: url }));
+    }, [playing]);
+
+    return (
+        <div className={cl("panel", shape)}>
+            <div className={cl("tabs")} role="tablist">
+                <button
+                    type="button"
+                    role="tab"
+                    aria-selected={group === "original"}
+                    className={cl("tab", { on: group === "original" })}
+                    onClick={() => onGroup("original")}
+                >Originals</button>
+                <button
+                    type="button"
+                    role="tab"
+                    aria-selected={group === "cropped"}
+                    className={cl("tab", { on: group === "cropped" })}
+                    onClick={() => onGroup("cropped")}
+                >{croppedLabel(kind)}</button>
+
+                {onPutBack && (
+                    <button type="button" className={cl("action")} onClick={onPutBack}>
+                        Put back the last one
+                    </button>
+                )}
+
+            </div>
+
+            <div className={cl("strip")} role="group" aria-label="Saved pictures">
+                {entries.map(entry => (
+                    <div
+                        key={entry.id}
+                        className={cl("item", { pinned: entry.pinned, worn: entry.id === wornId })}
+                        onMouseEnter={() => play(entry)}
+                        onMouseLeave={() => setHovered(null)}
+                    >
+                        <button
+                            type="button"
+                            aria-label={entry.name}
+                            title={entry.id === wornId ? `${entry.name}
+You are wearing this` : entry.name}
+                            className={cl("thumb", { active: activeId === entry.id })}
+                            style={{ backgroundImage: `url(${(hovered === entry.id && playing[entry.id]) || thumbs[entry.id]})` }}
+                            onClick={() => onPick(entry)}
+                            onContextMenu={event => {
+                                event.preventDefault();
+                                onForget(entry, event.shiftKey);
+                            }}
+                        />
+                        <button
+                            type="button"
+                            className={cl("remove")}
+                            aria-label={`Remove ${entry.name}`}
+                            title="Remove. Hold Shift to skip the confirmation"
+                            onClick={event => onForget(entry, event.shiftKey)}
+                        >
+                            <DeleteIcon width={10} height={10} />
+                        </button>
+                        <button
+                            type="button"
+                            aria-pressed={!!entry.pinned}
+                            className={cl("pin", { on: entry.pinned })}
+                            aria-label={entry.pinned ? `Unpin ${entry.name}` : `Pin ${entry.name}`}
+                            title={entry.pinned ? "Pinned, so it never drops off the shelf" : "Pin so it never drops off the shelf"}
+                            onClick={() => onPin(entry)}
+                        >
+                            <PinIcon width={10} height={10} />
+                        </button>
+                    </div>
+                ))}
+
+                {!entries.length && (
+                    <span className={cl("empty")}>
+                        {group === "original"
+                            ? "Pictures you pick, paste or drop land here"
+                            : "Pictures you crop land here"}
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/equicordplugins/betterImageEditor/components/Shelf.tsx
+++ b/src/equicordplugins/betterImageEditor/components/Shelf.tsx
@@ -23,8 +23,7 @@ const KIND_NAMES: Record<string, string> = {
     HOME_HEADER: "home headers",
     AVATAR_DECORATION: "decorations",
     PERSONAL_WIDGET_COVER: "widget covers",
-    PERSONAL_WIDGET_FIELD: "widget images",
-    VIDEO_BACKGROUND: "video backgrounds"
+    PERSONAL_WIDGET_FIELD: "widget images"
 };
 
 const kindName = (kind: Kind) => KIND_NAMES[kind] ?? kind.toLowerCase().replace(/_/g, " ");

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -566,7 +566,7 @@ let wrapped: React.ComponentType<EditorProps> | null = null;
 
 export default definePlugin({
     name: "BetterImageEditor",
-    description: "Keeps your own pictures on the image picker and under the crop window, on an uncropped shelf and a cropped one, for avatars, banners, server icons, server banners, event covers, home headers, widget covers and widget images. Remembers how you framed each picture, and takes a paste or a dropped file straight in.",
+    description: "Image Editor with shelving for older images and allowing cropping",
     authors: [EquicordDevs.heart_menace],
     settings,
 

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -566,7 +566,7 @@ let wrapped: React.ComponentType<EditorProps> | null = null;
 
 export default definePlugin({
     name: "BetterImageEditor",
-    description: "Image Editor with shelving for older images and allowing cropping",
+    description: "Image editor with shelving for older images and allowing cropping",
     authors: [EquicordDevs.heart_menace],
     settings,
 

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -633,7 +633,7 @@ let wrapped: React.ComponentType<any> | null = null;
 
 export default definePlugin({
     name: "BetterImageEditor",
-    description: "Keeps your own pictures on the image picker and under the crop window, for avatars and banners, on an uncropped shelf and a cropped one. Remembers how you framed each picture, and takes a paste or a dropped file straight in.",
+    description: "Keeps your own pictures on the image picker and under the crop window, on an uncropped shelf and a cropped one, for avatars, banners, server icons, server banners, event covers, home headers, decorations, widget covers, widget images and video backgrounds. Remembers how you framed each picture, and takes a paste or a dropped file straight in.",
     authors: [EquicordDevs.heart_menace],
     settings,
 

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -78,7 +78,7 @@ const settings = definePluginSettings({
                 color={Button.Colors.PRIMARY}
                 onClick={() => Alerts.show({
                     title: "Forget every remembered crop?",
-                    body: <p>Your pictures stay. Each one opens unframed from now on, until you crop it again.</p>,
+                    body: "Your pictures stay. Each one opens unframed from now on, until you crop it again.",
                     confirmColor: Button.Colors.RED,
                     confirmText: "Forget",
                     cancelText: "Cancel",
@@ -122,7 +122,7 @@ const settings = definePluginSettings({
                 color={Button.Colors.PRIMARY}
                 onClick={() => Alerts.show({
                     title: "Clear saved pictures?",
-                    body: <p>Every picture you have saved here goes, along with the crop remembered for each one. Discord's own archive and your current avatar and banner are not touched.</p>,
+                    body: "Every picture you have saved here goes, along with the crop remembered for each one. Discord's own archive and your current avatar and banner are not touched.",
                     confirmColor: Button.Colors.RED,
                     confirmText: "Clear",
                     cancelText: "Cancel",
@@ -247,7 +247,7 @@ function useForget(bump: () => void) {
 
         Alerts.show({
             title: "Remove this picture?",
-            body: <p>{entry.name} goes from your saved pictures, along with the crop remembered for it.</p>,
+            body: `${entry.name} goes from your saved pictures, along with the crop remembered for it.`,
             confirmColor: Button.Colors.RED,
             confirmText: "Remove",
             cancelText: "Cancel",
@@ -486,7 +486,7 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
 
         Alerts.show({
             title: "Keep the cropped copy?",
-            body: <p>It goes on the {croppedLabel(kind).toLowerCase()} shelf, next to your originals.</p>,
+            body: `It goes on the ${croppedLabel(kind).toLowerCase()} shelf, next to your originals.`,
             confirmText: "Keep",
             cancelText: "No thanks",
             onConfirm: run

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -8,17 +8,14 @@ import "./style.css";
 
 import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
-import { DeleteIcon } from "@components/Icons";
 import { EquicordDevs } from "@utils/constants";
-import { classNameFactory } from "@utils/css";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType } from "@utils/types";
 import { chooseFile, saveFile } from "@utils/web";
 import { Alerts, Button, React, Toasts, useCallback, useEffect, useRef, useState } from "@webpack/common";
 
+import { cl, croppedLabel, Shelf } from "./components/Shelf";
 import { add, byRecency, clear, CropState, currentApplied, Entry, exportAll, forget, forgetCrops, getFile, getThumbs, Group, importAll, Kind, previousApplied, readIndex, recordApplied, saveCrop, toDataUrl, togglePin, touch } from "./library";
-
-const cl = classNameFactory("vc-bie-");
 
 interface PickResult {
     imageUri: string;
@@ -137,38 +134,12 @@ function noteHanded(kind: Kind, id: string) {
 
 const kindOf = (uploadType?: string): Kind => uploadType || "AVATAR";
 
-const SQUARE = new Set(["AVATAR", "AVATAR_DECORATION", "GUILD_ICON", "PERSONAL_WIDGET_FIELD"]);
-
-const KIND_NAMES: Record<string, string> = {
-    AVATAR: "avatars",
-    BANNER: "banners",
-    GUILD_ICON: "server icons",
-    GUILD_BANNER: "server banners",
-    SCHEDULED_EVENT_IMAGE: "event covers",
-    HOME_HEADER: "home headers",
-    AVATAR_DECORATION: "decorations",
-    PERSONAL_WIDGET_COVER: "widget covers",
-    PERSONAL_WIDGET_FIELD: "widget images",
-    VIDEO_BACKGROUND: "video backgrounds"
-};
-
-const kindName = (kind: Kind) => KIND_NAMES[kind] ?? kind.toLowerCase().replace(/_/g, " ");
-
-const isAnimated = (entry: Entry) => entry.type === "image/gif" || entry.name.toLowerCase().endsWith(".gif");
-const croppedLabel = (kind: Kind) => `Cropped ${kindName(kind)}`;
-
 const EXTENSIONS: Record<string, string> = {
     "image/gif": "gif",
     "image/png": "png",
     "image/jpeg": "jpg",
     "image/webp": "webp"
 };
-
-const PinIcon = (props: React.SVGProps<SVGSVGElement>) => (
-    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden {...props}>
-        <path d="M15 4V9l3 3v2h-5v7l-1 1-1-1v-7H6v-2l3-3V4H8V2h8v2z" />
-    </svg>
-);
 
 const FILENAME = "better-image-editor.json";
 
@@ -272,7 +243,6 @@ function useForget(bump: () => void) {
     }, [bump]);
 }
 
-// the picker stays mounted under the cropper, so only the topmost surface takes a paste
 let editorsOpen = 0;
 
 function usePasteAndDrop(accept: (file: File) => void, active: () => boolean) {
@@ -307,120 +277,6 @@ function usePasteAndDrop(accept: (file: File) => void, active: () => boolean) {
     }, [accept, active]);
 }
 
-function Shelf({ kind, group, entries, thumbs, activeId, wornId, onGroup, onPick, onPin, onForget, onPutBack }: {
-    kind: Kind;
-    group: Group;
-    entries: Entry[];
-    thumbs: Record<string, string>;
-    activeId: string | null;
-    wornId: string | null;
-    onGroup(group: Group): void;
-    onPick(entry: Entry): void;
-    onPin(entry: Entry): void;
-    onForget(entry: Entry, immediate: boolean): void;
-    onPutBack?(): void;
-}) {
-    const shape = SQUARE.has(kind) ? "square" : "wide";
-
-    const [hovered, setHovered] = useState<string | null>(null);
-    const [playing, setPlaying] = useState<Record<string, string>>({});
-    const played = useRef<string[]>([]);
-
-    useEffect(() => () => played.current.forEach(URL.revokeObjectURL), []);
-
-    const play = useCallback(async (entry: Entry) => {
-        setHovered(entry.id);
-        if (!isAnimated(entry) || playing[entry.id]) return;
-
-        const blob = await getFile(entry.id);
-        if (!blob) return;
-
-        const url = URL.createObjectURL(blob);
-        played.current.push(url);
-        setPlaying(current => ({ ...current, [entry.id]: url }));
-    }, [playing]);
-
-    return (
-        <div className={cl("panel", shape)}>
-            <div className={cl("tabs")} role="tablist">
-                <button
-                    type="button"
-                    role="tab"
-                    aria-selected={group === "original"}
-                    className={cl("tab", { on: group === "original" })}
-                    onClick={() => onGroup("original")}
-                >Originals</button>
-                <button
-                    type="button"
-                    role="tab"
-                    aria-selected={group === "cropped"}
-                    className={cl("tab", { on: group === "cropped" })}
-                    onClick={() => onGroup("cropped")}
-                >{croppedLabel(kind)}</button>
-
-                {onPutBack && (
-                    <button type="button" className={cl("action")} onClick={onPutBack}>
-                        Put back the last one
-                    </button>
-                )}
-
-            </div>
-
-            <div className={cl("strip")} role="group" aria-label="Saved pictures">
-                {entries.map(entry => (
-                    <div
-                        key={entry.id}
-                        className={cl("item", { pinned: entry.pinned, worn: entry.id === wornId })}
-                        onMouseEnter={() => play(entry)}
-                        onMouseLeave={() => setHovered(null)}
-                    >
-                        <button
-                            type="button"
-                            aria-label={entry.name}
-                            title={entry.id === wornId ? `${entry.name}
-You are wearing this` : entry.name}
-                            className={cl("thumb", { active: activeId === entry.id })}
-                            style={{ backgroundImage: `url(${(hovered === entry.id && playing[entry.id]) || thumbs[entry.id]})` }}
-                            onClick={() => onPick(entry)}
-                            onContextMenu={event => {
-                                event.preventDefault();
-                                onForget(entry, event.shiftKey);
-                            }}
-                        />
-                        <button
-                            type="button"
-                            className={cl("remove")}
-                            aria-label={`Remove ${entry.name}`}
-                            title="Remove. Hold Shift to skip the confirmation"
-                            onClick={event => onForget(entry, event.shiftKey)}
-                        >
-                            <DeleteIcon width={10} height={10} />
-                        </button>
-                        <button
-                            type="button"
-                            aria-pressed={!!entry.pinned}
-                            className={cl("pin", { on: entry.pinned })}
-                            aria-label={entry.pinned ? `Unpin ${entry.name}` : `Pin ${entry.name}`}
-                            title={entry.pinned ? "Pinned, so it never drops off the shelf" : "Pin so it never drops off the shelf"}
-                            onClick={() => onPin(entry)}
-                        >
-                            <PinIcon width={10} height={10} />
-                        </button>
-                    </div>
-                ))}
-
-                {!entries.length && (
-                    <span className={cl("empty")}>
-                        {group === "original"
-                            ? "Pictures you pick, paste or drop land here"
-                            : "Pictures you crop land here"}
-                    </span>
-                )}
-            </div>
-        </div>
-    );
-}
-
 function PickerShelf({ kind, open, complete }: {
     kind: Kind;
     open(imageUri: string, file: File): void;
@@ -429,7 +285,6 @@ function PickerShelf({ kind, open, complete }: {
     const { group, setGroup, entries, thumbs, worn, bump } = useLibrary(kind);
     const onForget = useForget(bump);
 
-    // a data URI, never an object URL: that dies with the surface that made it
     const hand = useCallback(async (id: string | null, file: File, crop: CropState | null) => {
         handoff = { id, transform: crop };
         open(await toDataUrl(file), file);
@@ -542,7 +397,6 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
         return () => { editorsOpen--; };
     }, []);
 
-    // Discord's arrow-key nudging only listens on hidden inputs that Tab reaches, not a click
     useEffect(() => {
         function focusPan({ target }: MouseEvent) {
             let scope = anchor.current?.parentElement ?? null;
@@ -691,7 +545,6 @@ export default definePlugin({
             }
         },
         {
-            // grouped: rendering bieShelf without destructuring it throws
             find: '"SET_IMAGE_ZOOM_RATIO"',
             group: true,
             replacement: [
@@ -708,7 +561,6 @@ export default definePlugin({
         {
             find: 'displayName="RecentAvatarsStore"',
             replacement: {
-                // takes over the slot Discord renders its own recent avatars into
                 match: /(uploadType:(\i),guild:\i,handleOpenImageEditingModal:(\i),[\s\S]{0,500}?)\i&&\(0,\i\.jsx\)\(\i,\{onComplete:(\i),returnRef:\i\}\)/,
                 replace: "$1$self.pickerRow($2,$3,$4)"
             }

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -1,0 +1,698 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import "./style.css";
+
+import { definePluginSettings } from "@api/Settings";
+import ErrorBoundary from "@components/ErrorBoundary";
+import { DeleteIcon } from "@components/Icons";
+import { EquicordDevs } from "@utils/constants";
+import { Logger } from "@utils/Logger";
+import definePlugin, { OptionType } from "@utils/types";
+import { chooseFile, saveFile } from "@utils/web";
+import { Alerts, Button, FluxDispatcher, React, Toasts, useCallback, useEffect, useRef, useState } from "@webpack/common";
+
+import { add, byRecency, clear, CropState, currentApplied, Entry, exportAll, forget, forgetCrops, getFile, getThumbs, Group, importAll, Kind, previousApplied, readIndex, recordApplied, saveCrop, toDataUrl, togglePin, touch } from "./library";
+
+interface Picked {
+    id: string;
+    uri: string;
+    file: File;
+}
+
+const logger = new Logger("BetterImageEditor");
+
+const settings = definePluginSettings({
+    librarySize: {
+        type: OptionType.SLIDER,
+        description: "How many pictures to keep on each shelf",
+        markers: [6, 12, 24, 48],
+        default: 24,
+        stickToMarkers: true
+    },
+    rememberCrop: {
+        type: OptionType.BOOLEAN,
+        description: "Restore the zoom and position you last used for a picture",
+        default: true
+    },
+    forgetFraming: {
+        type: OptionType.COMPONENT,
+        description: "Drop every remembered crop and open each picture the way Discord would",
+        component: () => (
+            <Button
+                color={Button.Colors.PRIMARY}
+                onClick={() => Alerts.show({
+                    title: "Forget every remembered crop?",
+                    body: <p>Your pictures stay. Each one opens unframed from now on, until you crop it again.</p>,
+                    confirmColor: Button.Colors.RED,
+                    confirmText: "Forget",
+                    cancelText: "Cancel",
+                    onConfirm: () => forgetCrops()
+                        .then(count => Toasts.show(Toasts.create(
+                            count ? `Forgot the framing on ${count} picture${count === 1 ? "" : "s"}` : "Nothing was framed",
+                            Toasts.Type.SUCCESS
+                        )))
+                        .catch(err => logger.error("could not forget the remembered crops", err))
+                })}
+            >
+                Forget remembered framing
+            </Button>
+        )
+    },
+    saveCropped: {
+        type: OptionType.BOOLEAN,
+        description: "Keep a copy of each picture after you crop it",
+        default: true
+    },
+    askBeforeSavingCropped: {
+        type: OptionType.BOOLEAN,
+        description: "Ask first, instead of keeping the cropped copy automatically",
+        default: false
+    },
+    transfer: {
+        type: OptionType.COMPONENT,
+        description: "Carry your pictures, and how each one is framed, to another device",
+        component: () => (
+            <div className="bie-buttons">
+                <Button color={Button.Colors.PRIMARY} onClick={exportLibrary}>Export to a file</Button>
+                <Button color={Button.Colors.PRIMARY} onClick={importLibrary}>Import from a file</Button>
+            </div>
+        )
+    },
+    clearLibrary: {
+        type: OptionType.COMPONENT,
+        description: "Throw away every picture you have saved",
+        component: () => (
+            <Button
+                color={Button.Colors.PRIMARY}
+                onClick={() => Alerts.show({
+                    title: "Clear saved pictures?",
+                    body: <p>Every picture you have saved here goes, along with the crop remembered for each one. Discord's own archive and your current avatar and banner are not touched.</p>,
+                    confirmColor: Button.Colors.RED,
+                    confirmText: "Clear",
+                    cancelText: "Cancel",
+                    onConfirm: () => clear().catch(err => logger.error("could not clear the library", err))
+                })}
+            >
+                Clear saved pictures
+            </Button>
+        )
+    }
+});
+
+// handoff marks a picture the picker already dealt with, so the editor does not file a
+// second copy of it. handedOver is what a confirmed profile save should be credited to.
+let handoff: { id: string | null; transform: CropState | null; } | null = null;
+let handedOver: { id: string; kind: Kind; } | null = null;
+
+const kindOf = (uploadType: string): Kind => uploadType || "AVATAR";
+
+// the cropper masks these to a square; everything else it crops wide
+const SQUARE = new Set(["AVATAR", "AVATAR_DECORATION", "GUILD_ICON", "PERSONAL_WIDGET_FIELD"]);
+
+const KIND_NAMES: Record<string, string> = {
+    AVATAR: "avatars",
+    BANNER: "banners",
+    GUILD_ICON: "server icons",
+    GUILD_BANNER: "server banners",
+    SCHEDULED_EVENT_IMAGE: "event covers",
+    HOME_HEADER: "home headers",
+    AVATAR_DECORATION: "decorations",
+    PERSONAL_WIDGET_COVER: "widget covers",
+    PERSONAL_WIDGET_FIELD: "widget images",
+    VIDEO_BACKGROUND: "video backgrounds"
+};
+
+const kindName = (kind: Kind) => KIND_NAMES[kind] ?? kind.toLowerCase().replace(/_/g, " ");
+
+const isAnimated = (entry: Entry) => entry.type === "image/gif" || entry.name.toLowerCase().endsWith(".gif");
+const croppedLabel = (kind: Kind) => `Cropped ${kindName(kind)}`;
+
+const EXTENSIONS: Record<string, string> = {
+    "image/gif": "gif",
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp"
+};
+
+const PinIcon = (props: any) => (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden {...props}>
+        <path d="M15 4V9l3 3v2h-5v7l-1 1-1-1v-7H6v-2l3-3V4H8V2h8v2z" />
+    </svg>
+);
+
+const FILENAME = "better-image-editor.json";
+
+async function exportLibrary() {
+    try {
+        const data = new TextEncoder().encode(await exportAll());
+
+        if (IS_DISCORD_DESKTOP) DiscordNative.fileManager.saveWithDialog(data, FILENAME);
+        else saveFile(new File([data], FILENAME, { type: "application/json" }));
+    } catch (err) {
+        logger.error("could not export the library", err);
+        Toasts.show(Toasts.create("Could not export your pictures", Toasts.Type.FAILURE));
+    }
+}
+
+async function readChosenFile() {
+    if (!IS_DISCORD_DESKTOP) return (await chooseFile("application/json"))?.text() ?? null;
+
+    const [file] = await DiscordNative.fileManager.openFiles({
+        filters: [{ name: "Picture library", extensions: ["json"] }]
+    });
+    return file ? new TextDecoder().decode(file.data) : null;
+}
+
+async function importLibrary() {
+    try {
+        const json = await readChosenFile();
+        if (!json) return;
+
+        const added = await importAll(json, settings.store.librarySize);
+        Toasts.show(Toasts.create(
+            added ? `Added ${added} picture${added === 1 ? "" : "s"}` : "Nothing new in that file",
+            Toasts.Type.SUCCESS
+        ));
+    } catch (err) {
+        logger.error("could not import the library", err);
+        Toasts.show(Toasts.create("Could not read that file", Toasts.Type.FAILURE));
+    }
+}
+
+function useLibrary(kind: Kind) {
+    const [group, setGroup] = useState<Group>("original");
+    const [version, setVersion] = useState(0);
+    const [entries, setEntries] = useState<Entry[]>([]);
+    const [thumbs, setThumbs] = useState<Record<string, string>>({});
+    const [worn, setWorn] = useState<string | null>(null);
+
+    const urls = useRef<string[]>([]);
+    const bump = useCallback(() => setVersion(v => v + 1), []);
+    const track = useCallback((url: string) => { urls.current.push(url); return url; }, []);
+
+    useEffect(() => () => urls.current.forEach(URL.revokeObjectURL), []);
+
+    useEffect(() => {
+        let live = true;
+
+        (async () => {
+            const mine = byRecency((await readIndex()).filter(entry => entry.kind === kind && entry.group === group))
+                .sort((a, b) => Number(!!b.pinned) - Number(!!a.pinned));
+            const blobs = await getThumbs(mine.map(entry => entry.id));
+            if (!live) return;
+
+            const next: Record<string, string> = {};
+            mine.forEach((entry, index) => {
+                const blob = blobs[index];
+                if (blob) next[entry.id] = track(URL.createObjectURL(blob));
+            });
+
+            setThumbs(next);
+            setEntries(mine);
+        })();
+
+        return () => { live = false; };
+    }, [kind, group, version]);
+
+    useEffect(() => {
+        currentApplied(kind)
+            .then(setWorn)
+            .catch(err => logger.error("could not read what you are wearing", err));
+    }, [kind, version]);
+
+    return { group, setGroup, entries, thumbs, worn, bump, track };
+}
+
+function useForget(bump: () => void) {
+    return useCallback((entry: Entry, immediate: boolean) => {
+        const run = () => forget(entry.id)
+            .then(bump)
+            .catch(err => logger.error("could not remove that picture", err));
+
+        if (immediate) return void run();
+
+        Alerts.show({
+            title: "Remove this picture?",
+            body: <p>{entry.name} goes from your saved pictures, along with the crop remembered for it.</p>,
+            confirmColor: Button.Colors.RED,
+            confirmText: "Remove",
+            cancelText: "Cancel",
+            onConfirm: run
+        });
+    }, [bump]);
+}
+
+// the picker stays mounted under the cropper, so both surfaces listen at once. the
+// cropper is always the one on top, and takes the paste.
+let editorsOpen = 0;
+
+function usePasteAndDrop(accept: (file: File) => void, active: () => boolean) {
+    useEffect(() => {
+        const imageIn = (list: FileList | undefined) =>
+            [...(list ?? [])].find(file => file.type.startsWith("image/"));
+
+        const take = (file: File | undefined, event: Event) => {
+            if (!file || !active()) return;
+            event.preventDefault();
+            event.stopPropagation();
+            accept(file);
+        };
+
+        const onPaste = (event: ClipboardEvent) => take(imageIn(event.clipboardData?.files), event);
+        const onDrop = (event: DragEvent) => take(imageIn(event.dataTransfer?.files), event);
+        const onDragOver = (event: DragEvent) => {
+            if (!event.dataTransfer?.types.includes("Files")) return;
+            event.preventDefault();
+            event.stopPropagation();
+        };
+
+        document.addEventListener("paste", onPaste, true);
+        document.addEventListener("drop", onDrop, true);
+        document.addEventListener("dragover", onDragOver, true);
+
+        return () => {
+            document.removeEventListener("paste", onPaste, true);
+            document.removeEventListener("drop", onDrop, true);
+            document.removeEventListener("dragover", onDragOver, true);
+        };
+    }, [accept, active]);
+}
+
+function Shelf({ kind, group, entries, thumbs, activeId, wornId, onGroup, onPick, onPin, onForget, onPutBack }: {
+    kind: Kind;
+    group: Group;
+    entries: Entry[];
+    thumbs: Record<string, string>;
+    activeId: string | null;
+    wornId: string | null;
+    onGroup(group: Group): void;
+    onPick(entry: Entry): void;
+    onPin(entry: Entry): void;
+    onForget(entry: Entry, immediate: boolean): void;
+    onPutBack?(): void;
+}) {
+    const shape = SQUARE.has(kind) ? "bie-square" : "bie-wide";
+
+    const [hovered, setHovered] = useState<string | null>(null);
+    const [playing, setPlaying] = useState<Record<string, string>>({});
+    const played = useRef<string[]>([]);
+
+    useEffect(() => () => played.current.forEach(URL.revokeObjectURL), []);
+
+    const play = useCallback(async (entry: Entry) => {
+        setHovered(entry.id);
+        if (!isAnimated(entry) || playing[entry.id]) return;
+
+        const blob = await getFile(entry.id);
+        if (!blob) return;
+
+        const url = URL.createObjectURL(blob);
+        played.current.push(url);
+        setPlaying(current => ({ ...current, [entry.id]: url }));
+    }, [playing]);
+
+    return (
+        <div className={`bie-panel ${shape}`}>
+            <div className="bie-tabs" role="tablist">
+                <button
+                    type="button"
+                    role="tab"
+                    aria-selected={group === "original"}
+                    className={`bie-tab${group === "original" ? " bie-on" : ""}`}
+                    onClick={() => onGroup("original")}
+                >Originals</button>
+                <button
+                    type="button"
+                    role="tab"
+                    aria-selected={group === "cropped"}
+                    className={`bie-tab${group === "cropped" ? " bie-on" : ""}`}
+                    onClick={() => onGroup("cropped")}
+                >{croppedLabel(kind)}</button>
+
+                {onPutBack && (
+                    <button type="button" className="bie-action" onClick={onPutBack}>
+                        Put back the last one
+                    </button>
+                )}
+
+            </div>
+
+            <div className="bie-strip" role="group" aria-label="Saved pictures">
+                {entries.map(entry => (
+                    <div
+                        key={entry.id}
+                        className={`bie-item${entry.pinned ? " bie-pinned" : ""}${entry.id === wornId ? " bie-worn" : ""}`}
+                        onMouseEnter={() => play(entry)}
+                        onMouseLeave={() => setHovered(null)}
+                    >
+                        <button
+                            type="button"
+                            aria-label={entry.name}
+                            title={entry.id === wornId ? `${entry.name}
+You are wearing this` : entry.name}
+                            className={`bie-thumb${activeId === entry.id ? " bie-active" : ""}`}
+                            style={{ backgroundImage: `url(${(hovered === entry.id && playing[entry.id]) || thumbs[entry.id]})` }}
+                            onClick={() => onPick(entry)}
+                            onContextMenu={event => {
+                                event.preventDefault();
+                                onForget(entry, event.shiftKey);
+                            }}
+                        />
+                        <button
+                            type="button"
+                            className="bie-remove"
+                            aria-label={`Remove ${entry.name}`}
+                            title="Remove. Hold Shift to skip the confirmation"
+                            onClick={event => onForget(entry, event.shiftKey)}
+                        >
+                            <DeleteIcon width={10} height={10} />
+                        </button>
+                        <button
+                            type="button"
+                            aria-pressed={!!entry.pinned}
+                            className={`bie-pin${entry.pinned ? " bie-on" : ""}`}
+                            aria-label={entry.pinned ? `Unpin ${entry.name}` : `Pin ${entry.name}`}
+                            title={entry.pinned ? "Pinned, so it never drops off the shelf" : "Pin so it never drops off the shelf"}
+                            onClick={() => onPin(entry)}
+                        >
+                            <PinIcon width={10} height={10} />
+                        </button>
+                    </div>
+                ))}
+
+                {!entries.length && (
+                    <span className="bie-empty">
+                        {group === "original"
+                            ? "Pictures you pick, paste or drop land here"
+                            : "Pictures you crop land here"}
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function PickerShelf({ kind, open, complete }: {
+    kind: Kind;
+    open(imageUri: string, file: File): void;
+    complete(result: { imageUri: string; file: File; }): void;
+}) {
+    const { group, setGroup, entries, thumbs, worn, bump } = useLibrary(kind);
+    const onForget = useForget(bump);
+
+    // a data URI, not an object URL: Discord only ever hands the cropper the former, and an
+    // object URL dies with whichever surface made it
+    const hand = useCallback(async (id: string | null, file: File, crop: CropState | null) => {
+        handoff = { id, transform: crop };
+        if (id) handedOver = { id, kind };
+        open(await toDataUrl(file), file);
+    }, [open]);
+
+    const [putBack, setPutBack] = useState<Entry | null>(null);
+
+    useEffect(() => {
+        previousApplied(kind)
+            .then(setPutBack)
+            .catch(err => logger.error("could not read what you wore before", err));
+    }, [kind]);
+
+    const onPick = useCallback(async (entry: Entry) => {
+        const blob = await getFile(entry.id);
+        if (!blob) return;
+
+        const file = new File([blob], entry.name, { type: blob.type });
+        await touch(entry.id);
+        bump();
+
+        // already framed, so it goes straight to the profile editor without the cropper
+        if (entry.group === "cropped") {
+            handedOver = { id: entry.id, kind };
+            return complete({ imageUri: await toDataUrl(blob), file });
+        }
+
+        await hand(entry.id, file, settings.store.rememberCrop ? entry.crop ?? null : null);
+    }, [hand, complete, kind, bump]);
+
+    const onPin = useCallback((entry: Entry) => {
+        togglePin(entry.id).then(bump).catch(err => logger.error("could not pin that picture", err));
+    }, [bump]);
+
+    const accept = useCallback(async (file: File) => {
+        try {
+            const id = await add(file, kind, "original", settings.store.librarySize);
+            bump();
+            await hand(id, file, null);
+        } catch (err) {
+            logger.error("could not take that picture", err);
+        }
+    }, [kind, hand, bump]);
+
+    usePasteAndDrop(accept, useCallback(() => editorsOpen === 0, []));
+
+    return (
+        <Shelf
+            kind={kind}
+            group={group}
+            entries={entries}
+            thumbs={thumbs}
+            activeId={null}
+            wornId={worn}
+            onGroup={setGroup}
+            onPick={onPick}
+            onPin={onPin}
+            onForget={onForget}
+            onPutBack={putBack ? () => onPick(putBack) : undefined}
+        />
+    );
+}
+
+function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any>; ownProps: any; }) {
+    const kind = kindOf(ownProps.uploadType);
+
+    const { group, setGroup, entries, thumbs, worn, bump } = useLibrary(kind);
+    const onForget = useForget(bump);
+
+    const [picked, setPicked] = useState<Picked | null>(null);
+    const [transform, setTransform] = useState<CropState | null>(() => handoff?.transform ?? null);
+
+    const incomingId = useRef<string | null>(null);
+    const pickedId = useRef<string | null>(null);
+    const pickedName = useRef<string | null>(null);
+    const captured = useRef(false);
+
+    pickedId.current = picked?.id ?? null;
+    pickedName.current = picked?.file.name ?? ownProps.file?.name ?? null;
+
+    const show = useCallback(async (id: string, file: File, crop: CropState | null) => {
+        setTransform(crop);
+        setPicked({ id, uri: await toDataUrl(file), file });
+    }, []);
+
+    useEffect(() => {
+        if (captured.current) return;
+        captured.current = true;
+
+        // the picker shelf already dealt with this one
+        if (handoff) {
+            incomingId.current = handoff.id;
+            handoff = null;
+            return;
+        }
+
+        if (!(ownProps.file instanceof File)) return;
+
+        add(ownProps.file, kind, "original", settings.store.librarySize)
+            .then(id => {
+                incomingId.current = id;
+                bump();
+            })
+            .catch(err => logger.error("could not save that picture", err));
+    }, []);
+
+    useEffect(() => {
+        editorsOpen++;
+        return () => { editorsOpen--; };
+    }, []);
+
+    // the cropper already nudges by 4px on an arrow, 40 with shift, but the handler lives on
+    // two hidden range inputs that only Tab reaches. a click on the picture hands them focus.
+    useEffect(() => {
+        const container = document.querySelector('[class*="editingContainer"]')?.parentElement;
+        if (!container) return;
+
+        const focusPan = () => container
+            .querySelector<HTMLInputElement>('input[type="range"][aria-orientation="horizontal"]')
+            ?.focus({ preventScroll: true });
+
+        container.addEventListener("mouseup", focusPan);
+        return () => container.removeEventListener("mouseup", focusPan);
+    }, [picked?.id]);
+
+    const accept = useCallback(async (file: File) => {
+        try {
+            const id = await add(file, kind, "original", settings.store.librarySize);
+            setGroup("original");
+            bump();
+            await show(id, file, null);
+        } catch (err) {
+            logger.error("could not take that picture", err);
+        }
+    }, [kind, show, bump, setGroup]);
+
+    usePasteAndDrop(accept, useCallback(() => true, []));
+
+    const onPick = useCallback(async (entry: Entry) => {
+        const blob = await getFile(entry.id);
+        if (!blob) return;
+
+        await touch(entry.id);
+        bump();
+        await show(entry.id, new File([blob], entry.name, { type: blob.type }), settings.store.rememberCrop ? entry.crop ?? null : null);
+    }, [show, bump]);
+
+    const onPin = useCallback((entry: Entry) => {
+        togglePin(entry.id).then(bump).catch(err => logger.error("could not pin that picture", err));
+    }, [bump]);
+
+    const keepCropped = useCallback((result: any) => {
+        const uri = result?.imageUri;
+        if (typeof uri !== "string") return logger.warn("the cropper returned something that cannot be saved", result);
+
+        const source = pickedId.current ?? incomingId.current ?? undefined;
+        const save = async () => {
+            const stem = (pickedName.current ?? "picture").replace(/\.[^.]+$/, "");
+            const blob = await fetch(uri).then(r => r.blob());
+            const name = `${stem} (cropped).${EXTENSIONS[blob.type] ?? "png"}`;
+
+            await add(new File([blob], name, { type: blob.type }), kind, "cropped", settings.store.librarySize, source);
+            bump();
+        };
+        const run = () => save().catch(err => logger.error("could not keep the cropped copy", err));
+
+        if (!settings.store.askBeforeSavingCropped) return void run();
+
+        Alerts.show({
+            title: "Keep the cropped copy?",
+            body: <p>It goes on the {croppedLabel(kind).toLowerCase()} shelf, next to your originals.</p>,
+            confirmText: "Keep",
+            cancelText: "No thanks",
+            onConfirm: run
+        });
+    }, [kind, bump]);
+
+    const onCrop = useCallback((...args: any[]) => {
+        const id = pickedId.current ?? incomingId.current;
+        const transform = args[0]?.transform;
+
+        if (id) handedOver = { id, kind };
+        if (id && transform && settings.store.rememberCrop) {
+            saveCrop(id, transform).catch(err => logger.error("could not remember that crop", err));
+        }
+
+        if (settings.store.saveCropped) keepCropped(args[0]);
+
+        return ownProps.onCrop?.(...args);
+    }, [ownProps.onCrop, keepCropped]);
+
+    const props = picked
+        ? { ...ownProps, imageUri: picked.uri, file: picked.file, originalAsset: null, onCrop, initialTransform: transform }
+        : { ...ownProps, onCrop, initialTransform: transform ?? ownProps.initialTransform };
+
+    return (
+        <Original
+            key={picked?.id ?? "incoming"}
+            {...props}
+            bieShelf={
+                <ErrorBoundary noop>
+                    <Shelf
+                        kind={kind}
+                        group={group}
+                        entries={entries}
+                        thumbs={thumbs}
+                        activeId={picked?.id ?? null}
+                        wornId={worn}
+                        onGroup={setGroup}
+                        onPick={onPick}
+                        onPin={onPin}
+                        onForget={onForget}
+                    />
+                </ErrorBoundary>
+            }
+        />
+    );
+}
+
+function onProfileSaved() {
+    if (!handedOver) return;
+
+    const { id, kind } = handedOver;
+    handedOver = null;
+    recordApplied(kind, id).catch(err => logger.error("could not note what you put on", err));
+}
+
+let wrapped: React.ComponentType<any> | null = null;
+
+export default definePlugin({
+    name: "BetterImageEditor",
+    description: "Keeps your own pictures on the image picker and under the crop window, for avatars and banners, on an uncropped shelf and a cropped one. Remembers how you framed each picture, and takes a paste or a dropped file straight in.",
+    authors: [EquicordDevs.heart_menace],
+    settings,
+
+    start() {
+        FluxDispatcher.subscribe("USER_PROFILE_SETTINGS_SUBMIT_SUCCESS", onProfileSaved);
+    },
+
+    stop() {
+        FluxDispatcher.unsubscribe("USER_PROFILE_SETTINGS_SUBMIT_SUCCESS", onProfileSaved);
+    },
+
+    patches: [
+        {
+            find: '"SET_IMAGE_ZOOM_RATIO"',
+            replacement: {
+                match: /\{default:\(\)=>(\i)\}/,
+                replace: "{default:()=>$self.wrapEditor($1)}"
+            }
+        },
+        {
+            // grouped on purpose: rendering bieShelf without destructuring it throws
+            find: '"SET_IMAGE_ZOOM_RATIO"',
+            group: true,
+            replacement: [
+                {
+                    match: /\{file:(\i),imageUri:/,
+                    replace: "{bieShelf,file:$1,imageUri:"
+                },
+                {
+                    match: /(\(0,\i\.jsx\)\(\i\.A,\{id:\i,children:)/,
+                    replace: "bieShelf,$1"
+                }
+            ]
+        },
+        {
+            find: 'displayName="RecentAvatarsStore"',
+            replacement: {
+                // our shelf goes in above Discord's own list of archived avatars
+                match: /(uploadType:(\i),guild:\i,handleOpenImageEditingModal:(\i),[\s\S]{0,500}?)(\i&&\(0,\i\.jsx\)\(\i,\{onComplete:(\i),returnRef:\i\}\))/,
+                replace: "$1$self.pickerRow($2,$3,$5),$4"
+            }
+        }
+    ],
+
+    wrapEditor(Original: React.ComponentType<any>) {
+        wrapped ??= (props: any) => <EditorShelf Original={Original} ownProps={props} />;
+        return wrapped;
+    },
+
+    pickerRow(uploadType: string, open: (imageUri: string, file: File) => void, complete: (result: any) => void) {
+        return (
+            <ErrorBoundary noop key="bie-picker">
+                <PickerShelf kind={kindOf(uploadType)} open={open} complete={complete} />
+            </ErrorBoundary>
+        );
+    }
+});

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -539,6 +539,7 @@ function onProfileSaved({ guildId }: { guildId?: string; }) {
 
 function onProfileDiscarded() {
     handedOver.clear();
+    offered = null;
 }
 
 let wrapped: React.ComponentType<EditorProps> | null = null;

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -633,7 +633,7 @@ let wrapped: React.ComponentType<any> | null = null;
 
 export default definePlugin({
     name: "BetterImageEditor",
-    description: "Keeps your own pictures on the image picker and under the crop window, on an uncropped shelf and a cropped one, for avatars, banners, server icons, server banners, event covers, home headers, decorations, widget covers, widget images and video backgrounds. Remembers how you framed each picture, and takes a paste or a dropped file straight in.",
+    description: "Keeps your own pictures on the image picker and under the crop window, on an uncropped shelf and a cropped one, for avatars, banners, server icons, server banners, event covers, home headers, widget covers, widget images and video backgrounds. Remembers how you framed each picture, and takes a paste or a dropped file straight in.",
     authors: [EquicordDevs.heart_menace],
     settings,
 

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -676,9 +676,9 @@ export default definePlugin({
         {
             find: 'displayName="RecentAvatarsStore"',
             replacement: {
-                // our shelf goes in above Discord's own list of archived avatars
-                match: /(uploadType:(\i),guild:\i,handleOpenImageEditingModal:(\i),[\s\S]{0,500}?)(\i&&\(0,\i\.jsx\)\(\i,\{onComplete:(\i),returnRef:\i\}\))/,
-                replace: "$1$self.pickerRow($2,$3,$5),$4"
+                // takes over the slot Discord renders its own recent avatars into
+                match: /(uploadType:(\i),guild:\i,handleOpenImageEditingModal:(\i),[\s\S]{0,500}?)\i&&\(0,\i\.jsx\)\(\i,\{onComplete:(\i),returnRef:\i\}\)/,
+                replace: "$1$self.pickerRow($2,$3,$4)"
             }
         }
     ],

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -103,14 +103,11 @@ const settings = definePluginSettings({
     }
 });
 
-// handoff marks a picture the picker already dealt with, so the editor does not file a
-// second copy of it. handedOver is what a confirmed profile save should be credited to.
 let handoff: { id: string | null; transform: CropState | null; } | null = null;
 let handedOver: { id: string; kind: Kind; } | null = null;
 
 const kindOf = (uploadType: string): Kind => uploadType || "AVATAR";
 
-// the cropper masks these to a square; everything else it crops wide
 const SQUARE = new Set(["AVATAR", "AVATAR_DECORATION", "GUILD_ICON", "PERSONAL_WIDGET_FIELD"]);
 
 const KIND_NAMES: Record<string, string> = {
@@ -246,8 +243,7 @@ function useForget(bump: () => void) {
     }, [bump]);
 }
 
-// the picker stays mounted under the cropper, so both surfaces listen at once. the
-// cropper is always the one on top, and takes the paste.
+// the picker stays mounted under the cropper, so only the topmost surface takes a paste
 let editorsOpen = 0;
 
 function usePasteAndDrop(accept: (file: File) => void, active: () => boolean) {
@@ -404,8 +400,7 @@ function PickerShelf({ kind, open, complete }: {
     const { group, setGroup, entries, thumbs, worn, bump } = useLibrary(kind);
     const onForget = useForget(bump);
 
-    // a data URI, not an object URL: Discord only ever hands the cropper the former, and an
-    // object URL dies with whichever surface made it
+    // a data URI, never an object URL: that dies with the surface that made it
     const hand = useCallback(async (id: string | null, file: File, crop: CropState | null) => {
         handoff = { id, transform: crop };
         if (id) handedOver = { id, kind };
@@ -428,7 +423,6 @@ function PickerShelf({ kind, open, complete }: {
         await touch(entry.id);
         bump();
 
-        // already framed, so it goes straight to the profile editor without the cropper
         if (entry.group === "cropped") {
             handedOver = { id: entry.id, kind };
             return complete({ imageUri: await toDataUrl(blob), file });
@@ -496,7 +490,6 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
         if (captured.current) return;
         captured.current = true;
 
-        // the picker shelf already dealt with this one
         if (handoff) {
             incomingId.current = handoff.id;
             handoff = null;
@@ -518,8 +511,7 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
         return () => { editorsOpen--; };
     }, []);
 
-    // the cropper already nudges by 4px on an arrow, 40 with shift, but the handler lives on
-    // two hidden range inputs that only Tab reaches. a click on the picture hands them focus.
+    // Discord's arrow-key nudging only listens on hidden inputs that Tab reaches, not a click
     useEffect(() => {
         const container = document.querySelector('[class*="editingContainer"]')?.parentElement;
         if (!container) return;
@@ -659,7 +651,7 @@ export default definePlugin({
             }
         },
         {
-            // grouped on purpose: rendering bieShelf without destructuring it throws
+            // grouped: rendering bieShelf without destructuring it throws
             find: '"SET_IMAGE_ZOOM_RATIO"',
             group: true,
             replacement: [

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -14,7 +14,7 @@ import { classNameFactory } from "@utils/css";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType } from "@utils/types";
 import { chooseFile, saveFile } from "@utils/web";
-import { Alerts, Button, FluxDispatcher, React, Toasts, useCallback, useEffect, useRef, useState } from "@webpack/common";
+import { Alerts, Button, React, Toasts, useCallback, useEffect, useRef, useState } from "@webpack/common";
 
 import { add, byRecency, clear, CropState, currentApplied, Entry, exportAll, forget, forgetCrops, getFile, getThumbs, Group, importAll, Kind, previousApplied, readIndex, recordApplied, saveCrop, toDataUrl, togglePin, touch } from "./library";
 
@@ -667,12 +667,6 @@ function onProfileDiscarded() {
     handedOver = null;
 }
 
-const DISCARD_EVENTS = [
-    "USER_PROFILE_SETTINGS_RESET_PENDING_CHANGES",
-    "USER_PROFILE_SETTINGS_RESET_PENDING_PROFILE_CHANGES",
-    "USER_PROFILE_SETTINGS_RESET_AND_CLOSE_FORM"
-];
-
 let wrapped: React.ComponentType<EditorProps> | null = null;
 
 export default definePlugin({
@@ -681,14 +675,11 @@ export default definePlugin({
     authors: [EquicordDevs.heart_menace],
     settings,
 
-    start() {
-        FluxDispatcher.subscribe("USER_PROFILE_SETTINGS_SUBMIT_SUCCESS", onProfileSaved);
-        for (const event of DISCARD_EVENTS) FluxDispatcher.subscribe(event, onProfileDiscarded);
-    },
-
-    stop() {
-        FluxDispatcher.unsubscribe("USER_PROFILE_SETTINGS_SUBMIT_SUCCESS", onProfileSaved);
-        for (const event of DISCARD_EVENTS) FluxDispatcher.unsubscribe(event, onProfileDiscarded);
+    flux: {
+        USER_PROFILE_SETTINGS_SUBMIT_SUCCESS: onProfileSaved,
+        USER_PROFILE_SETTINGS_RESET_PENDING_CHANGES: onProfileDiscarded,
+        USER_PROFILE_SETTINGS_RESET_PENDING_PROFILE_CHANGES: onProfileDiscarded,
+        USER_PROFILE_SETTINGS_RESET_AND_CLOSE_FORM: onProfileDiscarded
     },
 
     patches: [

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -10,12 +10,34 @@ import { definePluginSettings } from "@api/Settings";
 import ErrorBoundary from "@components/ErrorBoundary";
 import { DeleteIcon } from "@components/Icons";
 import { EquicordDevs } from "@utils/constants";
+import { classNameFactory } from "@utils/css";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType } from "@utils/types";
 import { chooseFile, saveFile } from "@utils/web";
 import { Alerts, Button, FluxDispatcher, React, Toasts, useCallback, useEffect, useRef, useState } from "@webpack/common";
 
 import { add, byRecency, clear, CropState, currentApplied, Entry, exportAll, forget, forgetCrops, getFile, getThumbs, Group, importAll, Kind, previousApplied, readIndex, recordApplied, saveCrop, toDataUrl, togglePin, touch } from "./library";
+
+const cl = classNameFactory("vc-bie-");
+
+interface PickResult {
+    imageUri: string;
+    file: File;
+}
+
+interface CropResult extends PickResult {
+    transform: CropState;
+}
+
+interface EditorProps {
+    file?: File;
+    imageUri?: string;
+    originalAsset?: unknown;
+    uploadType?: string;
+    initialTransform?: CropState | null;
+    onCrop?(result: CropResult): unknown;
+    bieShelf?: React.ReactNode;
+}
 
 interface Picked {
     id: string;
@@ -77,7 +99,7 @@ const settings = definePluginSettings({
         type: OptionType.COMPONENT,
         description: "Carry your pictures, and how each one is framed, to another device",
         component: () => (
-            <div className="bie-buttons">
+            <div className={cl("buttons")}>
                 <Button color={Button.Colors.PRIMARY} onClick={exportLibrary}>Export to a file</Button>
                 <Button color={Button.Colors.PRIMARY} onClick={importLibrary}>Import from a file</Button>
             </div>
@@ -107,7 +129,13 @@ const settings = definePluginSettings({
 let handoff: { id: string | null; transform: CropState | null; } | null = null;
 let handedOver: { id: string; kind: Kind; } | null = null;
 
-const kindOf = (uploadType: string): Kind => uploadType || "AVATAR";
+const PROFILE_KINDS = new Set(["AVATAR", "BANNER"]);
+
+function noteHanded(kind: Kind, id: string) {
+    if (PROFILE_KINDS.has(kind)) handedOver = { id, kind };
+}
+
+const kindOf = (uploadType?: string): Kind => uploadType || "AVATAR";
 
 const SQUARE = new Set(["AVATAR", "AVATAR_DECORATION", "GUILD_ICON", "PERSONAL_WIDGET_FIELD"]);
 
@@ -136,7 +164,7 @@ const EXTENSIONS: Record<string, string> = {
     "image/webp": "webp"
 };
 
-const PinIcon = (props: any) => (
+const PinIcon = (props: React.SVGProps<SVGSVGElement>) => (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden {...props}>
         <path d="M15 4V9l3 3v2h-5v7l-1 1-1-1v-7H6v-2l3-3V4H8V2h8v2z" />
     </svg>
@@ -292,7 +320,7 @@ function Shelf({ kind, group, entries, thumbs, activeId, wornId, onGroup, onPick
     onForget(entry: Entry, immediate: boolean): void;
     onPutBack?(): void;
 }) {
-    const shape = SQUARE.has(kind) ? "bie-square" : "bie-wide";
+    const shape = SQUARE.has(kind) ? "square" : "wide";
 
     const [hovered, setHovered] = useState<string | null>(null);
     const [playing, setPlaying] = useState<Record<string, string>>({});
@@ -313,36 +341,36 @@ function Shelf({ kind, group, entries, thumbs, activeId, wornId, onGroup, onPick
     }, [playing]);
 
     return (
-        <div className={`bie-panel ${shape}`}>
-            <div className="bie-tabs" role="tablist">
+        <div className={cl("panel", shape)}>
+            <div className={cl("tabs")} role="tablist">
                 <button
                     type="button"
                     role="tab"
                     aria-selected={group === "original"}
-                    className={`bie-tab${group === "original" ? " bie-on" : ""}`}
+                    className={cl("tab", { on: group === "original" })}
                     onClick={() => onGroup("original")}
                 >Originals</button>
                 <button
                     type="button"
                     role="tab"
                     aria-selected={group === "cropped"}
-                    className={`bie-tab${group === "cropped" ? " bie-on" : ""}`}
+                    className={cl("tab", { on: group === "cropped" })}
                     onClick={() => onGroup("cropped")}
                 >{croppedLabel(kind)}</button>
 
                 {onPutBack && (
-                    <button type="button" className="bie-action" onClick={onPutBack}>
+                    <button type="button" className={cl("action")} onClick={onPutBack}>
                         Put back the last one
                     </button>
                 )}
 
             </div>
 
-            <div className="bie-strip" role="group" aria-label="Saved pictures">
+            <div className={cl("strip")} role="group" aria-label="Saved pictures">
                 {entries.map(entry => (
                     <div
                         key={entry.id}
-                        className={`bie-item${entry.pinned ? " bie-pinned" : ""}${entry.id === wornId ? " bie-worn" : ""}`}
+                        className={cl("item", { pinned: entry.pinned, worn: entry.id === wornId })}
                         onMouseEnter={() => play(entry)}
                         onMouseLeave={() => setHovered(null)}
                     >
@@ -351,7 +379,7 @@ function Shelf({ kind, group, entries, thumbs, activeId, wornId, onGroup, onPick
                             aria-label={entry.name}
                             title={entry.id === wornId ? `${entry.name}
 You are wearing this` : entry.name}
-                            className={`bie-thumb${activeId === entry.id ? " bie-active" : ""}`}
+                            className={cl("thumb", { active: activeId === entry.id })}
                             style={{ backgroundImage: `url(${(hovered === entry.id && playing[entry.id]) || thumbs[entry.id]})` }}
                             onClick={() => onPick(entry)}
                             onContextMenu={event => {
@@ -361,7 +389,7 @@ You are wearing this` : entry.name}
                         />
                         <button
                             type="button"
-                            className="bie-remove"
+                            className={cl("remove")}
                             aria-label={`Remove ${entry.name}`}
                             title="Remove. Hold Shift to skip the confirmation"
                             onClick={event => onForget(entry, event.shiftKey)}
@@ -371,7 +399,7 @@ You are wearing this` : entry.name}
                         <button
                             type="button"
                             aria-pressed={!!entry.pinned}
-                            className={`bie-pin${entry.pinned ? " bie-on" : ""}`}
+                            className={cl("pin", { on: entry.pinned })}
                             aria-label={entry.pinned ? `Unpin ${entry.name}` : `Pin ${entry.name}`}
                             title={entry.pinned ? "Pinned, so it never drops off the shelf" : "Pin so it never drops off the shelf"}
                             onClick={() => onPin(entry)}
@@ -382,7 +410,7 @@ You are wearing this` : entry.name}
                 ))}
 
                 {!entries.length && (
-                    <span className="bie-empty">
+                    <span className={cl("empty")}>
                         {group === "original"
                             ? "Pictures you pick, paste or drop land here"
                             : "Pictures you crop land here"}
@@ -396,7 +424,7 @@ You are wearing this` : entry.name}
 function PickerShelf({ kind, open, complete }: {
     kind: Kind;
     open(imageUri: string, file: File): void;
-    complete(result: { imageUri: string; file: File; }): void;
+    complete(result: PickResult): void;
 }) {
     const { group, setGroup, entries, thumbs, worn, bump } = useLibrary(kind);
     const onForget = useForget(bump);
@@ -404,7 +432,6 @@ function PickerShelf({ kind, open, complete }: {
     // a data URI, never an object URL: that dies with the surface that made it
     const hand = useCallback(async (id: string | null, file: File, crop: CropState | null) => {
         handoff = { id, transform: crop };
-        if (id) handedOver = { id, kind };
         open(await toDataUrl(file), file);
     }, [open]);
 
@@ -425,7 +452,7 @@ function PickerShelf({ kind, open, complete }: {
         bump();
 
         if (entry.group === "cropped") {
-            handedOver = { id: entry.id, kind };
+            noteHanded(kind, entry.id);
             return complete({ imageUri: await toDataUrl(blob), file });
         }
 
@@ -465,7 +492,7 @@ function PickerShelf({ kind, open, complete }: {
     );
 }
 
-function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any>; ownProps: any; }) {
+function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<EditorProps>; ownProps: EditorProps; }) {
     const kind = kindOf(ownProps.uploadType);
 
     const { group, setGroup, entries, thumbs, worn, bump } = useLibrary(kind);
@@ -479,6 +506,7 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
     const pickedName = useRef<string | null>(null);
     const pickedGroup = useRef<Group>("original");
     const captured = useRef(false);
+    const anchor = useRef<HTMLDivElement>(null);
 
     pickedId.current = picked?.id ?? null;
     pickedGroup.current = picked?.group ?? "original";
@@ -516,16 +544,21 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
 
     // Discord's arrow-key nudging only listens on hidden inputs that Tab reaches, not a click
     useEffect(() => {
-        const container = document.querySelector('[class*="editingContainer"]')?.parentElement;
-        if (!container) return;
+        function focusPan({ target }: MouseEvent) {
+            let scope = anchor.current?.parentElement ?? null;
+            let pan: HTMLInputElement | null = null;
 
-        const focusPan = () => container
-            .querySelector<HTMLInputElement>('input[type="range"][aria-orientation="horizontal"]')
-            ?.focus({ preventScroll: true });
+            while (scope && !pan) {
+                pan = scope.querySelector('input[type="range"][aria-orientation="horizontal"]');
+                if (!pan) scope = scope.parentElement;
+            }
 
-        container.addEventListener("mouseup", focusPan);
-        return () => container.removeEventListener("mouseup", focusPan);
-    }, [picked?.id]);
+            if (pan && scope?.contains(target as Node)) pan.focus({ preventScroll: true });
+        }
+
+        document.addEventListener("mouseup", focusPan);
+        return () => document.removeEventListener("mouseup", focusPan);
+    }, []);
 
     const accept = useCallback(async (file: File) => {
         try {
@@ -553,10 +586,8 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
         togglePin(entry.id).then(bump).catch(err => logger.error("could not pin that picture", err));
     }, [bump]);
 
-    const keepCropped = useCallback((result: any) => {
-        const uri = result?.imageUri;
-        if (typeof uri !== "string") return logger.warn("the cropper returned something that cannot be saved", result);
-
+    const keepCropped = useCallback((result: CropResult) => {
+        const uri = result.imageUri;
         const source = pickedId.current ?? incomingId.current ?? undefined;
         const save = async () => {
             const stem = (pickedName.current ?? "picture").replace(/\.[^.]+$/, "");
@@ -579,19 +610,18 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
         });
     }, [kind, bump]);
 
-    const onCrop = useCallback((...args: any[]) => {
+    const onCrop = useCallback((result: CropResult) => {
         const id = pickedId.current ?? incomingId.current;
-        const transform = args[0]?.transform;
 
-        if (id) handedOver = { id, kind };
-        if (id && transform && settings.store.rememberCrop) {
-            saveCrop(id, transform).catch(err => logger.error("could not remember that crop", err));
+        if (id) noteHanded(kind, id);
+        if (id && result.transform && settings.store.rememberCrop) {
+            saveCrop(id, result.transform).catch(err => logger.error("could not remember that crop", err));
         }
 
-        if (settings.store.saveCropped && pickedGroup.current !== "cropped") keepCropped(args[0]);
+        if (settings.store.saveCropped && pickedGroup.current !== "cropped") keepCropped(result);
 
-        return ownProps.onCrop?.(...args);
-    }, [ownProps.onCrop, keepCropped]);
+        return ownProps.onCrop?.(result);
+    }, [ownProps.onCrop, keepCropped, kind]);
 
     const props = picked
         ? { ...ownProps, imageUri: picked.uri, file: picked.file, originalAsset: null, onCrop, initialTransform: transform }
@@ -603,33 +633,47 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
             {...props}
             bieShelf={
                 <ErrorBoundary noop>
-                    <Shelf
-                        kind={kind}
-                        group={group}
-                        entries={entries}
-                        thumbs={thumbs}
-                        activeId={picked?.id ?? null}
-                        wornId={worn}
-                        onGroup={setGroup}
-                        onPick={onPick}
-                        onPin={onPin}
-                        onForget={onForget}
-                    />
+                    <div ref={anchor}>
+                        <Shelf
+                            kind={kind}
+                            group={group}
+                            entries={entries}
+                            thumbs={thumbs}
+                            activeId={picked?.id ?? null}
+                            wornId={worn}
+                            onGroup={setGroup}
+                            onPick={onPick}
+                            onPin={onPin}
+                            onForget={onForget}
+                        />
+                    </div>
                 </ErrorBoundary>
             }
         />
     );
 }
 
-function onProfileSaved() {
+function onProfileSaved({ guildId }: { guildId?: string; }) {
     if (!handedOver) return;
 
     const { id, kind } = handedOver;
     handedOver = null;
+    if (guildId) return;
+
     recordApplied(kind, id).catch(err => logger.error("could not note what you put on", err));
 }
 
-let wrapped: React.ComponentType<any> | null = null;
+function onProfileDiscarded() {
+    handedOver = null;
+}
+
+const DISCARD_EVENTS = [
+    "USER_PROFILE_SETTINGS_RESET_PENDING_CHANGES",
+    "USER_PROFILE_SETTINGS_RESET_PENDING_PROFILE_CHANGES",
+    "USER_PROFILE_SETTINGS_RESET_AND_CLOSE_FORM"
+];
+
+let wrapped: React.ComponentType<EditorProps> | null = null;
 
 export default definePlugin({
     name: "BetterImageEditor",
@@ -639,10 +683,12 @@ export default definePlugin({
 
     start() {
         FluxDispatcher.subscribe("USER_PROFILE_SETTINGS_SUBMIT_SUCCESS", onProfileSaved);
+        for (const event of DISCARD_EVENTS) FluxDispatcher.subscribe(event, onProfileDiscarded);
     },
 
     stop() {
         FluxDispatcher.unsubscribe("USER_PROFILE_SETTINGS_SUBMIT_SUCCESS", onProfileSaved);
+        for (const event of DISCARD_EVENTS) FluxDispatcher.unsubscribe(event, onProfileDiscarded);
     },
 
     patches: [
@@ -678,12 +724,12 @@ export default definePlugin({
         }
     ],
 
-    wrapEditor(Original: React.ComponentType<any>) {
-        wrapped ??= (props: any) => <EditorShelf Original={Original} ownProps={props} />;
+    wrapEditor(Original: React.ComponentType<EditorProps>) {
+        wrapped ??= (props: EditorProps) => <EditorShelf Original={Original} ownProps={props} />;
         return wrapped;
     },
 
-    pickerRow(uploadType: string, open: (imageUri: string, file: File) => void, complete: (result: any) => void) {
+    pickerRow(uploadType: string, open: (imageUri: string, file: File) => void, complete: (result: PickResult) => void) {
         return (
             <ErrorBoundary noop key="bie-picker">
                 <PickerShelf kind={kindOf(uploadType)} open={open} complete={complete} />

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -12,10 +12,10 @@ import { EquicordDevs } from "@utils/constants";
 import { Logger } from "@utils/Logger";
 import definePlugin, { OptionType } from "@utils/types";
 import { chooseFile, saveFile } from "@utils/web";
-import { Alerts, Button, React, Toasts, useCallback, useEffect, useRef, useState } from "@webpack/common";
+import { Alerts, Button, React, showToast, Toasts, useCallback, useEffect, useRef, useState } from "@webpack/common";
 
 import { cl, croppedLabel, Shelf } from "./components/Shelf";
-import { add, byRecency, clear, CropState, currentApplied, Entry, exportAll, forget, forgetCrops, getFile, getThumbs, Group, importAll, Kind, previousApplied, readIndex, recordApplied, saveCrop, toDataUrl, togglePin, touch } from "./library";
+import { add, clear, CropState, currentApplied, Entry, exportAll, forget, forgetCrops, getFile, getThumbs, Group, importAll, Kind, previousApplied, readIndex, recordApplied, saveCrop, toDataUrl, togglePin, touch } from "./library";
 
 interface PickResult {
     imageUri: string;
@@ -23,7 +23,19 @@ interface PickResult {
 }
 
 interface CropResult extends PickResult {
+    staticImageUri?: string;
     transform: CropState;
+}
+
+interface PickerProps {
+    allowRecentAvatarsSelection?: boolean;
+    maxFileSizeBytes?: number;
+}
+
+interface PendingChanges {
+    guildId?: string;
+    pendingAvatar?: { imageUri: string; } | null;
+    pendingBanner?: { imageUri: string; } | null;
 }
 
 interface EditorProps {
@@ -48,19 +60,19 @@ const logger = new Logger("BetterImageEditor");
 const settings = definePluginSettings({
     librarySize: {
         type: OptionType.SLIDER,
-        description: "How many pictures to keep on each shelf",
+        description: "How many pictures to keep on each shelf.",
         markers: [6, 12, 24, 48],
         default: 24,
         stickToMarkers: true
     },
     rememberCrop: {
         type: OptionType.BOOLEAN,
-        description: "Restore the zoom and position you last used for a picture",
+        description: "Restore the zoom and position you last used for a picture.",
         default: true
     },
     forgetFraming: {
         type: OptionType.COMPONENT,
-        description: "Drop every remembered crop and open each picture the way Discord would",
+        description: "Drop every remembered crop and open each picture the way Discord would.",
         component: () => (
             <Button
                 color={Button.Colors.PRIMARY}
@@ -71,10 +83,10 @@ const settings = definePluginSettings({
                     confirmText: "Forget",
                     cancelText: "Cancel",
                     onConfirm: () => forgetCrops()
-                        .then(count => Toasts.show(Toasts.create(
+                        .then(count => showToast(
                             count ? `Forgot the framing on ${count} picture${count === 1 ? "" : "s"}` : "Nothing was framed",
                             Toasts.Type.SUCCESS
-                        )))
+                        ))
                         .catch(err => logger.error("could not forget the remembered crops", err))
                 })}
             >
@@ -84,17 +96,17 @@ const settings = definePluginSettings({
     },
     saveCropped: {
         type: OptionType.BOOLEAN,
-        description: "Keep a copy of each picture after you crop it",
+        description: "Keep a copy of each picture after you crop it.",
         default: true
     },
     askBeforeSavingCropped: {
         type: OptionType.BOOLEAN,
-        description: "Ask first, instead of keeping the cropped copy automatically",
+        description: "Ask first, instead of keeping the cropped copy automatically.",
         default: false
     },
     transfer: {
         type: OptionType.COMPONENT,
-        description: "Carry your pictures, and how each one is framed, to another device",
+        description: "Carry your pictures, and how each one is framed, to another device.",
         component: () => (
             <div className={cl("buttons")}>
                 <Button color={Button.Colors.PRIMARY} onClick={exportLibrary}>Export to a file</Button>
@@ -104,7 +116,7 @@ const settings = definePluginSettings({
     },
     clearLibrary: {
         type: OptionType.COMPONENT,
-        description: "Throw away every picture you have saved",
+        description: "Throw away every picture you have saved.",
         component: () => (
             <Button
                 color={Button.Colors.PRIMARY}
@@ -123,13 +135,15 @@ const settings = definePluginSettings({
     }
 });
 
-let handoff: { id: string | null; transform: CropState | null; } | null = null;
-let handedOver: { id: string; kind: Kind; } | null = null;
+let handoff: { id: string; transform: CropState | null; file: File; } | null = null;
+let offered: { kind: Kind; id: string; uris: (string | undefined)[]; } | null = null;
+const handedOver = new Map<string, string | null>();
+let editorAllowed = true;
 
-const PROFILE_KINDS = new Set(["AVATAR", "BANNER"]);
+const PENDING = [["AVATAR", "pendingAvatar"], ["BANNER", "pendingBanner"]] as const;
 
-function noteHanded(kind: Kind, id: string) {
-    if (PROFILE_KINDS.has(kind)) handedOver = { id, kind };
+function offer(kind: Kind, id: string, uris: (string | undefined)[]) {
+    offered = { kind, id, uris };
 }
 
 const kindOf = (uploadType?: string): Kind => uploadType || "AVATAR";
@@ -151,7 +165,7 @@ async function exportLibrary() {
         else saveFile(new File([data], FILENAME, { type: "application/json" }));
     } catch (err) {
         logger.error("could not export the library", err);
-        Toasts.show(Toasts.create("Could not export your pictures", Toasts.Type.FAILURE));
+        showToast("Could not export your pictures", Toasts.Type.FAILURE);
     }
 }
 
@@ -170,13 +184,13 @@ async function importLibrary() {
         if (!json) return;
 
         const added = await importAll(json, settings.store.librarySize);
-        Toasts.show(Toasts.create(
+        showToast(
             added ? `Added ${added} picture${added === 1 ? "" : "s"}` : "Nothing new in that file",
             Toasts.Type.SUCCESS
-        ));
+        );
     } catch (err) {
         logger.error("could not import the library", err);
-        Toasts.show(Toasts.create("Could not read that file", Toasts.Type.FAILURE));
+        showToast("Could not read that file", Toasts.Type.FAILURE);
     }
 }
 
@@ -187,25 +201,24 @@ function useLibrary(kind: Kind) {
     const [thumbs, setThumbs] = useState<Record<string, string>>({});
     const [worn, setWorn] = useState<string | null>(null);
 
-    const urls = useRef<string[]>([]);
     const bump = useCallback(() => setVersion(v => v + 1), []);
-    const track = useCallback((url: string) => { urls.current.push(url); return url; }, []);
 
-    useEffect(() => () => urls.current.forEach(URL.revokeObjectURL), []);
+    useEffect(() => () => Object.values(thumbs).forEach(URL.revokeObjectURL), [thumbs]);
 
     useEffect(() => {
         let live = true;
 
         (async () => {
-            const mine = byRecency((await readIndex()).filter(entry => entry.kind === kind && entry.group === group))
-                .sort((a, b) => Number(!!b.pinned) - Number(!!a.pinned));
+            const mine = (await readIndex())
+                .filter(entry => entry.kind === kind && entry.group === group)
+                .sort((a, b) => Number(!!b.pinned) - Number(!!a.pinned) || (b.used ?? b.added) - (a.used ?? a.added));
             const blobs = await getThumbs(mine.map(entry => entry.id));
             if (!live) return;
 
             const next: Record<string, string> = {};
             mine.forEach((entry, index) => {
                 const blob = blobs[index];
-                if (blob) next[entry.id] = track(URL.createObjectURL(blob));
+                if (blob) next[entry.id] = URL.createObjectURL(blob);
             });
 
             setThumbs(next);
@@ -221,7 +234,7 @@ function useLibrary(kind: Kind) {
             .catch(err => logger.error("could not read what you are wearing", err));
     }, [kind, version]);
 
-    return { group, setGroup, entries, thumbs, worn, bump, track };
+    return { group, setGroup, entries, thumbs, worn, bump };
 }
 
 function useForget(bump: () => void) {
@@ -277,16 +290,26 @@ function usePasteAndDrop(accept: (file: File) => void, active: () => boolean) {
     }, [accept, active]);
 }
 
-function PickerShelf({ kind, open, complete }: {
+function EditorGate() {
+    useEffect(() => {
+        editorAllowed = false;
+        return () => { editorAllowed = true; };
+    }, []);
+
+    return null;
+}
+
+function PickerShelf({ kind, open, complete, maxSize }: {
     kind: Kind;
     open(imageUri: string, file: File): void;
     complete(result: PickResult): void;
+    maxSize?: number;
 }) {
     const { group, setGroup, entries, thumbs, worn, bump } = useLibrary(kind);
     const onForget = useForget(bump);
 
-    const hand = useCallback(async (id: string | null, file: File, crop: CropState | null) => {
-        handoff = { id, transform: crop };
+    const hand = useCallback(async (id: string, file: File, crop: CropState | null) => {
+        handoff = { id, transform: crop, file };
         open(await toDataUrl(file), file);
     }, [open]);
 
@@ -307,8 +330,9 @@ function PickerShelf({ kind, open, complete }: {
         bump();
 
         if (entry.group === "cropped") {
-            noteHanded(kind, entry.id);
-            return complete({ imageUri: await toDataUrl(blob), file });
+            const uri = await toDataUrl(blob);
+            offer(kind, entry.id, [uri]);
+            return complete({ imageUri: uri, file });
         }
 
         await hand(entry.id, file, settings.store.rememberCrop ? entry.crop ?? null : null);
@@ -319,14 +343,16 @@ function PickerShelf({ kind, open, complete }: {
     }, [bump]);
 
     const accept = useCallback(async (file: File) => {
+        if (maxSize && file.size > maxSize) return showToast("That picture is too big for Discord", Toasts.Type.FAILURE);
+
         try {
-            const id = await add(file, kind, "original", settings.store.librarySize);
+            const entry = await add(file, kind, "original", settings.store.librarySize);
             bump();
-            await hand(id, file, null);
+            await hand(entry.id, file, settings.store.rememberCrop ? entry.crop ?? null : null);
         } catch (err) {
             logger.error("could not take that picture", err);
         }
-    }, [kind, hand, bump]);
+    }, [kind, hand, bump, maxSize]);
 
     usePasteAndDrop(accept, useCallback(() => editorsOpen === 0, []));
 
@@ -354,13 +380,12 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
     const onForget = useForget(bump);
 
     const [picked, setPicked] = useState<Picked | null>(null);
-    const [transform, setTransform] = useState<CropState | null>(() => handoff?.transform ?? null);
+    const [transform, setTransform] = useState<CropState | null>(() => handoff && handoff.file === ownProps.file ? handoff.transform : null);
 
     const incomingId = useRef<string | null>(null);
     const pickedId = useRef<string | null>(null);
     const pickedName = useRef<string | null>(null);
     const pickedGroup = useRef<Group>("original");
-    const captured = useRef(false);
     const anchor = useRef<HTMLDivElement>(null);
 
     pickedId.current = picked?.id ?? null;
@@ -373,21 +398,22 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
     }, []);
 
     useEffect(() => {
-        if (captured.current) return;
-        captured.current = true;
+        const incoming = handoff;
+        handoff = null;
 
-        if (handoff) {
-            incomingId.current = handoff.id;
-            handoff = null;
+        if (incoming && incoming.file === ownProps.file) {
+            incomingId.current = incoming.id;
             return;
         }
 
-        if (!(ownProps.file instanceof File)) return;
+        const { file } = ownProps;
+        if (!(file instanceof File) || !file.type.startsWith("image/")) return;
 
-        add(ownProps.file, kind, "original", settings.store.librarySize)
-            .then(id => {
-                incomingId.current = id;
+        add(file, kind, "original", settings.store.librarySize)
+            .then(entry => {
+                incomingId.current = entry.id;
                 bump();
+                if (entry.crop && settings.store.rememberCrop) return show(entry.id, file, entry.crop);
             })
             .catch(err => logger.error("could not save that picture", err));
     }, []);
@@ -398,28 +424,31 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
     }, []);
 
     useEffect(() => {
+        let scope = anchor.current?.parentElement ?? null;
+        let pan: HTMLInputElement | null = null;
+
+        while (scope && !pan) {
+            pan = scope.querySelector('input[type="range"][aria-orientation="horizontal"]');
+            if (!pan) scope = scope.parentElement;
+        }
+        if (!scope || !pan) return;
+
+        const container = scope;
+        const slider = pan;
         function focusPan({ target }: MouseEvent) {
-            let scope = anchor.current?.parentElement ?? null;
-            let pan: HTMLInputElement | null = null;
-
-            while (scope && !pan) {
-                pan = scope.querySelector('input[type="range"][aria-orientation="horizontal"]');
-                if (!pan) scope = scope.parentElement;
-            }
-
-            if (pan && scope?.contains(target as Node)) pan.focus({ preventScroll: true });
+            if (!anchor.current?.contains(target as Node)) slider.focus({ preventScroll: true });
         }
 
-        document.addEventListener("mouseup", focusPan);
-        return () => document.removeEventListener("mouseup", focusPan);
-    }, []);
+        container.addEventListener("mouseup", focusPan);
+        return () => container.removeEventListener("mouseup", focusPan);
+    }, [picked?.id]);
 
     const accept = useCallback(async (file: File) => {
         try {
-            const id = await add(file, kind, "original", settings.store.librarySize);
+            const entry = await add(file, kind, "original", settings.store.librarySize);
             setGroup("original");
             bump();
-            await show(id, file, null);
+            await show(entry.id, file, settings.store.rememberCrop ? entry.crop ?? null : null);
         } catch (err) {
             logger.error("could not take that picture", err);
         }
@@ -467,7 +496,7 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
     const onCrop = useCallback((result: CropResult) => {
         const id = pickedId.current ?? incomingId.current;
 
-        if (id) noteHanded(kind, id);
+        if (id) offer(kind, id, [result.imageUri, result.staticImageUri]);
         if (id && result.transform && settings.store.rememberCrop) {
             saveCrop(id, result.transform).catch(err => logger.error("could not remember that crop", err));
         }
@@ -507,29 +536,42 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
     );
 }
 
+function onPendingChanged({ guildId, ...changes }: PendingChanges) {
+    for (const [kind, field] of PENDING) {
+        if (!(field in changes)) continue;
+
+        const key = `${kind}:${guildId ?? ""}`;
+        const pending = changes[field];
+        if (pending === undefined) handedOver.delete(key);
+        else if (pending && offered?.kind === kind && offered.uris.includes(pending.imageUri)) handedOver.set(key, offered.id);
+        else handedOver.set(key, null);
+    }
+}
+
 function onProfileSaved({ guildId }: { guildId?: string; }) {
-    if (!handedOver) return;
+    for (const [key, id] of handedOver) {
+        const [kind, guild] = key.split(":");
+        if (guild !== (guildId ?? "")) continue;
 
-    const { id, kind } = handedOver;
-    handedOver = null;
-    if (guildId) return;
-
-    recordApplied(kind, id).catch(err => logger.error("could not note what you put on", err));
+        handedOver.delete(key);
+        if (!guildId) recordApplied(kind, id).catch(err => logger.error("could not note what you put on", err));
+    }
 }
 
 function onProfileDiscarded() {
-    handedOver = null;
+    handedOver.clear();
 }
 
 let wrapped: React.ComponentType<EditorProps> | null = null;
 
 export default definePlugin({
     name: "BetterImageEditor",
-    description: "Keeps your own pictures on the image picker and under the crop window, on an uncropped shelf and a cropped one, for avatars, banners, server icons, server banners, event covers, home headers, widget covers, widget images and video backgrounds. Remembers how you framed each picture, and takes a paste or a dropped file straight in.",
+    description: "Keeps your own pictures on the image picker and under the crop window, on an uncropped shelf and a cropped one, for avatars, banners, server icons, server banners, event covers, home headers, widget covers and widget images. Remembers how you framed each picture, and takes a paste or a dropped file straight in.",
     authors: [EquicordDevs.heart_menace],
     settings,
 
     flux: {
+        USER_PROFILE_SETTINGS_SET_PENDING_CHANGES: onPendingChanged,
         USER_PROFILE_SETTINGS_SUBMIT_SUCCESS: onProfileSaved,
         USER_PROFILE_SETTINGS_RESET_PENDING_CHANGES: onProfileDiscarded,
         USER_PROFILE_SETTINGS_RESET_PENDING_PROFILE_CHANGES: onProfileDiscarded,
@@ -562,20 +604,30 @@ export default definePlugin({
             find: 'displayName="RecentAvatarsStore"',
             replacement: {
                 match: /(uploadType:(\i),guild:\i,handleOpenImageEditingModal:(\i),[\s\S]{0,500}?)\i&&\(0,\i\.jsx\)\(\i,\{onComplete:(\i),returnRef:\i\}\)/,
-                replace: "$1$self.pickerRow($2,$3,$4)"
+                replace: "$1$self.pickerRow($2,$3,$4,arguments[0])"
             }
         }
     ],
 
     wrapEditor(Original: React.ComponentType<EditorProps>) {
-        wrapped ??= (props: EditorProps) => <EditorShelf Original={Original} ownProps={props} />;
+        if (!wrapped) {
+            const Safe = ErrorBoundary.wrap(EditorShelf, {
+                fallback: ({ wrappedProps }) => <Original {...wrappedProps.ownProps} />
+            });
+            wrapped = (props: EditorProps) => editorAllowed
+                ? <Safe Original={Original} ownProps={props} />
+                : <Original {...props} />;
+        }
+
         return wrapped;
     },
 
-    pickerRow(uploadType: string, open: (imageUri: string, file: File) => void, complete: (result: PickResult) => void) {
+    pickerRow(uploadType: string, open: (imageUri: string, file: File) => void, complete: (result: PickResult) => void, picker: PickerProps) {
+        if (picker.allowRecentAvatarsSelection === false) return <EditorGate key="bie-picker" />;
+
         return (
             <ErrorBoundary noop key="bie-picker">
-                <PickerShelf kind={kindOf(uploadType)} open={open} complete={complete} />
+                <PickerShelf kind={kindOf(uploadType)} open={open} complete={complete} maxSize={picker.maxFileSizeBytes} />
             </ErrorBoundary>
         );
     }

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -386,7 +386,6 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
     const pickedId = useRef<string | null>(null);
     const pickedName = useRef<string | null>(null);
     const pickedGroup = useRef<Group>("original");
-    const anchor = useRef<HTMLDivElement>(null);
 
     pickedId.current = picked?.id ?? null;
     pickedGroup.current = picked?.group ?? "original";
@@ -422,26 +421,6 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
         editorsOpen++;
         return () => { editorsOpen--; };
     }, []);
-
-    useEffect(() => {
-        let scope = anchor.current?.parentElement ?? null;
-        let pan: HTMLInputElement | null = null;
-
-        while (scope && !pan) {
-            pan = scope.querySelector('input[type="range"][aria-orientation="horizontal"]');
-            if (!pan) scope = scope.parentElement;
-        }
-        if (!scope || !pan) return;
-
-        const container = scope;
-        const slider = pan;
-        function focusPan({ target }: MouseEvent) {
-            if (!anchor.current?.contains(target as Node)) slider.focus({ preventScroll: true });
-        }
-
-        container.addEventListener("mouseup", focusPan);
-        return () => container.removeEventListener("mouseup", focusPan);
-    }, [picked?.id]);
 
     const accept = useCallback(async (file: File) => {
         try {
@@ -516,7 +495,7 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<Edi
             {...props}
             bieShelf={
                 <ErrorBoundary noop>
-                    <div ref={anchor}>
+                    <div>
                         <Shelf
                             kind={kind}
                             group={group}

--- a/src/equicordplugins/betterImageEditor/index.tsx
+++ b/src/equicordplugins/betterImageEditor/index.tsx
@@ -21,6 +21,7 @@ interface Picked {
     id: string;
     uri: string;
     file: File;
+    group: Group;
 }
 
 const logger = new Logger("BetterImageEditor");
@@ -476,14 +477,16 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
     const incomingId = useRef<string | null>(null);
     const pickedId = useRef<string | null>(null);
     const pickedName = useRef<string | null>(null);
+    const pickedGroup = useRef<Group>("original");
     const captured = useRef(false);
 
     pickedId.current = picked?.id ?? null;
+    pickedGroup.current = picked?.group ?? "original";
     pickedName.current = picked?.file.name ?? ownProps.file?.name ?? null;
 
-    const show = useCallback(async (id: string, file: File, crop: CropState | null) => {
+    const show = useCallback(async (id: string, file: File, crop: CropState | null, group: Group = "original") => {
         setTransform(crop);
-        setPicked({ id, uri: await toDataUrl(file), file });
+        setPicked({ id, uri: await toDataUrl(file), file, group });
     }, []);
 
     useEffect(() => {
@@ -543,7 +546,7 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
 
         await touch(entry.id);
         bump();
-        await show(entry.id, new File([blob], entry.name, { type: blob.type }), settings.store.rememberCrop ? entry.crop ?? null : null);
+        await show(entry.id, new File([blob], entry.name, { type: blob.type }), settings.store.rememberCrop ? entry.crop ?? null : null, entry.group);
     }, [show, bump]);
 
     const onPin = useCallback((entry: Entry) => {
@@ -585,7 +588,7 @@ function EditorShelf({ Original, ownProps }: { Original: React.ComponentType<any
             saveCrop(id, transform).catch(err => logger.error("could not remember that crop", err));
         }
 
-        if (settings.store.saveCropped) keepCropped(args[0]);
+        if (settings.store.saveCropped && pickedGroup.current !== "cropped") keepCropped(args[0]);
 
         return ownProps.onCrop?.(...args);
     }, [ownProps.onCrop, keepCropped]);

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -8,12 +8,11 @@ import * as DataStore from "@api/DataStore";
 
 const store = DataStore.createStore("BetterImageEditor", "library");
 
-// Discord's own uploadType: AVATAR, BANNER, GUILD_ICON, GUILD_BANNER and the rest
+// Discord's uploadType, such as AVATAR or GUILD_BANNER
 export type Kind = string;
 export type Group = "original" | "cropped";
 
-// the shape of the cropper's own initialTransform prop. offsetRatio is a fraction of the
-// drag range rather than pixels, so it replays at any image size.
+// the cropper's initialTransform prop. offsetRatio is a fraction of the drag range, not pixels
 export interface CropState {
     zoomRatio: number;
     imageRotation: number;
@@ -40,8 +39,7 @@ const thumbKey = (id: string) => `thumb:${id}`;
 
 const THUMB_MAX = 160;
 
-// entries predating the cropped shelf carry no group and are all originals; ones predating
-// the wider upload types are named in lower case. crops kept in pixels cannot be replayed.
+// older entries lack a group, use lower-case kinds, or hold crops in pixels
 const LEGACY_KINDS: Record<string, string> = { avatar: "AVATAR", banner: "BANNER" };
 
 export const readIndex = () => DataStore.get<Entry[]>(INDEX, store)
@@ -69,7 +67,6 @@ const fromDataUrl = (url: string) => fetch(url).then(r => r.blob());
 
 const newId = () => `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
 
-// keeps the source aspect so the strip can crop it to a circle or a wide tile in CSS
 function thumbnail(source: Blob) {
     return new Promise<Blob>((resolve, reject) => {
         const url = URL.createObjectURL(source);
@@ -103,8 +100,7 @@ export async function add(file: File, kind: Kind, group: Group, limit: number, f
     const known = stored.find(entry => sameShelf(entry) && entry.sig === sig);
     if (known) return known.id;
 
-    // one cropped copy per source picture. a pinned copy is kept, since pinning is what you
-    // do to a framing you want back later.
+    // one cropped copy per source, unless the old one is pinned
     const replaced = from ? stored.filter(entry => sameShelf(entry) && entry.from === from && !entry.pinned) : [];
     const entries = stored.filter(entry => !replaced.includes(entry));
 
@@ -169,7 +165,6 @@ export async function importAll(json: string, limit: number) {
         added++;
     }
 
-    // same rule add() uses: newest kept, oldest off the end of each shelf
     entries.sort((a, b) => b.added - a.added);
 
     const counts = new Map<string, number>();
@@ -204,7 +199,6 @@ export async function forgetCrops() {
     return framed.length;
 }
 
-// the shelf is most-recently-used: picking a picture sends it to the front
 export const byRecency = (entries: Entry[]) =>
     [...entries].sort((a, b) => (b.used ?? b.added) - (a.used ?? a.added));
 
@@ -226,8 +220,7 @@ export async function togglePin(id: string) {
     await writeIndex(entries);
 }
 
-// which pictures you have actually worn, newest first. recorded when Discord confirms the
-// profile saved, not when one is handed to the editor.
+// recorded when Discord confirms the save, not when a picture is handed to the editor
 const historyKey = (kind: Kind) => `history:${kind}`;
 
 export async function recordApplied(kind: Kind, id: string) {

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -62,7 +62,7 @@ function queued<T>(work: () => Promise<T>) {
 export const getFile = (id: string) => DataStore.get<Blob>(fileKey(id), store);
 export const getThumb = (id: string) => DataStore.get<Blob>(thumbKey(id), store);
 export const getThumbs = (ids: string[]) => DataStore.getMany<Blob>(ids.map(thumbKey), store);
-export const clear = () => DataStore.clear(store);
+export const clear = () => queued(() => DataStore.clear(store));
 
 export const toDataUrl = (blob: Blob) => new Promise<string>((resolve, reject) => {
     const reader = new FileReader();

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -51,6 +51,14 @@ export const readIndex = () => DataStore.get<Entry[]>(INDEX, store)
     })));
 const writeIndex = (entries: Entry[]) => DataStore.set(INDEX, entries, store);
 
+let turn: Promise<unknown> = Promise.resolve();
+
+function queued<T>(work: () => Promise<T>) {
+    const result = turn.then(work);
+    turn = result.catch(() => { });
+    return result;
+}
+
 export const getFile = (id: string) => DataStore.get<Blob>(fileKey(id), store);
 export const getThumb = (id: string) => DataStore.get<Blob>(thumbKey(id), store);
 export const getThumbs = (ids: string[]) => DataStore.getMany<Blob>(ids.map(thumbKey), store);
@@ -79,8 +87,10 @@ function thumbnail(source: Blob) {
             const canvas = document.createElement("canvas");
             canvas.width = Math.round(image.width * scale);
             canvas.height = Math.round(image.height * scale);
-            canvas.getContext("2d")!.drawImage(image, 0, 0, canvas.width, canvas.height);
+            const context = canvas.getContext("2d");
+            if (!context) return reject(new Error("could not draw a thumbnail"));
 
+            context.drawImage(image, 0, 0, canvas.width, canvas.height);
             canvas.toBlob(blob => blob ? resolve(blob) : reject(new Error("could not draw a thumbnail")), "image/webp", 0.8);
         };
         image.onerror = () => {
@@ -92,31 +102,33 @@ function thumbnail(source: Blob) {
     });
 }
 
-export async function add(file: File, kind: Kind, group: Group, limit: number, from?: string) {
-    const sig = `${file.name}:${file.size}:${file.lastModified}`;
-    const stored = await readIndex();
-    const sameShelf = (entry: Entry) => entry.kind === kind && entry.group === group;
+export function add(file: File, kind: Kind, group: Group, limit: number, from?: string) {
+    return queued(async () => {
+        const sig = `${file.name}:${file.size}:${file.lastModified}`;
+        const stored = await readIndex();
+        const sameShelf = (entry: Entry) => entry.kind === kind && entry.group === group;
 
-    const known = stored.find(entry => sameShelf(entry) && entry.sig === sig);
-    if (known) return known.id;
+        const known = stored.find(entry => sameShelf(entry) && entry.sig === sig);
+        if (known) return known.id;
 
-    // one cropped copy per source, unless the old one is pinned
-    const replaced = from ? stored.filter(entry => sameShelf(entry) && entry.from === from && !entry.pinned) : [];
-    const entries = stored.filter(entry => !replaced.includes(entry));
+        // one cropped copy per source, unless the old one is pinned
+        const replaced = from ? stored.filter(entry => sameShelf(entry) && entry.from === from && !entry.pinned) : [];
+        const entries = stored.filter(entry => !replaced.includes(entry));
 
-    const id = newId();
-    const thumb = await thumbnail(file);
+        const id = newId();
+        const thumb = await thumbnail(file);
 
-    await DataStore.set(fileKey(id), file, store);
-    await DataStore.set(thumbKey(id), thumb, store);
+        await DataStore.set(fileKey(id), file, store);
+        await DataStore.set(thumbKey(id), thumb, store);
 
-    const next = byRecency([{ id, name: file.name, type: file.type, kind, group, sig, added: Date.now(), from }, ...entries]);
-    const dropped = next.filter(entry => sameShelf(entry) && !entry.pinned).slice(limit);
+        const next = byRecency([{ id, name: file.name, type: file.type, kind, group, sig, added: Date.now(), from }, ...entries]);
+        const dropped = next.filter(entry => sameShelf(entry) && !entry.pinned).slice(limit);
 
-    await writeIndex(next.filter(entry => !dropped.includes(entry)));
-    for (const entry of [...dropped, ...replaced]) await forgetBlobs(entry.id);
+        await writeIndex(next.filter(entry => !dropped.includes(entry)));
+        for (const entry of [...dropped, ...replaced]) await forgetBlobs(entry.id);
 
-    return id;
+        return id;
+    });
 }
 
 async function forgetBlobs(id: string) {
@@ -124,100 +136,122 @@ async function forgetBlobs(id: string) {
     await DataStore.del(thumbKey(id), store);
 }
 
-export async function forget(id: string) {
-    await forgetBlobs(id);
-    await writeIndex((await readIndex()).filter(entry => entry.id !== id));
+export function forget(id: string) {
+    return queued(async () => {
+        await writeIndex((await readIndex()).filter(entry => entry.id !== id));
+        await forgetBlobs(id);
+    });
 }
 
 export async function exportAll() {
-    const entries = await readIndex();
-    const pictures = await Promise.all(entries.map(async entry => ({
-        ...entry,
-        file: await toDataUrl((await getFile(entry.id))!),
-        thumb: await toDataUrl((await getThumb(entry.id))!)
-    })));
+    const pictures: Array<Entry & { file: string; thumb: string; }> = [];
+
+    for (const entry of await readIndex()) {
+        const [file, thumb] = await Promise.all([getFile(entry.id), getThumb(entry.id)]);
+        if (!file || !thumb) continue;
+
+        pictures.push({ ...entry, file: await toDataUrl(file), thumb: await toDataUrl(thumb) });
+    }
 
     return JSON.stringify({ format: "BetterImageEditor", version: 1, pictures }, null, 4);
 }
 
-export async function importAll(json: string, limit: number) {
+export function importAll(json: string, limit: number) {
     const parsed = JSON.parse(json);
     if (parsed?.format !== "BetterImageEditor" || !Array.isArray(parsed.pictures)) {
         throw new Error("that file is not a picture library");
     }
 
-    const entries = await readIndex();
-    const seen = new Set(entries.map(entry => `${entry.kind}:${entry.group}:${entry.sig}`));
-    let added = 0;
+    return queued(async () => {
+        const entries = await readIndex();
+        const known = new Map(entries.map(entry => [`${entry.kind}:${entry.group}:${entry.sig}`, entry.id]));
+        const renamed = new Map<string, string>();
+        const imported: Entry[] = [];
 
-    for (const picture of parsed.pictures) {
-        const shelf = `${picture.kind}:${picture.group}:${picture.sig}`;
-        if (seen.has(shelf)) continue;
-        seen.add(shelf);
+        for (const picture of parsed.pictures) {
+            const shelf = `${picture.kind}:${picture.group}:${picture.sig}`;
+            const existing = known.get(shelf);
+            if (existing) {
+                renamed.set(picture.id, existing);
+                continue;
+            }
 
-        const { file, thumb, ...rest } = picture;
-        const id = newId();
+            const { file, thumb, ...rest } = picture;
+            const id = newId();
+            known.set(shelf, id);
+            renamed.set(picture.id, id);
 
-        await DataStore.set(fileKey(id), await fromDataUrl(file), store);
-        await DataStore.set(thumbKey(id), await fromDataUrl(thumb), store);
+            await DataStore.set(fileKey(id), await fromDataUrl(file), store);
+            await DataStore.set(thumbKey(id), await fromDataUrl(thumb), store);
 
-        entries.push({ ...rest, id });
-        added++;
-    }
-
-    entries.sort((a, b) => b.added - a.added);
-
-    const counts = new Map<string, number>();
-    const kept: Entry[] = [];
-    const dropped: Entry[] = [];
-
-    for (const entry of entries) {
-        if (entry.pinned) {
-            kept.push(entry);
-            continue;
+            imported.push({ ...rest, id });
         }
 
-        const shelf = `${entry.kind}:${entry.group}`;
-        const nth = (counts.get(shelf) ?? 0) + 1;
-        counts.set(shelf, nth);
-        (nth <= limit ? kept : dropped).push(entry);
-    }
+        for (const entry of imported) {
+            if (entry.from) entry.from = renamed.get(entry.from) ?? entry.from;
+        }
 
-    await writeIndex(kept);
-    for (const entry of dropped) await forgetBlobs(entry.id);
+        entries.push(...imported);
+        entries.sort((a, b) => b.added - a.added);
 
-    return added;
+        const counts = new Map<string, number>();
+        const kept: Entry[] = [];
+        const dropped: Entry[] = [];
+
+        for (const entry of entries) {
+            if (entry.pinned) {
+                kept.push(entry);
+                continue;
+            }
+
+            const shelf = `${entry.kind}:${entry.group}`;
+            const nth = (counts.get(shelf) ?? 0) + 1;
+            counts.set(shelf, nth);
+            (nth <= limit ? kept : dropped).push(entry);
+        }
+
+        await writeIndex(kept);
+        for (const entry of dropped) await forgetBlobs(entry.id);
+
+        return imported.length;
+    });
 }
 
-export async function forgetCrops() {
-    const entries = await readIndex();
-    const framed = entries.filter(entry => entry.crop);
+export function forgetCrops() {
+    return queued(async () => {
+        const entries = await readIndex();
+        const framed = entries.filter(entry => entry.crop);
 
-    for (const entry of framed) delete entry.crop;
-    await writeIndex(entries);
+        for (const entry of framed) delete entry.crop;
+        await writeIndex(entries);
 
-    return framed.length;
+        return framed.length;
+    });
 }
 
 export const byRecency = (entries: Entry[]) =>
     [...entries].sort((a, b) => (b.used ?? b.added) - (a.used ?? a.added));
 
-export async function touch(id: string) {
-    const entries = await readIndex();
-    const entry = entries.find(entry => entry.id === id);
-    if (!entry) return;
+export function touch(id: string) {
+    return queued(async () => {
+        const entries = await readIndex();
+        const entry = entries.find(entry => entry.id === id);
+        if (!entry) return;
 
-    entry.used = Date.now();
-    await writeIndex(byRecency(entries));
+        entry.used = Date.now();
+        await writeIndex(byRecency(entries));
+    });
 }
 
-export async function togglePin(id: string) {
-    const entries = await readIndex();
-    const entry = entries.find(entry => entry.id === id);
-    if (!entry) return;
+export function togglePin(id: string) {
+    return queued(async () => {
+        const entries = await readIndex();
+        const entry = entries.find(entry => entry.id === id);
+        if (!entry) return;
 
-    entry.pinned = !entry.pinned;
-    await writeIndex(entries);
+        entry.pinned = !entry.pinned;
+        await writeIndex(entries);
+    });
 }
 
 // recorded when Discord confirms the save, not when a picture is handed to the editor
@@ -238,11 +272,13 @@ export async function previousApplied(kind: Kind) {
 export const currentApplied = (kind: Kind) =>
     DataStore.get<string[]>(historyKey(kind), store).then(worn => worn?.[0] ?? null);
 
-export async function saveCrop(id: string, crop: CropState) {
-    const entries = await readIndex();
-    const entry = entries.find(entry => entry.id === id);
-    if (!entry) return;
+export function saveCrop(id: string, crop: CropState) {
+    return queued(async () => {
+        const entries = await readIndex();
+        const entry = entries.find(entry => entry.id === id);
+        if (!entry) return;
 
-    entry.crop = crop;
-    await writeIndex(entries);
+        entry.crop = crop;
+        await writeIndex(entries);
+    });
 }

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -174,22 +174,33 @@ export function importAll(json: string, limit: number) {
         const renamed = new Map<string, string>();
         const imported: Entry[] = [];
 
-        for (const { file, thumb, ...picture } of parsed.pictures) {
-            if (typeof picture.name !== "string" || typeof picture.added !== "number" || !isDataUrl(file) || !isDataUrl(thumb)) continue;
+        try {
+            for (const { file, thumb, ...picture } of parsed.pictures) {
+                if (typeof picture.id !== "string" || typeof picture.name !== "string" || typeof picture.kind !== "string"
+                    || typeof picture.sig !== "string" || typeof picture.added !== "number"
+                    || (picture.group !== "original" && picture.group !== "cropped")
+                    || !isDataUrl(file) || !isDataUrl(thumb)) continue;
 
-            const shelf = `${picture.kind}:${picture.group}:${picture.sig}`;
-            const existing = known.get(shelf);
-            if (existing) {
-                renamed.set(picture.id, existing);
-                continue;
+                const shelf = `${picture.kind}:${picture.group}:${picture.sig}`;
+                const existing = known.get(shelf);
+                if (existing) {
+                    renamed.set(picture.id, existing);
+                    continue;
+                }
+
+                const decoded = await Promise.all([fromDataUrl(file), fromDataUrl(thumb)]).catch(() => null);
+                if (!decoded) continue;
+
+                const id = nanoid();
+                known.set(shelf, id);
+                renamed.set(picture.id, id);
+                await DataStore.setMany([[fileKey(id), decoded[0]], [thumbKey(id), decoded[1]]], store);
+
+                imported.push({ ...picture, id });
             }
-
-            const id = nanoid();
-            known.set(shelf, id);
-            renamed.set(picture.id, id);
-            await DataStore.setMany([[fileKey(id), await fromDataUrl(file)], [thumbKey(id), await fromDataUrl(thumb)]], store);
-
-            imported.push({ ...picture, id });
+        } catch (err) {
+            await forgetBlobs(imported.map(entry => entry.id));
+            throw err;
         }
 
         const local = new Set(entries.map(entry => entry.id));
@@ -203,7 +214,7 @@ export function importAll(json: string, limit: number) {
         await writeIndex(kept);
         await forgetBlobs(dropped.map(entry => entry.id));
 
-        return imported.length;
+        return kept.filter(entry => imported.includes(entry)).length;
     });
 }
 

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -125,12 +125,13 @@ export function add(file: File, kind: Kind, group: Group, limit: number, from?: 
         const known = stored.find(entry => sameShelf(entry) && entry.sig === sig);
         if (known) return known;
 
-        const replaced = from ? stored.filter(entry => sameShelf(entry) && entry.from === from && !entry.pinned) : [];
+        const source = from ? stored.find(entry => entry.id === from)?.sig : undefined;
+        const replaced = source ? stored.filter(entry => sameShelf(entry) && entry.from === source && !entry.pinned) : [];
         const id = nanoid();
         const thumb = await thumbnail(file);
         await DataStore.setMany([[fileKey(id), file], [thumbKey(id), thumb]], store);
 
-        const entry: Entry = { id, name: file.name, type: file.type, kind, group, sig, added: Date.now(), from };
+        const entry: Entry = { id, name: file.name, type: file.type, kind, group, sig, added: Date.now(), from: source };
         const { kept, dropped } = trim([entry, ...stored.filter(other => !replaced.includes(other))], limit);
 
         await writeIndex(kept);
@@ -170,30 +171,24 @@ export function importAll(json: string, limit: number) {
 
     return queued(async () => {
         const entries = await readIndex();
-        const known = new Map(entries.map(entry => [`${entry.kind}:${entry.group}:${entry.sig}`, entry.id]));
-        const renamed = new Map<string, string>();
+        const known = new Set(entries.map(entry => `${entry.kind}:${entry.group}:${entry.sig}`));
         const imported: Entry[] = [];
 
         try {
             for (const { file, thumb, ...picture } of parsed.pictures) {
-                if (typeof picture.id !== "string" || typeof picture.name !== "string" || typeof picture.kind !== "string"
+                if (typeof picture.name !== "string" || typeof picture.kind !== "string"
                     || typeof picture.sig !== "string" || typeof picture.added !== "number"
                     || (picture.group !== "original" && picture.group !== "cropped")
                     || !isDataUrl(file) || !isDataUrl(thumb)) continue;
 
                 const shelf = `${picture.kind}:${picture.group}:${picture.sig}`;
-                const existing = known.get(shelf);
-                if (existing) {
-                    renamed.set(picture.id, existing);
-                    continue;
-                }
+                if (known.has(shelf)) continue;
 
                 const decoded = await Promise.all([fromDataUrl(file), fromDataUrl(thumb)]).catch(() => null);
                 if (!decoded) continue;
 
                 const id = nanoid();
-                known.set(shelf, id);
-                renamed.set(picture.id, id);
+                known.add(shelf);
                 await DataStore.setMany([[fileKey(id), decoded[0]], [thumbKey(id), decoded[1]]], store);
 
                 imported.push({ ...picture, id });
@@ -201,13 +196,6 @@ export function importAll(json: string, limit: number) {
         } catch (err) {
             await forgetBlobs(imported.map(entry => entry.id));
             throw err;
-        }
-
-        const local = new Set(entries.map(entry => entry.id));
-        const source = (from: string) => renamed.get(from) ?? (local.has(from) ? from : undefined);
-
-        for (const entry of imported) {
-            if (entry.from) entry.from = source(entry.from);
         }
 
         const { kept, dropped } = trim([...entries, ...imported], limit);

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -63,6 +63,7 @@ export const toDataUrl = (blob: Blob) => new Promise<string>((resolve, reject) =
 
 const fromDataUrl = (url: string) => fetch(url).then(r => r.blob());
 const isDataUrl = (value: unknown) => typeof value === "string" && value.startsWith("data:");
+const isSig = (value: unknown) => typeof value === "string" && /^\d+:[0-9a-f]{64}$/.test(value);
 
 async function signature(file: Blob) {
     const digest = await crypto.subtle.digest("SHA-256", await file.arrayBuffer());
@@ -194,7 +195,7 @@ export function importAll(json: string, limit: number) {
                 known.add(shelf);
                 await DataStore.setMany([[fileKey(id), decoded[0]], [thumbKey(id), decoded[1]]], store);
 
-                imported.push({ ...picture, id, from: sigById.get(picture.from) ?? picture.from });
+                imported.push({ ...picture, id, from: isSig(picture.from) ? picture.from : sigById.get(picture.from) });
             }
         } catch (err) {
             await forgetBlobs(imported.map(entry => entry.id));

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -5,14 +5,13 @@
  */
 
 import * as DataStore from "@api/DataStore";
+import { nanoid } from "nanoid";
 
 const store = DataStore.createStore("BetterImageEditor", "library");
 
-// Discord's uploadType, such as AVATAR or GUILD_BANNER
 export type Kind = string;
 export type Group = "original" | "cropped";
 
-// the cropper's initialTransform prop. offsetRatio is a fraction of the drag range, not pixels
 export interface CropState {
     zoomRatio: number;
     imageRotation: number;
@@ -39,16 +38,7 @@ const thumbKey = (id: string) => `thumb:${id}`;
 
 const THUMB_MAX = 160;
 
-// older entries lack a group, use lower-case kinds, or hold crops in pixels
-const LEGACY_KINDS: Record<string, string> = { avatar: "AVATAR", banner: "BANNER" };
-
-export const readIndex = () => DataStore.get<Entry[]>(INDEX, store)
-    .then(entries => (entries ?? []).map(({ crop, ...entry }) => ({
-        ...entry,
-        kind: LEGACY_KINDS[entry.kind] ?? entry.kind,
-        group: entry.group ?? "original" as Group,
-        ...(crop?.offsetRatio ? { crop } : {})
-    })));
+export const readIndex = () => DataStore.get<Entry[]>(INDEX, store).then(entries => entries ?? []);
 const writeIndex = (entries: Entry[]) => DataStore.set(INDEX, entries, store);
 
 let turn: Promise<unknown> = Promise.resolve();
@@ -72,8 +62,32 @@ export const toDataUrl = (blob: Blob) => new Promise<string>((resolve, reject) =
 });
 
 const fromDataUrl = (url: string) => fetch(url).then(r => r.blob());
+const isDataUrl = (value: unknown) => typeof value === "string" && value.startsWith("data:");
 
-const newId = () => `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+async function signature(file: Blob) {
+    const digest = await crypto.subtle.digest("SHA-256", await file.arrayBuffer());
+    return `${file.size}:${[...new Uint8Array(digest)].map(byte => byte.toString(16).padStart(2, "0")).join("")}`;
+}
+
+function trim(entries: Entry[], limit: number) {
+    const counts = new Map<string, number>();
+    const kept: Entry[] = [];
+    const dropped: Entry[] = [];
+
+    for (const entry of byRecency(entries)) {
+        if (entry.pinned) {
+            kept.push(entry);
+            continue;
+        }
+
+        const shelf = `${entry.kind}:${entry.group}`;
+        const nth = (counts.get(shelf) ?? 0) + 1;
+        counts.set(shelf, nth);
+        (nth <= limit ? kept : dropped).push(entry);
+    }
+
+    return { kept, dropped };
+}
 
 function thumbnail(source: Blob) {
     return new Promise<Blob>((resolve, reject) => {
@@ -104,42 +118,34 @@ function thumbnail(source: Blob) {
 
 export function add(file: File, kind: Kind, group: Group, limit: number, from?: string) {
     return queued(async () => {
-        const sig = `${file.name}:${file.size}:${file.lastModified}`;
+        const sig = await signature(file);
         const stored = await readIndex();
         const sameShelf = (entry: Entry) => entry.kind === kind && entry.group === group;
 
         const known = stored.find(entry => sameShelf(entry) && entry.sig === sig);
-        if (known) return known.id;
+        if (known) return known;
 
-        // one cropped copy per source, unless the old one is pinned
         const replaced = from ? stored.filter(entry => sameShelf(entry) && entry.from === from && !entry.pinned) : [];
-        const entries = stored.filter(entry => !replaced.includes(entry));
-
-        const id = newId();
+        const id = nanoid();
         const thumb = await thumbnail(file);
+        await DataStore.setMany([[fileKey(id), file], [thumbKey(id), thumb]], store);
 
-        await DataStore.set(fileKey(id), file, store);
-        await DataStore.set(thumbKey(id), thumb, store);
+        const entry: Entry = { id, name: file.name, type: file.type, kind, group, sig, added: Date.now(), from };
+        const { kept, dropped } = trim([entry, ...stored.filter(other => !replaced.includes(other))], limit);
 
-        const next = byRecency([{ id, name: file.name, type: file.type, kind, group, sig, added: Date.now(), from }, ...entries]);
-        const dropped = next.filter(entry => sameShelf(entry) && !entry.pinned).slice(limit);
+        await writeIndex(kept);
+        await forgetBlobs([...dropped, ...replaced].map(other => other.id));
 
-        await writeIndex(next.filter(entry => !dropped.includes(entry)));
-        for (const entry of [...dropped, ...replaced]) await forgetBlobs(entry.id);
-
-        return id;
+        return entry;
     });
 }
 
-async function forgetBlobs(id: string) {
-    await DataStore.del(fileKey(id), store);
-    await DataStore.del(thumbKey(id), store);
-}
+const forgetBlobs = (ids: string[]) => DataStore.delMany(ids.flatMap(id => [fileKey(id), thumbKey(id)]), store);
 
 export function forget(id: string) {
     return queued(async () => {
         await writeIndex((await readIndex()).filter(entry => entry.id !== id));
-        await forgetBlobs(id);
+        await forgetBlobs([id]);
     });
 }
 
@@ -168,7 +174,9 @@ export function importAll(json: string, limit: number) {
         const renamed = new Map<string, string>();
         const imported: Entry[] = [];
 
-        for (const picture of parsed.pictures) {
+        for (const { file, thumb, ...picture } of parsed.pictures) {
+            if (typeof picture.name !== "string" || typeof picture.added !== "number" || !isDataUrl(file) || !isDataUrl(thumb)) continue;
+
             const shelf = `${picture.kind}:${picture.group}:${picture.sig}`;
             const existing = known.get(shelf);
             if (existing) {
@@ -176,42 +184,21 @@ export function importAll(json: string, limit: number) {
                 continue;
             }
 
-            const { file, thumb, ...rest } = picture;
-            const id = newId();
+            const id = nanoid();
             known.set(shelf, id);
             renamed.set(picture.id, id);
+            await DataStore.setMany([[fileKey(id), await fromDataUrl(file)], [thumbKey(id), await fromDataUrl(thumb)]], store);
 
-            await DataStore.set(fileKey(id), await fromDataUrl(file), store);
-            await DataStore.set(thumbKey(id), await fromDataUrl(thumb), store);
-
-            imported.push({ ...rest, id });
+            imported.push({ ...picture, id });
         }
 
         for (const entry of imported) {
             if (entry.from) entry.from = renamed.get(entry.from) ?? entry.from;
         }
 
-        entries.push(...imported);
-        entries.sort((a, b) => b.added - a.added);
-
-        const counts = new Map<string, number>();
-        const kept: Entry[] = [];
-        const dropped: Entry[] = [];
-
-        for (const entry of entries) {
-            if (entry.pinned) {
-                kept.push(entry);
-                continue;
-            }
-
-            const shelf = `${entry.kind}:${entry.group}`;
-            const nth = (counts.get(shelf) ?? 0) + 1;
-            counts.set(shelf, nth);
-            (nth <= limit ? kept : dropped).push(entry);
-        }
-
+        const { kept, dropped } = trim([...entries, ...imported], limit);
         await writeIndex(kept);
-        for (const entry of dropped) await forgetBlobs(entry.id);
+        await forgetBlobs(dropped.map(entry => entry.id));
 
         return imported.length;
     });
@@ -254,23 +241,24 @@ export function togglePin(id: string) {
     });
 }
 
-// recorded when Discord confirms the save, not when a picture is handed to the editor
 const historyKey = (kind: Kind) => `history:${kind}`;
 
-export async function recordApplied(kind: Kind, id: string) {
-    const worn = await DataStore.get<string[]>(historyKey(kind), store) ?? [];
-    if (worn[0] === id) return;
+export function recordApplied(kind: Kind, id: string | null) {
+    return queued(async () => {
+        const worn = await DataStore.get<(string | null)[]>(historyKey(kind), store) ?? [];
+        if (worn[0] === id) return;
 
-    await DataStore.set(historyKey(kind), [id, ...worn.filter(seen => seen !== id)].slice(0, 5), store);
+        await DataStore.set(historyKey(kind), [id, ...worn.filter(seen => seen !== id)].slice(0, 5), store);
+    });
 }
 
 export async function previousApplied(kind: Kind) {
-    const worn = await DataStore.get<string[]>(historyKey(kind), store) ?? [];
+    const worn = await DataStore.get<(string | null)[]>(historyKey(kind), store) ?? [];
     return (await readIndex()).find(entry => entry.id === worn[1]) ?? null;
 }
 
 export const currentApplied = (kind: Kind) =>
-    DataStore.get<string[]>(historyKey(kind), store).then(worn => worn?.[0] ?? null);
+    DataStore.get<(string | null)[]>(historyKey(kind), store).then(worn => worn?.[0] ?? null);
 
 export function saveCrop(id: string, crop: CropState) {
     return queued(async () => {

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -192,8 +192,11 @@ export function importAll(json: string, limit: number) {
             imported.push({ ...picture, id });
         }
 
+        const local = new Set(entries.map(entry => entry.id));
+        const source = (from: string) => renamed.get(from) ?? (local.has(from) ? from : undefined);
+
         for (const entry of imported) {
-            if (entry.from) entry.from = renamed.get(entry.from) ?? entry.from;
+            if (entry.from) entry.from = source(entry.from);
         }
 
         const { kept, dropped } = trim([...entries, ...imported], limit);

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -126,7 +126,8 @@ export function add(file: File, kind: Kind, group: Group, limit: number, from?: 
         if (known) return known;
 
         const source = from ? stored.find(entry => entry.id === from)?.sig : undefined;
-        const replaced = source ? stored.filter(entry => sameShelf(entry) && entry.from === source && !entry.pinned) : [];
+        const cropOf = (entry: Entry) => entry.from === source || entry.from === from;
+        const replaced = source ? stored.filter(entry => sameShelf(entry) && cropOf(entry) && !entry.pinned) : [];
         const id = nanoid();
         const thumb = await thumbnail(file);
         await DataStore.setMany([[fileKey(id), file], [thumbKey(id), thumb]], store);
@@ -160,7 +161,7 @@ export async function exportAll() {
         pictures.push({ ...entry, file: await toDataUrl(file), thumb: await toDataUrl(thumb) });
     }
 
-    return JSON.stringify({ format: "BetterImageEditor", version: 1, pictures }, null, 4);
+    return JSON.stringify({ format: "BetterImageEditor", version: 2, pictures }, null, 4);
 }
 
 export function importAll(json: string, limit: number) {
@@ -168,6 +169,8 @@ export function importAll(json: string, limit: number) {
     if (parsed?.format !== "BetterImageEditor" || !Array.isArray(parsed.pictures)) {
         throw new Error("that file is not a picture library");
     }
+
+    const sigById = new Map<string, string>(parsed.pictures.map((picture: Entry) => [picture.id, picture.sig]));
 
     return queued(async () => {
         const entries = await readIndex();
@@ -191,7 +194,7 @@ export function importAll(json: string, limit: number) {
                 known.add(shelf);
                 await DataStore.setMany([[fileKey(id), decoded[0]], [thumbKey(id), decoded[1]]], store);
 
-                imported.push({ ...picture, id });
+                imported.push({ ...picture, id, from: sigById.get(picture.from) ?? picture.from });
             }
         } catch (err) {
             await forgetBlobs(imported.map(entry => entry.id));

--- a/src/equicordplugins/betterImageEditor/library.ts
+++ b/src/equicordplugins/betterImageEditor/library.ts
@@ -1,0 +1,255 @@
+/*
+ * Vencord, a Discord client mod
+ * Copyright (c) 2026 Vendicated and contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+import * as DataStore from "@api/DataStore";
+
+const store = DataStore.createStore("BetterImageEditor", "library");
+
+// Discord's own uploadType: AVATAR, BANNER, GUILD_ICON, GUILD_BANNER and the rest
+export type Kind = string;
+export type Group = "original" | "cropped";
+
+// the shape of the cropper's own initialTransform prop. offsetRatio is a fraction of the
+// drag range rather than pixels, so it replays at any image size.
+export interface CropState {
+    zoomRatio: number;
+    imageRotation: number;
+    offsetRatio: { x: number; y: number; };
+}
+
+export interface Entry {
+    id: string;
+    name: string;
+    type?: string;
+    kind: Kind;
+    group: Group;
+    sig: string;
+    added: number;
+    crop?: CropState;
+    pinned?: boolean;
+    used?: number;
+    from?: string;
+}
+
+const INDEX = "index";
+const fileKey = (id: string) => `file:${id}`;
+const thumbKey = (id: string) => `thumb:${id}`;
+
+const THUMB_MAX = 160;
+
+// entries predating the cropped shelf carry no group and are all originals; ones predating
+// the wider upload types are named in lower case. crops kept in pixels cannot be replayed.
+const LEGACY_KINDS: Record<string, string> = { avatar: "AVATAR", banner: "BANNER" };
+
+export const readIndex = () => DataStore.get<Entry[]>(INDEX, store)
+    .then(entries => (entries ?? []).map(({ crop, ...entry }) => ({
+        ...entry,
+        kind: LEGACY_KINDS[entry.kind] ?? entry.kind,
+        group: entry.group ?? "original" as Group,
+        ...(crop?.offsetRatio ? { crop } : {})
+    })));
+const writeIndex = (entries: Entry[]) => DataStore.set(INDEX, entries, store);
+
+export const getFile = (id: string) => DataStore.get<Blob>(fileKey(id), store);
+export const getThumb = (id: string) => DataStore.get<Blob>(thumbKey(id), store);
+export const getThumbs = (ids: string[]) => DataStore.getMany<Blob>(ids.map(thumbKey), store);
+export const clear = () => DataStore.clear(store);
+
+export const toDataUrl = (blob: Blob) => new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+});
+
+const fromDataUrl = (url: string) => fetch(url).then(r => r.blob());
+
+const newId = () => `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+
+// keeps the source aspect so the strip can crop it to a circle or a wide tile in CSS
+function thumbnail(source: Blob) {
+    return new Promise<Blob>((resolve, reject) => {
+        const url = URL.createObjectURL(source);
+        const image = new Image();
+
+        image.onload = () => {
+            URL.revokeObjectURL(url);
+
+            const scale = Math.min(1, THUMB_MAX / Math.max(image.width, image.height));
+            const canvas = document.createElement("canvas");
+            canvas.width = Math.round(image.width * scale);
+            canvas.height = Math.round(image.height * scale);
+            canvas.getContext("2d")!.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+            canvas.toBlob(blob => blob ? resolve(blob) : reject(new Error("could not draw a thumbnail")), "image/webp", 0.8);
+        };
+        image.onerror = () => {
+            URL.revokeObjectURL(url);
+            reject(new Error("could not decode that image"));
+        };
+
+        image.src = url;
+    });
+}
+
+export async function add(file: File, kind: Kind, group: Group, limit: number, from?: string) {
+    const sig = `${file.name}:${file.size}:${file.lastModified}`;
+    const stored = await readIndex();
+    const sameShelf = (entry: Entry) => entry.kind === kind && entry.group === group;
+
+    const known = stored.find(entry => sameShelf(entry) && entry.sig === sig);
+    if (known) return known.id;
+
+    // one cropped copy per source picture. a pinned copy is kept, since pinning is what you
+    // do to a framing you want back later.
+    const replaced = from ? stored.filter(entry => sameShelf(entry) && entry.from === from && !entry.pinned) : [];
+    const entries = stored.filter(entry => !replaced.includes(entry));
+
+    const id = newId();
+    const thumb = await thumbnail(file);
+
+    await DataStore.set(fileKey(id), file, store);
+    await DataStore.set(thumbKey(id), thumb, store);
+
+    const next = byRecency([{ id, name: file.name, type: file.type, kind, group, sig, added: Date.now(), from }, ...entries]);
+    const dropped = next.filter(entry => sameShelf(entry) && !entry.pinned).slice(limit);
+
+    await writeIndex(next.filter(entry => !dropped.includes(entry)));
+    for (const entry of [...dropped, ...replaced]) await forgetBlobs(entry.id);
+
+    return id;
+}
+
+async function forgetBlobs(id: string) {
+    await DataStore.del(fileKey(id), store);
+    await DataStore.del(thumbKey(id), store);
+}
+
+export async function forget(id: string) {
+    await forgetBlobs(id);
+    await writeIndex((await readIndex()).filter(entry => entry.id !== id));
+}
+
+export async function exportAll() {
+    const entries = await readIndex();
+    const pictures = await Promise.all(entries.map(async entry => ({
+        ...entry,
+        file: await toDataUrl((await getFile(entry.id))!),
+        thumb: await toDataUrl((await getThumb(entry.id))!)
+    })));
+
+    return JSON.stringify({ format: "BetterImageEditor", version: 1, pictures }, null, 4);
+}
+
+export async function importAll(json: string, limit: number) {
+    const parsed = JSON.parse(json);
+    if (parsed?.format !== "BetterImageEditor" || !Array.isArray(parsed.pictures)) {
+        throw new Error("that file is not a picture library");
+    }
+
+    const entries = await readIndex();
+    const seen = new Set(entries.map(entry => `${entry.kind}:${entry.group}:${entry.sig}`));
+    let added = 0;
+
+    for (const picture of parsed.pictures) {
+        const shelf = `${picture.kind}:${picture.group}:${picture.sig}`;
+        if (seen.has(shelf)) continue;
+        seen.add(shelf);
+
+        const { file, thumb, ...rest } = picture;
+        const id = newId();
+
+        await DataStore.set(fileKey(id), await fromDataUrl(file), store);
+        await DataStore.set(thumbKey(id), await fromDataUrl(thumb), store);
+
+        entries.push({ ...rest, id });
+        added++;
+    }
+
+    // same rule add() uses: newest kept, oldest off the end of each shelf
+    entries.sort((a, b) => b.added - a.added);
+
+    const counts = new Map<string, number>();
+    const kept: Entry[] = [];
+    const dropped: Entry[] = [];
+
+    for (const entry of entries) {
+        if (entry.pinned) {
+            kept.push(entry);
+            continue;
+        }
+
+        const shelf = `${entry.kind}:${entry.group}`;
+        const nth = (counts.get(shelf) ?? 0) + 1;
+        counts.set(shelf, nth);
+        (nth <= limit ? kept : dropped).push(entry);
+    }
+
+    await writeIndex(kept);
+    for (const entry of dropped) await forgetBlobs(entry.id);
+
+    return added;
+}
+
+export async function forgetCrops() {
+    const entries = await readIndex();
+    const framed = entries.filter(entry => entry.crop);
+
+    for (const entry of framed) delete entry.crop;
+    await writeIndex(entries);
+
+    return framed.length;
+}
+
+// the shelf is most-recently-used: picking a picture sends it to the front
+export const byRecency = (entries: Entry[]) =>
+    [...entries].sort((a, b) => (b.used ?? b.added) - (a.used ?? a.added));
+
+export async function touch(id: string) {
+    const entries = await readIndex();
+    const entry = entries.find(entry => entry.id === id);
+    if (!entry) return;
+
+    entry.used = Date.now();
+    await writeIndex(byRecency(entries));
+}
+
+export async function togglePin(id: string) {
+    const entries = await readIndex();
+    const entry = entries.find(entry => entry.id === id);
+    if (!entry) return;
+
+    entry.pinned = !entry.pinned;
+    await writeIndex(entries);
+}
+
+// which pictures you have actually worn, newest first. recorded when Discord confirms the
+// profile saved, not when one is handed to the editor.
+const historyKey = (kind: Kind) => `history:${kind}`;
+
+export async function recordApplied(kind: Kind, id: string) {
+    const worn = await DataStore.get<string[]>(historyKey(kind), store) ?? [];
+    if (worn[0] === id) return;
+
+    await DataStore.set(historyKey(kind), [id, ...worn.filter(seen => seen !== id)].slice(0, 5), store);
+}
+
+export async function previousApplied(kind: Kind) {
+    const worn = await DataStore.get<string[]>(historyKey(kind), store) ?? [];
+    return (await readIndex()).find(entry => entry.id === worn[1]) ?? null;
+}
+
+export const currentApplied = (kind: Kind) =>
+    DataStore.get<string[]>(historyKey(kind), store).then(worn => worn?.[0] ?? null);
+
+export async function saveCrop(id: string, crop: CropState) {
+    const entries = await readIndex();
+    const entry = entries.find(entry => entry.id === id);
+    if (!entry) return;
+
+    entry.crop = crop;
+    await writeIndex(entries);
+}

--- a/src/equicordplugins/betterImageEditor/style.css
+++ b/src/equicordplugins/betterImageEditor/style.css
@@ -1,14 +1,14 @@
-.bie-panel {
+.vc-bie-panel {
     padding-top: 8px;
 }
 
-.bie-tabs {
+.vc-bie-tabs {
     display: flex;
     align-items: center;
     gap: 4px;
 }
 
-.bie-tab {
+.vc-bie-tab {
     padding: 4px 10px;
     border: none;
     border-radius: 4px;
@@ -20,22 +20,22 @@
     transition: background-color .1s ease-out, color .1s ease-out;
 }
 
-.bie-tab:focus-visible {
+.vc-bie-tab:focus-visible {
     outline: 2px solid var(--focus-primary);
 }
 
-.bie-tab:hover:not(.bie-on) {
+.vc-bie-tab:hover:not(.vc-bie-on) {
     background: var(--background-modifier-hover);
     color: var(--interactive-hover);
 }
 
 /* literal white on purpose: themes redefine --white to near black */
-.bie-tab.bie-on {
+.vc-bie-tab.vc-bie-on {
     background: var(--brand-500, #5865f2);
     color: #fff;
 }
 
-.bie-action {
+.vc-bie-action {
     padding: 4px 10px;
     border: none;
     border-radius: 4px;
@@ -45,26 +45,26 @@
     cursor: pointer;
 }
 
-.bie-action:hover {
+.vc-bie-action:hover {
     background: var(--background-modifier-hover);
     color: var(--interactive-hover);
 }
 
-.bie-action:focus-visible {
+.vc-bie-action:focus-visible {
     outline: 2px solid var(--focus-primary);
 }
 
 /* pushes the first action right; later ones sit beside it */
-.bie-tab + .bie-action {
+.vc-bie-tab + .vc-bie-action {
     margin-left: auto;
 }
 
-.bie-empty {
+.vc-bie-empty {
     color: var(--text-muted);
     font-size: 12px;
 }
 
-.bie-strip {
+.vc-bie-strip {
     display: flex;
     align-items: center;
     flex-wrap: nowrap;
@@ -74,34 +74,34 @@
     overflow: auto hidden;
 }
 
-.bie-wide .bie-strip {
+.vc-bie-wide .vc-bie-strip {
     gap: 8px;
 }
 
-.bie-strip::-webkit-scrollbar {
+.vc-bie-strip::-webkit-scrollbar {
     height: 6px;
 }
 
-.bie-strip::-webkit-scrollbar-track {
+.vc-bie-strip::-webkit-scrollbar-track {
     background: transparent;
 }
 
-.bie-strip::-webkit-scrollbar-thumb {
+.vc-bie-strip::-webkit-scrollbar-thumb {
     background: transparent;
     border-radius: 3px;
 }
 
-.bie-strip:hover::-webkit-scrollbar-thumb {
+.vc-bie-strip:hover::-webkit-scrollbar-thumb {
     background: var(--background-modifier-accent);
 }
 
-.bie-item {
+.vc-bie-item {
     position: relative;
     flex: 0 0 auto;
     line-height: 0;
 }
 
-.bie-thumb {
+.vc-bie-thumb {
     width: 44px;
     height: 44px;
     border-radius: 50%;
@@ -114,31 +114,31 @@
     transition: border-color .1s ease-out, transform .1s ease-out;
 }
 
-.bie-thumb:focus-visible {
+.vc-bie-thumb:focus-visible {
     outline: 2px solid var(--focus-primary);
     outline-offset: 2px;
 }
 
-.bie-thumb.bie-active {
+.vc-bie-thumb.vc-bie-active {
     border-color: var(--brand-500, #5865f2);
 }
 
-.bie-wide .bie-thumb {
+.vc-bie-wide .vc-bie-thumb {
     width: 96px;
     height: 40px;
     border-radius: 6px;
 }
 
-.bie-worn .bie-thumb {
+.vc-bie-worn .vc-bie-thumb {
     box-shadow: 0 0 0 2px var(--status-positive, #23a55a);
 }
 
-.bie-item:hover .bie-thumb {
+.vc-bie-item:hover .vc-bie-thumb {
     transform: scale(1.06);
 }
 
-.bie-remove,
-.bie-pin {
+.vc-bie-remove,
+.vc-bie-pin {
     position: absolute;
     top: -2px;
     width: 16px;
@@ -153,39 +153,39 @@
     cursor: pointer;
 }
 
-.bie-remove {
+.vc-bie-remove {
     right: -2px;
 }
 
-.bie-pin {
+.vc-bie-pin {
     left: -2px;
 }
 
-.bie-remove:hover {
+.vc-bie-remove:hover {
     color: var(--status-danger);
 }
 
-.bie-pin:hover {
+.vc-bie-pin:hover {
     color: var(--interactive-active);
 }
 
-.bie-remove:focus-visible,
-.bie-pin:focus-visible {
+.vc-bie-remove:focus-visible,
+.vc-bie-pin:focus-visible {
     outline: 2px solid var(--focus-primary);
 }
 
-.bie-pin.bie-on {
+.vc-bie-pin.vc-bie-on {
     color: var(--brand-500, #5865f2);
 }
 
-.bie-item:hover .bie-remove,
-.bie-item:focus-within .bie-remove,
-.bie-item:hover .bie-pin,
-.bie-item:focus-within .bie-pin {
+.vc-bie-item:hover .vc-bie-remove,
+.vc-bie-item:focus-within .vc-bie-remove,
+.vc-bie-item:hover .vc-bie-pin,
+.vc-bie-item:focus-within .vc-bie-pin {
     display: grid;
 }
 
-.bie-pinned::before {
+.vc-bie-pinned::before {
     content: "";
     position: absolute;
     top: 1px;
@@ -197,23 +197,23 @@
     pointer-events: none;
 }
 
-.bie-pinned:hover::before,
-.bie-pinned:focus-within::before {
+.vc-bie-pinned:hover::before,
+.vc-bie-pinned:focus-within::before {
     display: none;
 }
 
-.bie-buttons {
+.vc-bie-buttons {
     display: flex;
     gap: 8px;
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .bie-tab,
-    .bie-thumb {
+    .vc-bie-tab,
+    .vc-bie-thumb {
         transition: none;
     }
 
-    .bie-item:hover .bie-thumb {
+    .vc-bie-item:hover .vc-bie-thumb {
         transform: none;
     }
 }

--- a/src/equicordplugins/betterImageEditor/style.css
+++ b/src/equicordplugins/betterImageEditor/style.css
@@ -29,7 +29,6 @@
     color: var(--interactive-hover);
 }
 
-/* literal white on purpose: themes redefine --white to near black */
 .vc-bie-tab.vc-bie-on {
     background: var(--brand-500, #5865f2);
     color: #fff;
@@ -54,7 +53,6 @@
     outline: 2px solid var(--focus-primary);
 }
 
-/* pushes the first action right; later ones sit beside it */
 .vc-bie-tab + .vc-bie-action {
     margin-left: auto;
 }

--- a/src/equicordplugins/betterImageEditor/style.css
+++ b/src/equicordplugins/betterImageEditor/style.css
@@ -54,7 +54,7 @@
     outline: 2px solid var(--focus-primary);
 }
 
-/* only the action that follows the tabs gets pushed right; later ones sit beside it */
+/* pushes the first action right; later ones sit beside it */
 .bie-tab + .bie-action {
     margin-left: auto;
 }
@@ -78,7 +78,6 @@
     gap: 8px;
 }
 
-/* the bar keeps its space so nothing shifts, and only shows itself on hover */
 .bie-strip::-webkit-scrollbar {
     height: 6px;
 }

--- a/src/equicordplugins/betterImageEditor/style.css
+++ b/src/equicordplugins/betterImageEditor/style.css
@@ -1,0 +1,220 @@
+.bie-panel {
+    padding-top: 8px;
+}
+
+.bie-tabs {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.bie-tab {
+    padding: 4px 10px;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--interactive-normal);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color .1s ease-out, color .1s ease-out;
+}
+
+.bie-tab:focus-visible {
+    outline: 2px solid var(--focus-primary);
+}
+
+.bie-tab:hover:not(.bie-on) {
+    background: var(--background-modifier-hover);
+    color: var(--interactive-hover);
+}
+
+/* literal white on purpose: themes redefine --white to near black */
+.bie-tab.bie-on {
+    background: var(--brand-500, #5865f2);
+    color: #fff;
+}
+
+.bie-action {
+    padding: 4px 10px;
+    border: none;
+    border-radius: 4px;
+    background: none;
+    color: var(--text-muted);
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.bie-action:hover {
+    background: var(--background-modifier-hover);
+    color: var(--interactive-hover);
+}
+
+.bie-action:focus-visible {
+    outline: 2px solid var(--focus-primary);
+}
+
+/* only the action that follows the tabs gets pushed right; later ones sit beside it */
+.bie-tab + .bie-action {
+    margin-left: auto;
+}
+
+.bie-empty {
+    color: var(--text-muted);
+    font-size: 12px;
+}
+
+.bie-strip {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 6px;
+    padding: 8px 4px 6px;
+    min-height: 38px;
+    overflow: auto hidden;
+}
+
+.bie-wide .bie-strip {
+    gap: 8px;
+}
+
+/* the bar keeps its space so nothing shifts, and only shows itself on hover */
+.bie-strip::-webkit-scrollbar {
+    height: 6px;
+}
+
+.bie-strip::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.bie-strip::-webkit-scrollbar-thumb {
+    background: transparent;
+    border-radius: 3px;
+}
+
+.bie-strip:hover::-webkit-scrollbar-thumb {
+    background: var(--background-modifier-accent);
+}
+
+.bie-item {
+    position: relative;
+    flex: 0 0 auto;
+    line-height: 0;
+}
+
+.bie-thumb {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    padding: 0;
+    border: 2px solid transparent;
+    background: var(--background-modifier-hover);
+    background-size: cover;
+    background-position: center;
+    cursor: pointer;
+    transition: border-color .1s ease-out, transform .1s ease-out;
+}
+
+.bie-thumb:focus-visible {
+    outline: 2px solid var(--focus-primary);
+    outline-offset: 2px;
+}
+
+.bie-thumb.bie-active {
+    border-color: var(--brand-500, #5865f2);
+}
+
+.bie-wide .bie-thumb {
+    width: 96px;
+    height: 40px;
+    border-radius: 6px;
+}
+
+.bie-worn .bie-thumb {
+    box-shadow: 0 0 0 2px var(--status-positive, #23a55a);
+}
+
+.bie-item:hover .bie-thumb {
+    transform: scale(1.06);
+}
+
+.bie-remove,
+.bie-pin {
+    position: absolute;
+    top: -2px;
+    width: 16px;
+    height: 16px;
+    padding: 0;
+    display: none;
+    place-items: center;
+    border: none;
+    border-radius: 50%;
+    background: var(--background-tertiary);
+    color: var(--interactive-normal);
+    cursor: pointer;
+}
+
+.bie-remove {
+    right: -2px;
+}
+
+.bie-pin {
+    left: -2px;
+}
+
+.bie-remove:hover {
+    color: var(--status-danger);
+}
+
+.bie-pin:hover {
+    color: var(--interactive-active);
+}
+
+.bie-remove:focus-visible,
+.bie-pin:focus-visible {
+    outline: 2px solid var(--focus-primary);
+}
+
+.bie-pin.bie-on {
+    color: var(--brand-500, #5865f2);
+}
+
+.bie-item:hover .bie-remove,
+.bie-item:focus-within .bie-remove,
+.bie-item:hover .bie-pin,
+.bie-item:focus-within .bie-pin {
+    display: grid;
+}
+
+.bie-pinned::before {
+    content: "";
+    position: absolute;
+    top: 1px;
+    left: 1px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--brand-500, #5865f2);
+    pointer-events: none;
+}
+
+.bie-pinned:hover::before,
+.bie-pinned:focus-within::before {
+    display: none;
+}
+
+.bie-buttons {
+    display: flex;
+    gap: 8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .bie-tab,
+    .bie-thumb {
+        transition: none;
+    }
+
+    .bie-item:hover .bie-thumb {
+        transform: none;
+    }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -697,6 +697,10 @@ export const EquicordDevs = Object.freeze({
         name: "nobody",
         id: 0n
     },
+    heart_menace: {
+        name: "heart_menace",
+        id: 281162701303185408n
+    },
     thororen: {
         name: "thororen",
         id: 848339671629299742n


### PR DESCRIPTION
## Describe your Changes

BetterImagesEditor plugin is a plugin that is giving you a much bigger limit of your recent avatars,  banners etc. (With up to 50 pictures)  and a couple of other functionalities, like, for example, pinning your avatars and others so those will not go away,  keeping the uncropped version of this avatar if, by any chance, you did a wrong crop and you still want to change something, while also having a separate tab for the cropped versions. Having an option to remove the avatars, just like in the recent avatars Discord implemented. The plugin also gives you the option to have your banners saved, your server images, server banners, etc., saved. Of course, there’s also functionality to import and export your saved uncropped and cropped pictures and banners, so you can transfer them if, by any chance, you switch devices or reinstall Discord for some other reason. 

## Screenshots (if applicable)

<img width="323" height="273" alt="file-7e64d406681b22975fd164ee1537468c" src="https://github.com/user-attachments/assets/a16a4a1d-04b9-40c9-9c6f-6fdd0eb1947e" />
<img width="363" height="467" alt="image" src="https://github.com/user-attachments/assets/00fae8f4-bd8a-4e55-9b10-318bd0872e70" />
<img width="341" height="476" alt="image" src="https://github.com/user-attachments/assets/0e7e6684-fe7e-4ceb-ae63-098041425be0" />
<img width="334" height="287" alt="image" src="https://github.com/user-attachments/assets/bb232c59-9022-4565-8b38-f499550d0013" />
<img width="332" height="460" alt="image" src="https://github.com/user-attachments/assets/1db504a4-0b75-4dea-9af4-6d36a0fc8372" />


## Checklist before submitting
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [x] This pull request was written by me, and not an AI agent
