### PR TITLE
dragify(fix:) fix the scanning logic

### DIFF
--- a/src/equicordplugins/dragify/targets.ts
+++ b/src/equicordplugins/dragify/targets.ts
@@ -46,10 +46,6 @@ function collectEventElements(event: DragEvent): HTMLElement[] {
     add(event.target);
     for (const entry of event.composedPath?.() ?? []) add(entry);
 
-    if (typeof document !== "undefined" && event.clientX != null && event.clientY != null) {
-        for (const element of document.elementsFromPoint?.(event.clientX, event.clientY) ?? []) add(element);
-    }
-
     return elements;
 }
 


### PR DESCRIPTION
fixes the scanning logic for dragify by only using the drag event's target and ancestors. previously we were just scanning for dragify elements below the pointer which was causing fullscreen windows to still allow dragging, because those elements were below the pointer without scanning properly.