### PR TITLE
SMYN: Show and match custom names in the from: and mentions: search filters

### DIFF
--- a/src/plugins/showMeYourName/index.tsx
+++ b/src/plugins/showMeYourName/index.tsx
@@ -42,6 +42,11 @@ interface UserNameWithEffectsProps {
     shouldWrap?: boolean;
 }
 
+interface SearchUserResult {
+    text: string;
+    user: User;
+}
+
 const UserNameWithEffects = findComponentByCodeLazy<UserNameWithEffectsProps>(
     "UserNameWithEffects",
     "--custom-display-name-styles-prism-cycle"
@@ -1264,13 +1269,8 @@ function matchableCustomName(userId: string) {
     return custom.toLocaleLowerCase();
 }
 
-interface SearchUserResult {
-    text: string;
-    user: User;
-}
-
 function addCustomNameResults(results: SearchUserResult[], props: { currentToken?: { getFullMatch(): string | undefined; } | null; }) {
-    const query = props.currentToken?.getFullMatch()?.trim().toLocaleLowerCase();
+    const query = props.currentToken?.getFullMatch()?.trim()?.toLocaleLowerCase();
     if (!query) return results;
 
     const guildId = getCurrentChannel()?.guild_id;

--- a/src/plugins/showMeYourName/index.tsx
+++ b/src/plugins/showMeYourName/index.tsx
@@ -21,7 +21,7 @@ import { classNameFactory } from "@utils/index";
 import definePlugin, { OptionType } from "@utils/types";
 import { GuildMember, Message, RenderModalProps, User } from "@vencord/discord-types";
 import { findByCodeLazy, findByPropsLazy, findComponentByCodeLazy } from "@webpack";
-import { AccessibilityStore, ChannelStore, GuildMemberStore, GuildStore, Menu, MessageStore, Modal, openModal, RelationshipStore, StreamerModeStore, TextInput, useEffect, UserStore, useState } from "@webpack/common";
+import { AccessibilityStore, ChannelStore, GuildMemberStore, GuildStore, Menu, MessageStore, Modal, openModal, RelationshipStore, StreamerModeStore, TextInput, useEffect, UsernameUtils, UserStore, useState } from "@webpack/common";
 import { JSX } from "react";
 
 const SMYNC = classNameFactory();
@@ -1264,6 +1264,27 @@ function matchableCustomName(userId: string) {
     return custom.toLocaleLowerCase();
 }
 
+interface SearchUserResult {
+    text: string;
+    user: User;
+}
+
+function addCustomNameResults(results: SearchUserResult[], props: { currentToken?: { getFullMatch(): string; } | null; }) {
+    const query = props.currentToken?.getFullMatch()?.trim().toLocaleLowerCase();
+    if (!query) return results;
+
+    const guildId = getCurrentChannel()?.guild_id;
+    const extra: SearchUserResult[] = [];
+    for (const id in customNicknames) {
+        if (!matchableCustomName(id).includes(query)) continue;
+        if (guildId && !GuildMemberStore.getMember(guildId, id)) continue;
+        if (results.some(r => r.user?.id === id)) continue;
+        const user = UserStore.getUser(id);
+        if (user) extra.push({ text: UsernameUtils.getUserTag(user), user });
+    }
+    return extra.length ? [...results, ...extra] : results;
+}
+
 export default definePlugin({
     name: "ShowMeYourName",
     description: "Display any permutation of custom nicknames, friend nicknames, server nicknames, display names, and usernames in chat.",
@@ -1513,6 +1534,14 @@ export default definePlugin({
             }
         },
         {
+            // Add custom name matches to the server side results behind the from: and mentions: filters.
+            find: '="SearchAutocompleteStore"',
+            replacement: {
+                match: /(?<=&&!\i\)\i=)\i\(\i\)\.results/,
+                replace: "$self.addCustomNameResults($&,arguments[0])"
+            }
+        },
+        {
             // Replace names in the from: and mentions: search filter suggestions.
             find: "hasOtherSearchFiltersVisible",
             replacement: {
@@ -1589,5 +1618,6 @@ export default definePlugin({
     getTypingMemberListProfilesReactionsVoiceNameText,
     getTypingMemberListProfilesReactionsVoiceNameElement,
     getSearchFilterName,
-    matchableCustomName
+    matchableCustomName,
+    addCustomNameResults
 });

--- a/src/plugins/showMeYourName/index.tsx
+++ b/src/plugins/showMeYourName/index.tsx
@@ -1269,16 +1269,18 @@ interface SearchUserResult {
     user: User;
 }
 
-function addCustomNameResults(results: SearchUserResult[], props: { currentToken?: { getFullMatch(): string; } | null; }) {
+function addCustomNameResults(results: SearchUserResult[], props: { currentToken?: { getFullMatch(): string | undefined; } | null; }) {
     const query = props.currentToken?.getFullMatch()?.trim().toLocaleLowerCase();
     if (!query) return results;
 
     const guildId = getCurrentChannel()?.guild_id;
+    if (!guildId) return results;
+
     const extra: SearchUserResult[] = [];
     for (const id in customNicknames) {
         if (!matchableCustomName(id).includes(query)) continue;
-        if (guildId && !GuildMemberStore.getMember(guildId, id)) continue;
-        if (results.some(r => r.user?.id === id)) continue;
+        if (!GuildMemberStore.getMember(guildId, id)) continue;
+        if (results.some(r => r.user.id === id)) continue;
         const user = UserStore.getUser(id);
         if (user) extra.push({ text: UsernameUtils.getUserTag(user), user });
     }

--- a/src/plugins/showMeYourName/index.tsx
+++ b/src/plugins/showMeYourName/index.tsx
@@ -352,7 +352,7 @@ interface messageProps {
 
 interface memberListProfileReactionProps {
     user: User | null | undefined;
-    type: "typingIndicator" | "membersList" | "profilesPopout" | "profilesTooltip" | "reactionsTooltip" | "reactionsPopout" | "voiceChannel";
+    type: "typingIndicator" | "membersList" | "profilesPopout" | "profilesTooltip" | "reactionsTooltip" | "reactionsPopout" | "voiceChannel" | "searchFilter";
     guildId?: string;
     tags?: any;
     isHovered?: boolean;
@@ -375,7 +375,7 @@ function getTypingMemberListProfilesReactionsVoiceName(
     const guildId = props.guildId || props.tags?.props?.displayProfile?.guildId || null;
     const member = guildId && user ? GuildMemberStore.getMember(guildId, user.id) : null;
     const author = user && member ? { ...user, ...member } : user || member || null;
-    const shouldHookless = ["typingIndicator", "reactionsTooltip", "profilesTooltip"].includes(type);
+    const shouldHookless = ["typingIndicator", "reactionsTooltip", "profilesTooltip", "searchFilter"].includes(type);
     return renderUsername(author, null, null, type, "", shouldHookless, !!guildId, undefined, undefined, props.isHovered);
 }
 
@@ -385,6 +385,10 @@ function getTypingMemberListProfilesReactionsVoiceNameText(props: memberListProf
 
 function getTypingMemberListProfilesReactionsVoiceNameElement(props: memberListProfileReactionProps): JSX.Element | null {
     return getTypingMemberListProfilesReactionsVoiceName(props)[1];
+}
+
+function getSearchFilterName(props: { user: User; guildId: string | null; }, fallback: string): string {
+    return getTypingMemberListProfilesReactionsVoiceNameText({ user: props.user, guildId: props.guildId ?? undefined, type: "searchFilter" }) ?? fallback;
 }
 
 function getActiveNowNameElement({ user, guildId, isHovered }: activeNowNameProps): JSX.Element | string | null {
@@ -576,7 +580,7 @@ function renderUsername(
     author: User | GuildMember | null,
     channelId: string | null,
     messageId: string | null,
-    type: "messages" | "replies" | "typingIndicator" | "mentions" | "membersList" | "profilesPopout" | "profilesTooltip" | "reactionsTooltip" | "reactionsPopout" | "voiceChannel",
+    type: "messages" | "replies" | "typingIndicator" | "mentions" | "membersList" | "profilesPopout" | "profilesTooltip" | "reactionsTooltip" | "reactionsPopout" | "voiceChannel" | "searchFilter",
     mentionSymbol: string,
     hookless: boolean,
     inGuild: boolean,
@@ -1509,6 +1513,14 @@ export default definePlugin({
             }
         },
         {
+            // Replace names in the from: and mentions: search filter suggestions.
+            find: "hasOtherSearchFiltersVisible",
+            replacement: {
+                match: /(\i)=(\i\.\i\.useName\((\i),\i,(\i)\))/,
+                replace: "$1=$self.getSearchFilterName({user:$4,guildId:$3},$2)"
+            }
+        },
+        {
             // Let the mention autocomplete match custom names too.
             find: "queryGuildMentionResults(",
             group: true,
@@ -1576,5 +1588,6 @@ export default definePlugin({
     shouldAnimateNameEffects,
     getTypingMemberListProfilesReactionsVoiceNameText,
     getTypingMemberListProfilesReactionsVoiceNameElement,
+    getSearchFilterName,
     matchableCustomName
 });

--- a/src/plugins/showMeYourName/index.tsx
+++ b/src/plugins/showMeYourName/index.tsx
@@ -1290,7 +1290,7 @@ function addCustomNameResults(results: SearchUserResult[], props: { currentToken
 export default definePlugin({
     name: "ShowMeYourName",
     description: "Display any permutation of custom nicknames, friend nicknames, server nicknames, display names, and usernames in chat.",
-    authors: [EquicordDevs.Etorix, Devs.Rini, Devs.TheKodeToad, Devs.sadan, Devs.prism],
+    authors: [EquicordDevs.Etorix, Devs.Rini, Devs.TheKodeToad, Devs.sadan, Devs.prism, EquicordDevs.penguinwokrs],
     tags: ["Appearance", "Customisation"],
     searchTerms: ["SMYN", "Nicknames", "Custom Nicknames"],
     isModified: true,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1430,6 +1430,10 @@ export const EquicordDevs = Object.freeze({
         name: "ELJoOker",
         id: 605894319408283678n
     },
+    penguinwokrs: {
+        name: "penguinwokrs",
+        id: 385266832136863746n
+    }
 } satisfies Record<string, Dev>);
 
 // iife so #__PURE__ works correctly


### PR DESCRIPTION
<!--
We do not accept PRs that were created by AI. You will be permanently blocked with no further warning if you submit AI generated PRs.
Also do not use AI in communication, it makes me ill
-->

## Describe your Changes


Follow up to #1333. This adds ShowMeYourName custom names to the `from:` and `mentions:` filter suggestions in the search bar.

Two changes:

**Rendering the suggestion rows.** The name in a row comes straight from `UsernameUtils.useName(guildId, channelId, user)`, so the SMYN formatted name is injected there. `useName` is a hook, so short circuiting it with `??` would make the number of hook calls vary between rows. The hook result is passed in as the fallback argument instead, so it is always evaluated.

**Matching custom names.** Inside a guild, the suggestions come back from Discord's backend user search, so custom names, which only exist on the client, never match. Locally matched users are merged into the returned result list. The row's `text`, which is the value inserted into the search box on selection, stays `getUserTag(user)`, the same as Discord's, so nothing changes after a row is picked. This returns early when there is no `guild_id`, since DM search already goes through the local path that #1333 patches.

## Screenshots (if applicable)
* nickname
<img width="596" height="481" alt="image" src="https://github.com/user-attachments/assets/9ea06867-88a5-456e-a916-6f29a729f8ed" />

<img width="547" height="195" alt="image" src="https://github.com/user-attachments/assets/4285ef80-866b-440d-8312-134c74df0fc5" />

* from:
<img width="624" height="163" alt="image" src="https://github.com/user-attachments/assets/f4c15782-6891-4cf1-96b7-7dcc75782614" />

mention:
<img width="574" height="206" alt="image" src="https://github.com/user-attachments/assets/8540185f-c316-4dda-9133-13da673475d9" />


## Checklist before submitting
<!-- Hint: [x] this is how to check boxes -->
- [ ] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md) file and made sure this pull request complies with it
- [ ] This pull request was written by me, and not an AI agent
